### PR TITLE
Implement `bin` python built-in function

### DIFF
--- a/doconcurrentloop_01.py
+++ b/doconcurrentloop_01.py
@@ -1,3 +1,8 @@
+def test_bin():
+    b: str
+    b = bin(5)
+    b = bin(64)
+
 def triad(a: f32[:], b: f32[:], scalar: f32, c: f32[:]):
     N: i32
     i: i32

--- a/doconcurrentloop_01.py
+++ b/doconcurrentloop_01.py
@@ -1,8 +1,3 @@
-def test_bin():
-    b: str
-    b = bin(5)
-    b = bin(64)
-
 def triad(a: f32[:], b: f32[:], scalar: f32, c: f32[:]):
     N: i32
     i: i32

--- a/lpython_tests.py
+++ b/lpython_tests.py
@@ -1,3 +1,8 @@
+def test_bin():
+    b: str
+    b = bin(5)
+    b = bin(64)
+
 def test_complex():
     c: c128
     c1: c128

--- a/src/lfortran/semantics/python_ast_to_asr.cpp
+++ b/src/lfortran/semantics/python_ast_to_asr.cpp
@@ -1143,6 +1143,30 @@ public:
             ASR::binopType op = ASR::binopType::Pow;
             make_BinOp_helper(left, right, op, x.base.base.loc, false);
             return;
+        } else if (call_name == "bin") {
+            if (args.size() != 1) {
+                throw SemanticError("bin() takes exactly one argument (" +
+                    std::to_string(args.size()) + " given)", x.base.base.loc);
+            }
+            ASR::expr_t* expr = args[0];
+            ASR::ttype_t* type = ASRUtils::expr_type(expr);
+            if (ASR::is_a<ASR::Integer_t>(*type)) {
+                int64_t n = ASR::down_cast<ASR::ConstantInteger_t>(expr)->m_n;
+                ASR::ttype_t* str_type = ASRUtils::TYPE(ASR::make_Character_t(al,
+                    x.base.base.loc, 1, 1, nullptr, nullptr, 0));
+                std::string s;
+                s += std::bitset<64>(n).to_string();
+                s.erase(0, s.find_first_not_of('0'));
+                s.insert(0, "0b");
+                Str s2;
+                s2.from_str_view(s);
+                char *str_val = s2.c_str(al);
+                tmp = ASR::make_ConstantString_t(al, x.base.base.loc, str_val, str_type);
+                return;
+            } else {
+                throw SemanticError("bin() must have one integer argument",
+                    x.base.base.loc);
+            }
         }
 
         // Other functions

--- a/src/lfortran/semantics/python_ast_to_asr.cpp
+++ b/src/lfortran/semantics/python_ast_to_asr.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <cmath>
 #include <vector>
+#include <bitset>
 
 #include <lfortran/python_ast.h>
 #include <libasr/asr.h>


### PR DESCRIPTION
Reference code:
```python
def test_bin():
    b: str
    b = bin(5)
    b = bin(64)
```
ASR:
```
(TranslationUnit
   (SymbolTable
      1
      {
         test_bin:
            (Subroutine
               (SymbolTable
                  2
                  {
                     b:
                        (Variable
                           2
                           b
                           Local () ()
                           Default
                           (Character 1 -2 () [])
                           Source
                           Public
                           Required .false.)
                  })
               test_bin [] [
               (=
                  (Var 2 b)
                  (ConstantString "0b101"
                     (Character 1 1 () [])) ())
               (=
                  (Var 2 b)
                  (ConstantString "0b1000000"
                     (Character 1 1 () [])) ())]
               Source
               Public
               Implementation () .false. .false.)
      })
   [])
```
Verification:
```console
>>> 0b1000000
64
>>> 0b101
5
```