### PR TITLE
Implement `hex()` and `oct()`

### DIFF
--- a/lpython_tests.py
+++ b/lpython_tests.py
@@ -1,7 +1,11 @@
-def test_bin():
+def test_boz():
     b: str
     b = bin(5)
     b = bin(64)
+    b = oct(8)
+    b = oct(56)
+    b = hex(42)
+    b = hex(12648430)
 
 def test_complex():
     c: c128

--- a/src/lfortran/semantics/python_ast_to_asr.cpp
+++ b/src/lfortran/semantics/python_ast_to_asr.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <bitset>
 #include <complex>
+#include <sstream>
 
 #include <lfortran/python_ast.h>
 #include <libasr/asr.h>

--- a/src/lfortran/semantics/python_ast_to_asr.cpp
+++ b/src/lfortran/semantics/python_ast_to_asr.cpp
@@ -1211,9 +1211,9 @@ public:
             ASR::binopType op = ASR::binopType::Pow;
             make_BinOp_helper(left, right, op, x.base.base.loc, false);
             return;
-        } else if (call_name == "bin") {
+        } else if (call_name == "bin" || "oct" || "hex") {
             if (args.size() != 1) {
-                throw SemanticError("bin() takes exactly one argument (" +
+                throw SemanticError(call_name + "() takes exactly one argument (" +
                     std::to_string(args.size()) + " given)", x.base.base.loc);
             }
             ASR::expr_t* expr = args[0];
@@ -1223,16 +1223,28 @@ public:
                 ASR::ttype_t* str_type = ASRUtils::TYPE(ASR::make_Character_t(al,
                     x.base.base.loc, 1, 1, nullptr, nullptr, 0));
                 std::string s;
-                s += std::bitset<64>(n).to_string();
-                s.erase(0, s.find_first_not_of('0'));
-                s.insert(0, "0b");
+                if (call_name == "oct") {
+                    std::stringstream ss;
+                    ss << std::oct << n;
+                    s += ss.str();
+                    s.insert(0, "0o");
+                } else if (call_name == "bin") {
+                    s += std::bitset<64>(n).to_string();
+                    s.erase(0, s.find_first_not_of('0'));
+                    s.insert(0, "0b");
+                } else {
+                    std::stringstream ss;
+                    ss << std::hex << n;
+                    s += ss.str();
+                    s.insert(0, "0x");
+                }
                 Str s2;
                 s2.from_str_view(s);
                 char *str_val = s2.c_str(al);
                 tmp = ASR::make_ConstantString_t(al, x.base.base.loc, str_val, str_type);
                 return;
             } else {
-                throw SemanticError("bin() must have one integer argument",
+                throw SemanticError(call_name + "() must have one integer argument",
                     x.base.base.loc);
             }
         }


### PR DESCRIPTION
```python
def test_boz():
    b: str
    b = bin(5)
    b = bin(64)
    b = oct(8)
    b = oct(56)
    b = hex(42)
    b = hex(12648430)
```
ASR generated:
```bash
         test_boz:
            (Subroutine
               (SymbolTable
                  2
                  {
                     b:
                        (Variable
                           2
                           b
                           Local () ()
                           Default
                           (Character 1 -2 () [])
                           Source
                           Public
                           Required .false.)
                  })
               test_boz [] [
               (=
                  (Var 2 b)
                  (ConstantString "0b101"
                     (Character 1 1 () [])) ())
               (=
                  (Var 2 b)
                  (ConstantString "0b1000000"
                     (Character 1 1 () [])) ())
               (=
                  (Var 2 b)
                  (ConstantString "0o10"
                     (Character 1 1 () [])) ())
               (=
                  (Var 2 b)
                  (ConstantString "0o70"
                     (Character 1 1 () [])) ())
               (=
                  (Var 2 b)
                  (ConstantString "0x2a"
                     (Character 1 1 () [])) ())
               (=
                  (Var 2 b)
                  (ConstantString "0xc0ffee"
                     (Character 1 1 () [])) ())]
               Source
               Public
               Implementation () .false. .false.)
```