### PR TITLE
LLVM: get allocatable string declaration working

### DIFF
--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -11,6 +11,7 @@ tests = [
     "expr_03.py",
     "expr_04.py",
     "expr_05.py",
+    "test_str_01.py",
     "modules_01.py",
     #"modules_02.py",
     "test_math.py",

--- a/integration_tests/test_str_01.py
+++ b/integration_tests/test_str_01.py
@@ -1,0 +1,13 @@
+def f():
+    x: str
+    x = "ok"
+    print(x)
+    assert x == "ok"
+    x = "abcdefghijkl"
+    print(x)
+    assert x == "abcdefghijkl"
+    x = x + "123"
+    print(x)
+    assert x == "abcdefghijkl123"
+
+f()

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1502,6 +1502,10 @@ public:
                                 std::string empty(strlen, ' ');
                                 llvm::Value *init_value = builder->CreateGlobalStringPtr(s2c(al, empty));
                                 builder->CreateStore(init_value, target_var);
+                            } else if (strlen == -2) {
+                                // Allocatable string. Initialize to `nullptr` (unallocated)
+                                llvm::Value *init_value = llvm::Constant::getNullValue(type);
+                                builder->CreateStore(init_value, target_var);
                             } else if (strlen == -3) {
                                 LFORTRAN_ASSERT(t->m_len_expr)
                                 this->visit_expr(*t->m_len_expr);


### PR DESCRIPTION
Basic assignment also works, tests added.

This implementation leaks memory, the strings are never deallocated at runtime. This has to be fixed properly by #192.