### PR TITLE
Implement `complex` intrinsic function

### DIFF
--- a/doconcurrentloop_01.py
+++ b/doconcurrentloop_01.py
@@ -2,7 +2,10 @@ def test_complex():
     c: c128
     c = complex()
     c = complex(3.4)
-    c = complex(5., -4.3)
+    c = complex(5., 4.3)
+    c = complex(1)
+    c = complex(3, 4)
+    c = complex(2, 4.5)
 
 def triad(a: f32[:], b: f32[:], scalar: f32, c: f32[:]):
     N: i32

--- a/doconcurrentloop_01.py
+++ b/doconcurrentloop_01.py
@@ -1,11 +1,20 @@
 def test_complex():
     c: c128
+    c1: c128
+    c2: c128
+    c3: c128
+    b: bool
+
+    # constant real or int as args
     c = complex()
     c = complex(3.4)
     c = complex(5., 4.3)
     c = complex(1)
-    c = complex(3, 4)
-    c = complex(2, 4.5)
+    c1 = complex(3, 4)
+    c2 = complex(2, 4.5)
+    c3 = complex(3., 4.)
+    b = c1 != c2
+    b = c1 == c3
 
 def triad(a: f32[:], b: f32[:], scalar: f32, c: f32[:]):
     N: i32

--- a/doconcurrentloop_01.py
+++ b/doconcurrentloop_01.py
@@ -1,3 +1,9 @@
+def test_complex():
+    c: c128
+    c = complex()
+    c = complex(3.4)
+    c = complex(5., -4.3)
+
 def triad(a: f32[:], b: f32[:], scalar: f32, c: f32[:]):
     N: i32
     i: i32

--- a/doconcurrentloop_01.py
+++ b/doconcurrentloop_01.py
@@ -1,21 +1,3 @@
-def test_complex():
-    c: c128
-    c1: c128
-    c2: c128
-    c3: c128
-    b: bool
-
-    # constant real or int as args
-    c = complex()
-    c = complex(3.4)
-    c = complex(5., 4.3)
-    c = complex(1)
-    c1 = complex(3, 4)
-    c2 = complex(2, 4.5)
-    c3 = complex(3., 4.)
-    b = c1 != c2
-    b = c1 == c3
-
 def triad(a: f32[:], b: f32[:], scalar: f32, c: f32[:]):
     N: i32
     i: i32

--- a/lpython_tests.py
+++ b/lpython_tests.py
@@ -1,3 +1,21 @@
+def test_complex():
+    c: c128
+    c1: c128
+    c2: c128
+    c3: c128
+    b: bool
+
+    # constant real or int as args
+    c = complex()
+    c = complex(3.4)
+    c = complex(5., 4.3)
+    c = complex(1)
+    c1 = complex(3, 4)
+    c2 = complex(2, 4.5)
+    c3 = complex(3., 4.)
+    b = c1 != c2
+    b = c1 == c3
+
 def test_namedexpr():
     a: i32
     x: i32

--- a/src/lfortran/semantics/python_ast_to_asr.cpp
+++ b/src/lfortran/semantics/python_ast_to_asr.cpp
@@ -1212,6 +1212,29 @@ public:
             } else {
                 throw SemanticError("chr() must have one integer argument", x.base.base.loc);
             }
