### PR TITLE
Implement pow and refactor BinOp

### DIFF
--- a/src/lfortran/semantics/python_ast_to_asr.cpp
+++ b/src/lfortran/semantics/python_ast_to_asr.cpp
@@ -741,9 +741,9 @@ public:
 
     void visit_BinOp(const AST::BinOp_t &x) {
         this->visit_expr(*x.m_left);
-        ASR::expr_t *left = LFortran::ASRUtils::EXPR(tmp);
+        ASR::expr_t *left = ASRUtils::EXPR(tmp);
         this->visit_expr(*x.m_right);
-        ASR::expr_t *right = LFortran::ASRUtils::EXPR(tmp);
+        ASR::expr_t *right = ASRUtils::EXPR(tmp);
         ASR::binopType op;
         switch (x.m_op) {
             case (AST::operatorType::Add) : { op = ASR::binopType::Add; break; }

--- a/src/lfortran/semantics/python_ast_to_asr.cpp
+++ b/src/lfortran/semantics/python_ast_to_asr.cpp
@@ -703,7 +703,7 @@ public:
             // string repeat
             dest_type = right_is_int ? left_type : right_type;
             ASR::stropType ops = ASR::stropType::Repeat;
-            tmp = ASR::make_StrOp_t(al, x.base.base.loc, left, ops, right, dest_type,
+            tmp = ASR::make_StrOp_t(al, loc, left, ops, right, dest_type,
                                     value);
             return;
         } else {


### PR DESCRIPTION
Reference code:
```py
def check():
    a: i32
    a = pow(2, 2)
```


ASR:

```bash
(TranslationUnit 
   (SymbolTable 
      1 
      {
         check: 
            (Subroutine 
               (SymbolTable 
                  2 
                  {
                     a: 
                        (Variable 
                           2 
                           a 
                           Local () () 
                           Default 
                           (Integer 4 []) 
                           Source 
                           Public 
                           Required .false.)
                  }) 
               check [] [
               (= 
                  (Var 2 a) 
                  (BinOp (ConstantInteger 2 
                     (Integer 4 [])) 
                     Pow (ConstantInteger 2 
                     (Integer 4 [])) 
                     (Integer 4 []) () ()) ())] 
               Source 
               Public 
               Implementation () .false. .false.)
      }) 
   [])
```