### PR TITLE
Implement `visit_Raise`

### DIFF
--- a/src/lfortran/semantics/python_ast_to_asr.cpp
+++ b/src/lfortran/semantics/python_ast_to_asr.cpp
@@ -1045,6 +1045,17 @@ public:
         tmp = ASR::make_Exit_t(al, x.base.base.loc);
     }
 
+    void visit_Raise(const AST::Raise_t &x) {
+        ASR::expr_t *code;
+        if (x.m_cause) {
+            visit_expr(*x.m_cause);
+            code = LFortran::ASRUtils::EXPR(tmp);
+        } else {
+            code = nullptr;
+        }
+        tmp = ASR::make_ErrorStop_t(al, x.base.base.loc, code);
+    }
+
     void visit_Expr(const AST::Expr_t &x) {
         if (AST::is_a<AST::Call_t>(*x.m_value)) {
             AST::Call_t *c = AST::down_cast<AST::Call_t>(x.m_value);


### PR DESCRIPTION
On this reference code:

```py
def check():
    a: i32
    a = 1
    if a==1:
        raise
```


I get the following ASR:

```
(TranslationUnit 
   (SymbolTable 
      1 
      {
         check: 
            (Subroutine 
               (SymbolTable 
                  2 
                  {
                     a: 
                        (Variable 
                           2 
                           a 
                           Local () () 
                           Default 
                           (Integer 4 []) 
                           Source 
                           Public 
                           Required .false.)
                  }) 
               check [] [
               (= 
                  (Var 2 a) (ConstantInteger 1 
                  (Integer 4 [])) ()) 
               (If 
                  (Compare 
                     (Var 2 a) 
                     Eq (ConstantInteger 1 
                     (Integer 4 [])) 
                     (Logical 4 []) () ()) [
                  (ErrorStop ())] [])] 
               Source 
               Public 
               Implementation () .false. .false.)
      }) 
   [])
```