### PR TITLE
Make CI to run only on main `lpython` repo

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,17 @@
-name: CI
+name: LPython CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
 
 jobs:
   Build:
-    name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }})
+    name: LPython CI (${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Currently, CI runs on every commit on `lcompilers/lpython` as well as forked repo(`user/lpython`) which might be a waste of resources. So we could just run these tests when opened a PR in the `main` branch or pushed to the `main` branch.

cc @certik 