### PR TITLE
Fix double return in cpp

### DIFF
--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -447,10 +447,6 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
         }
         current_function = nullptr;
 
-        body += indent + "return "
-            + LFortran::ASRUtils::EXPR2VAR(x.m_return_var)->m_name
-            + ";\n";
-
         if (decl.size() > 0 || body.size() > 0) {
             sub += "{\n" + decl + body + "}\n";
         } else {

--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -441,11 +441,20 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 
         current_function = &x;
         std::string body;
+        bool visited_return = false;
+
         for (size_t i=0; i<x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
+            visited_return = visited_return || (is_a<ASR::Return_t>(*x.m_body[i]));
             body += src;
         }
         current_function = nullptr;
+
+        if(!visited_return) {
+            body += indent + "return "
+                + LFortran::ASRUtils::EXPR2VAR(x.m_return_var)->m_name
+                + ";\n";
+        }
 
         if (decl.size() > 0 || body.size() > 0) {
             sub += "{\n" + decl + body + "}\n";

--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -441,14 +441,17 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 
         current_function = &x;
         std::string body;
-        bool visited_return = false;
 
         for (size_t i=0; i<x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
-            visited_return = visited_return || (is_a<ASR::Return_t>(*x.m_body[i]));
             body += src;
         }
         current_function = nullptr;
+        bool visited_return = false;
+        
+        if (x.n_body > 0 && is_a<ASR::Return_t>(*x.m_body[x.n_body-1])) {
+            visited_return = true;
+        }
 
         if(!visited_return) {
             body += indent + "return "

--- a/tests/reference/cpp-doconcurrentloop_01-4e9f274.json
+++ b/tests/reference/cpp-doconcurrentloop_01-4e9f274.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-doconcurrentloop_01-4e9f274.stdout",
-    "stdout_hash": "5b94695014605fdca7c7321f466d169a447db70cc76f3f30f060198c",
+    "stdout_hash": "de28cb81fc84c0a8ffc413b397b8cbd21bd40fdf60f0d230488a4c96",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-doconcurrentloop_01-4e9f274.stdout
+++ b/tests/reference/cpp-doconcurrentloop_01-4e9f274.stdout
@@ -33,7 +33,6 @@ int main()
     std::cout << "End Stream Triad" << std::endl;
     _lpython_return_variable = 0;
     return _lpython_return_variable;
-    return _lpython_return_variable;
 }
 
 void triad(const Kokkos::View<float*> &a, const Kokkos::View<float*> &b, float scalar, const Kokkos::View<float*> &c)

--- a/tests/reference/cpp-expr7-529bd53.json
+++ b/tests/reference/cpp-expr7-529bd53.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr7-529bd53.stdout",
-    "stdout_hash": "1ee936733d2e68d146cf811a31ef5de115a82a6c10375fe2ccf29210",
+    "stdout_hash": "18198c92125926698a4464deef96547c7f7881728a1a10827391749c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr7-529bd53.stdout
+++ b/tests/reference/cpp-expr7-529bd53.stdout
@@ -27,6 +27,5 @@ int test_pow_1(int a, int b)
     res = std::pow(a, b);
     _lpython_return_variable = res;
     return _lpython_return_variable;
-    return _lpython_return_variable;
 }
 

--- a/tests/reference/cpp-expr9-48868e9.json
+++ b/tests/reference/cpp-expr9-48868e9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr9-48868e9.stdout",
-    "stdout_hash": "9287f998353996d7fdd00fa0127be3e3c8a483086fa4dd439e8b8437",
+    "stdout_hash": "2ee1306358a7c3ce6c80c7810fbd3b31ba4df12073ee4fe889561962",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr9-48868e9.stdout
+++ b/tests/reference/cpp-expr9-48868e9.stdout
@@ -21,7 +21,6 @@ int test_return_1(int a)
     x = 5;
     _lpython_return_variable = x;
     return _lpython_return_variable;
-    return _lpython_return_variable;
 }
 
 std::string test_return_2(int a)
@@ -31,7 +30,6 @@ std::string test_return_2(int a)
     x = "test";
     _lpython_return_variable = x;
     return _lpython_return_variable;
-    return _lpython_return_variable;
 }
 
 int test_return_3(int a)
@@ -39,7 +37,6 @@ int test_return_3(int a)
     int _lpython_return_variable;
     a = 3;
     _lpython_return_variable = a;
-    return _lpython_return_variable;
     return _lpython_return_variable;
 }
 

--- a/tests/reference/cpp-loop1-0a8cf3b.json
+++ b/tests/reference/cpp-loop1-0a8cf3b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-loop1-0a8cf3b.stdout",
-    "stdout_hash": "0145b7d64984ef91c6f5a841017e7c183992b210e9c0fc19a7b7b200",
+    "stdout_hash": "582ae4d190449b301dfeaf53c2b3dedab900ec187494838aab9f1f87",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-loop1-0a8cf3b.stdout
+++ b/tests/reference/cpp-loop1-0a8cf3b.stdout
@@ -29,7 +29,6 @@ int test_factorial_1(int x)
     };
     _lpython_return_variable = result;
     return _lpython_return_variable;
-    return _lpython_return_variable;
 }
 
 int test_factorial_2(int x)
@@ -42,7 +41,6 @@ int test_factorial_2(int x)
         result = result*i;
     };
     _lpython_return_variable = result;
-    return _lpython_return_variable;
     return _lpython_return_variable;
 }
 


### PR DESCRIPTION
Python code:
```py
def test_factorial_1(x: i32) -> i32:
    if x < 0:
        return 0
    result: i32
    result = 1
    while x > 0:
        result = result * x
        x -= 1
    return result
```

CPP code:

```cpp
#include <iostream>
#include <string>
#include <vector>
#include <Kokkos_Core.hpp>
#include <lfortran_intrinsics.h>

template <typename T>
Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
{
    Kokkos::View<T*> r("r", v.size());
    for (size_t i=0; i < v.size(); i++) {
        r(i) = v[i];
    }
    return r;
}

int test_factorial_1(int x)
{
    int _lpython_return_variable;
    int result;
    if (x < 0) {
        _lpython_return_variable = 0;
        return _lpython_return_variable;
    };
    result = 1;
    while (x > 0) {
        result = result*x;
        x = x - 1;
    };
    _lpython_return_variable = result;
    return _lpython_return_variable;
}

```