### PR TITLE
Handle casting in cpp

### DIFF
--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -591,8 +591,7 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
         visit_expr(*x.m_arg);
         switch (x.m_kind) {
             case (ASR::cast_kindType::IntegerToReal) : {
-                // In C++, we do not need to cast int to float explicitly:
-                // src = src;
+                src = "(float)(" + src + ")";
                 break;
             }
             case (ASR::cast_kindType::RealToInteger) : {

--- a/tests/reference/cpp-expr3-9c516d4.json
+++ b/tests/reference/cpp-expr3-9c516d4.json
@@ -1,0 +1,13 @@
+{
+    "basename": "cpp-expr3-9c516d4",
+    "cmd": "lpython --no-color --show-cpp {infile}",
+    "infile": "tests/expr3.py",
+    "infile_hash": "e480142391a42a92a9b87984232e7f7aaf3cfe146149597619e337e6",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "cpp-expr3-9c516d4.stdout",
+    "stdout_hash": "090ef6f4273cd1fcbe74df590797bfcd3c2d7d2b62328259d1cbb24d",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/cpp-expr3-9c516d4.stdout
+++ b/tests/reference/cpp-expr3-9c516d4.stdout
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <Kokkos_Core.hpp>
+#include <lfortran_intrinsics.h>
+
+template <typename T>
+Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
+{
+    Kokkos::View<T*> r("r", v.size());
+    for (size_t i=0; i < v.size(); i++) {
+        r(i) = v[i];
+    }
+    return r;
+}
+
+void test_cast()
+{
+    int a;
+    float b;
+    a = 2;
+    b = 4.200000;
+    a = (float)(a)*b;
+    b = b + (float)(1);
+    a = 5;
+    a = (float)(a) - 3.900000;
+    a = (float)(a)/b;
+    b = (float)(3)/(float)(4);
+}
+

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -34,6 +34,7 @@ cpp = true
 filename = "expr3.py"
 ast = true
 asr = true
+cpp = true
 
 [[test]]
 filename = "expr4.py"


### PR DESCRIPTION
We need Integer to real cast in cpp because of this failing example:
On python code:
```py
def test_cast():
    b: f32
    b = 3/4
    print(b) # b= 0.75
```
Presently, we get the following cpp(without handling cast in cpp) which is not correct:
```cpp
void test_cast()
{
    float b;
    b = 3/4;
    std::cout << b << std::endl; // this will print 0
}
```