+        } else if (call_name == "complex") {
+            LFORTRAN_ASSERT(ASRUtils::all_args_evaluated(args));
+            int16_t n_args = args.size();
+            ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Complex_t(al, x.base.base.loc,
+                8, nullptr, 0));
+            if (n_args == 0) {
+                tmp = ASR::make_ConstantComplex_t(al, x.base.base.loc, 0.0, 0.0, type);
+                return;
+            } else if (n_args == 1) {
+                ASR::expr_t* expr = args[0];
+                double c = ASR::down_cast<ASR::ConstantReal_t>(ASRUtils::expr_value(expr))->m_r;
+                tmp = ASR::make_ConstantComplex_t(al, x.base.base.loc, c, 0.0, type);
+                return;
+            } else if (n_args == 2) {
+                ASR::expr_t* expr1 = args[0];
+                ASR::expr_t* expr2 = args[1];
+                double c1 = ASR::down_cast<ASR::ConstantReal_t>(ASRUtils::expr_value(expr1))->m_r;
+                double c2 = ASR::down_cast<ASR::ConstantReal_t>(ASRUtils::expr_value(expr2))->m_r;
+                tmp = ASR::make_ConstantComplex_t(al, x.base.base.loc, c1, c2, type);
+                return;
+            } else {
+                throw SemanticError("complex() must have at most two real arguments", x.base.base.loc);
+            }
         }
 
         // Other functions

--- a/src/lfortran/semantics/python_ast_to_asr.cpp
+++ b/src/lfortran/semantics/python_ast_to_asr.cpp
@@ -1165,7 +1165,6 @@ public:
                 throw SemanticError("chr() must have one integer argument", x.base.base.loc);
             }
         } else if (call_name == "complex") {
-            LFORTRAN_ASSERT(ASRUtils::all_args_evaluated(args));
             int16_t n_args = args.size();
             ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Complex_t(al, x.base.base.loc,
                 8, nullptr, 0));

--- a/src/lfortran/semantics/python_ast_to_asr.cpp
+++ b/src/lfortran/semantics/python_ast_to_asr.cpp
@@ -1138,24 +1138,18 @@ public:
             int16_t n_args = args.size();
             ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Complex_t(al, x.base.base.loc,
                 8, nullptr, 0));
