### PR TITLE
Convert line/col to linear location

### DIFF
--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -542,10 +542,11 @@ int emit_asr(const std::string &infile,
 
     LFortran::LocationManager lm;
     lm.in_filename = infile;
+    std::string input = read_file(infile);
+    lm.init_simple(input);
     LFortran::diag::Diagnostics diagnostics;
     LFortran::Result<LFortran::ASR::TranslationUnit_t*>
         r = LFortran::Python::python_ast_to_asr(al, *ast, diagnostics, true);
-    std::string input = read_file(infile);
     std::cerr << diagnostics.render(input, lm, compiler_options);
     if (!r.ok) {
         LFORTRAN_ASSERT(diagnostics.has_error())


### PR DESCRIPTION
This gets the location information working:
```console
$ lpython --show-asr examples/expr2.py 
semantic error: Symbol is already declared in the same scope
 --> examples/expr2.py:2:5
  |
2 |     x: i32
  |     ~~~~~~ original declaration
  |
4 |     x: i32
  |     ^^^^^^ redeclaration


Note: if any of the above error or warning messages are not clear or are lacking
context please report it to us (we consider that a bug that needs to be fixed).
```
or
```console
$ lpython --show-asr examples/expr2.py
semantic error: Variable 'abc123' not declared
 --> examples/expr2.py:4:13
  |
4 |     x = 1 + abc123 + 3
  |             ^^^^^^ 


Note: if any of the above error or warning messages are not clear or are lacking
context please report it to us (we consider that a bug that needs to be fixed).
```