-            if (n_args == 0) {
-                tmp = ASR::make_ConstantComplex_t(al, x.base.base.loc, 0.0, 0.0, type);
-                return;
-            } else if (n_args == 1) {
-                ASR::expr_t* expr = args[0];
-                double c = ASR::down_cast<ASR::ConstantReal_t>(ASRUtils::expr_value(expr))->m_r;
-                tmp = ASR::make_ConstantComplex_t(al, x.base.base.loc, c, 0.0, type);
-                return;
-            } else if (n_args == 2) {
-                ASR::expr_t* expr1 = args[0];
-                ASR::expr_t* expr2 = args[1];
-                double c1 = ASR::down_cast<ASR::ConstantReal_t>(ASRUtils::expr_value(expr1))->m_r;
-                double c2 = ASR::down_cast<ASR::ConstantReal_t>(ASRUtils::expr_value(expr2))->m_r;
-                tmp = ASR::make_ConstantComplex_t(al, x.base.base.loc, c1, c2, type);
-                return;
-            } else {
+            if( n_args > 2 || n_args < 0 ) { // n_args shouldn't be less than 0 but added this check for safety
                 throw SemanticError("complex() must have at most two real arguments", x.base.base.loc);
             }
+            double c1 = 0.0, c2 = 0.0; // Default if n_args = 0
+            if (n_args >= 1) { // Handles both n_args = 1 and n_args = 2
+                c1 = ASR::down_cast<ASR::ConstantReal_t>(ASRUtils::expr_value(args[0]))->m_r;
+            }
+            if (n_args == 2) { // Extracts imaginary component if n_args = 2
+                c2 = ASR::down_cast<ASR::ConstantReal_t>(ASRUtils::expr_value(args[1]))->m_r;
+            }
+            tmp = ASR::make_ConstantComplex_t(al, x.base.base.loc, c1, c2, type);
+            return;
         } else if (call_name == "pow") {
             if (args.size() != 2) {
                 throw SemanticError("Two arguments are expected in pow",

--- a/src/lfortran/semantics/python_ast_to_asr.cpp
+++ b/src/lfortran/semantics/python_ast_to_asr.cpp
@@ -1139,14 +1139,23 @@ public:
             ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Complex_t(al, x.base.base.loc,
                 8, nullptr, 0));
             if( n_args > 2 || n_args < 0 ) { // n_args shouldn't be less than 0 but added this check for safety
-                throw SemanticError("complex() must have at most two real arguments", x.base.base.loc);
+                throw SemanticError("Only constant integer or real values are supported as "
+                    "the (at most two) arguments of complex()", x.base.base.loc);
             }
             double c1 = 0.0, c2 = 0.0; // Default if n_args = 0
             if (n_args >= 1) { // Handles both n_args = 1 and n_args = 2
-                c1 = ASR::down_cast<ASR::ConstantReal_t>(ASRUtils::expr_value(args[0]))->m_r;
+                if (ASR::is_a<ASR::ConstantInteger_t>(*args[0])) {
+                    c1 = ASR::down_cast<ASR::ConstantInteger_t>(args[0])->m_n;
+                } else if (ASR::is_a<ASR::ConstantReal_t>(*args[0])) {
+                    c1 = ASR::down_cast<ASR::ConstantReal_t>(ASRUtils::expr_value(args[0]))->m_r;
+                }
             }
             if (n_args == 2) { // Extracts imaginary component if n_args = 2
-                c2 = ASR::down_cast<ASR::ConstantReal_t>(ASRUtils::expr_value(args[1]))->m_r;
+                if (ASR::is_a<ASR::ConstantInteger_t>(*args[1])) {
+                    c2 = ASR::down_cast<ASR::ConstantInteger_t>(args[1])->m_n;
+                } else if (ASR::is_a<ASR::ConstantReal_t>(*args[1])) {
+                    c2 = ASR::down_cast<ASR::ConstantReal_t>(ASRUtils::expr_value(args[1]))->m_r;
+                }
             }
             tmp = ASR::make_ConstantComplex_t(al, x.base.base.loc, c1, c2, type);
             return;

--- a/src/lfortran/semantics/python_ast_to_asr.cpp
+++ b/src/lfortran/semantics/python_ast_to_asr.cpp
@@ -1156,6 +1156,16 @@ public:
             } else {
                 throw SemanticError("complex() must have at most two real arguments", x.base.base.loc);
             }
+        } else if (call_name == "pow") {
+            if (args.size() != 2) {
+                throw SemanticError("Two arguments are expected in pow",
+                    x.base.base.loc);
+            }
+            ASR::expr_t *left = args[0];
+            ASR::expr_t *right = args[1];
+            ASR::binopType op = ASR::binopType::Pow;
+            make_BinOp_helper(left, right, op, x.base.base.loc, false);
+            return;
         }
 
         // Other functions

--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -542,6 +542,12 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
         last_binary_plus = false;
     }
 
+    void visit_ConstantComplex(const ASR::ConstantComplex_t &x) {
+        src = "(" + std::to_string(x.m_re) + "," + std::to_string(x.m_im) + ")";
+        last_unary_plus = false;
+        last_binary_plus = false;
+    }
+
     void visit_ConstantLogical(const ASR::ConstantLogical_t &x) {
         if (x.m_value == true) {
             src = "true";


### PR DESCRIPTION
expr2.py contains:
```python
def main():
    c: c128
    c = complex()
    c = complex(3.4)
    c = complex(5., -4.3)
```
ASR:
```bash
(TranslationUnit
   (SymbolTable
      1
      {
         main:
            (Subroutine
               (SymbolTable
                  2
                  {
                     c:
                        (Variable
                           2
                           c
                           Local () ()
                           Default
                           (Complex 8 [])
                           Source
                           Public
                           Required .false.)
                  })
               main [] [
               (=
                  (Var 2 c)
                  (ConstantComplex 0.000000 0.000000
                     (Complex 8 [])) ())
               (=
                  (Var 2 c)
                  (ConstantComplex 3.400000 0.000000
                     (Complex 8 [])) ())
               (=
                  (Var 2 c)
                  (ConstantComplex 5.000000 -4.300000
                     (Complex 8 [])) ())]
               Source
               Public
               Implementation () .false. .false.)
      })
   [])
```
