### PR TITLE
Implement returning arrays from functions

### DIFF
--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -17,6 +17,7 @@ tests = [
     #"modules_02.py",
     "test_math.py",
     "test_numpy_01.py",
+    "test_numpy_02.py",
     "test_random.py",
     "test_builtin.py",
     "test_builtin_abs.py",

--- a/integration_tests/test_numpy_01.py
+++ b/integration_tests/test_numpy_01.py
@@ -1,10 +1,10 @@
 # This test handles various aspects of local arrays using the `numpy.empty()`
 # function
-from ltypes import f32
+from ltypes import f64
 from numpy import empty
 
 def test_local_arrays():
-    a: f32[16]
+    a: f64[16]
     a = empty(16)
     i: i32
     for i in range(16):

--- a/integration_tests/test_numpy_01.py
+++ b/integration_tests/test_numpy_01.py
@@ -1,5 +1,7 @@
+# This test handles various aspects of local arrays using the `numpy.empty()`
+# function
 from ltypes import f32
-from numpy import empty, float32
+from numpy import empty
 
 def test_local_arrays():
     a: f32[16]

--- a/integration_tests/test_numpy_02.py
+++ b/integration_tests/test_numpy_02.py
@@ -13,7 +13,13 @@ def zeros(n: i32) -> f64[n]:
         A[i] = 0.0
     return A
 
-
+def arange(n: i32) -> f64[n]:
+    A: f64[n]
+    A = empty(n)
+    i: i32
+    for i in range(n):
+        A[i] = 1.0 * i
+    return A
 
 def test_zeros():
     a: f64[4]
@@ -25,7 +31,18 @@ def test_zeros():
     assert abs(a[2] - 0.0) < eps
     assert abs(a[3] - 0.0) < eps
 
+def test_arange():
+    a: f64[4]
+    a = arange(4)
+    eps: f64
+    eps = 1e-12
+    assert abs(a[0] - 0.0) < eps
+    assert abs(a[1] - 1.0) < eps
+    assert abs(a[2] - 2.0) < eps
+    assert abs(a[3] - 3.0) < eps
+
 def check():
     test_zeros()
+    test_arange()
 
 check()

--- a/integration_tests/test_numpy_02.py
+++ b/integration_tests/test_numpy_02.py
@@ -1,0 +1,19 @@
+# This test handles actual LPython implementations of functions from the numpy
+# module.
+from ltypes import f32
+from numpy import zeros
+
+def test_zeros():
+    a: f32[4]
+    a = zeros(4)
+    eps: f64
+    eps = 1e-12
+    assert abs(a[0] - 0.0) < eps
+    assert abs(a[1] - 0.0) < eps
+    assert abs(a[2] - 0.0) < eps
+    assert abs(a[3] - 0.0) < eps
+
+def check():
+    test_zeros()
+
+check()

--- a/integration_tests/test_numpy_02.py
+++ b/integration_tests/test_numpy_02.py
@@ -1,10 +1,22 @@
 # This test handles actual LPython implementations of functions from the numpy
 # module.
-from ltypes import f32
-from numpy import zeros
+from ltypes import i32, f64
+from numpy import empty
+from typing import TypeVar
+
+n = TypeVar("n")
+def zeros(n: i32) -> f64[n]:
+    A: f64[n]
+    A = empty(n)
+    i: i32
+    for i in range(n):
+        A[i] = 0.0
+    return A
+
+
 
 def test_zeros():
-    a: f32[4]
+    a: f64[4]
     a = zeros(4)
     eps: f64
     eps = 1e-12

--- a/integration_tests/test_numpy_02.py
+++ b/integration_tests/test_numpy_02.py
@@ -1,8 +1,7 @@
 # This test handles actual LPython implementations of functions from the numpy
 # module.
-from ltypes import i32, f64
+from ltypes import i32, f64, TypeVar
 from numpy import empty
-from typing import TypeVar
 
 n = TypeVar("n")
 def zeros(n: i32) -> f64[n]:

--- a/integration_tests/test_numpy_02.py
+++ b/integration_tests/test_numpy_02.py
@@ -3,6 +3,7 @@
 from ltypes import i32, f64, TypeVar
 from numpy import empty
 
+n: i32
 n = TypeVar("n")
 def zeros(n: i32) -> f64[n]:
     A: f64[n]

--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -550,7 +550,8 @@ int emit_asr(const std::string &infile,
     lm.init_simple(input);
     LFortran::diag::Diagnostics diagnostics;
     LFortran::Result<LFortran::ASR::TranslationUnit_t*>
-        r = LFortran::Python::python_ast_to_asr(al, *ast, diagnostics, true);
+        r = LFortran::Python::python_ast_to_asr(al, *ast, diagnostics, true,
+            compiler_options.symtab_only);
     std::cerr << diagnostics.render(input, lm, compiler_options);
     if (!r.ok) {
         LFORTRAN_ASSERT(diagnostics.has_error())
@@ -581,7 +582,8 @@ int emit_cpp(const std::string &infile,
     lm.init_simple(input);
     LFortran::diag::Diagnostics diagnostics;
     LFortran::Result<LFortran::ASR::TranslationUnit_t*>
-        r1 = LFortran::Python::python_ast_to_asr(al, *ast, diagnostics, true);
+        r1 = LFortran::Python::python_ast_to_asr(al, *ast, diagnostics, true,
+            compiler_options.symtab_only);
     std::cerr << diagnostics.render(input, lm, compiler_options);
     if (!r1.ok) {
         LFORTRAN_ASSERT(diagnostics.has_error())
@@ -663,7 +665,8 @@ int emit_llvm(const std::string &infile,
     lm.init_simple(input);
     LFortran::diag::Diagnostics diagnostics;
     LFortran::Result<LFortran::ASR::TranslationUnit_t*>
-        r1 = LFortran::Python::python_ast_to_asr(al, *ast, diagnostics, true);
+        r1 = LFortran::Python::python_ast_to_asr(al, *ast, diagnostics, true,
+            compiler_options.symtab_only);
     std::cerr << diagnostics.render(input, lm, compiler_options);
     if (!r1.ok) {
         LFORTRAN_ASSERT(diagnostics.has_error())
@@ -725,7 +728,8 @@ int compile_python_to_object_file(
     lm.init_simple(input);
     LFortran::diag::Diagnostics diagnostics;
     LFortran::Result<LFortran::ASR::TranslationUnit_t*>
-        r1 = LFortran::Python::python_ast_to_asr(al, *ast, diagnostics, true);
+        r1 = LFortran::Python::python_ast_to_asr(al, *ast, diagnostics, true,
+            compiler_options.symtab_only);
     std::cerr << diagnostics.render(input, lm, compiler_options);
     if (!r1.ok) {
         LFORTRAN_ASSERT(diagnostics.has_error())

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -98,6 +98,7 @@ ASR::Module_t* load_module(Allocator &al, SymbolTable *symtab,
                             const std::string &module_name,
                             const Location &loc, bool intrinsic,
                             const std::string &rl_path,
+                            bool run_verify,
                             const std::function<void (const std::string &, const Location &)> err) {
     LFORTRAN_ASSERT(symtab);
     if (symtab->scope.find(module_name) != symtab->scope.end()) {
@@ -187,10 +188,9 @@ ASR::Module_t* load_module(Allocator &al, SymbolTable *symtab,
 
     // Fix all external symbols
     fix_external_symbols(*tu, *symtab);
-    // FIXME: this verify must be turned of while running from inside
-    // `array_op`, until the pass is complete, then it will pass again,
-    // otherwise it fails, because during the pass the ASR is not valid
-    //LFORTRAN_ASSERT(asr_verify(*tu));
+    if (run_verify) {
+        LFORTRAN_ASSERT(asr_verify(*tu));
+    }
     symtab->asr_owner = orig_asr_owner;
 
     return mod2;

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -187,7 +187,10 @@ ASR::Module_t* load_module(Allocator &al, SymbolTable *symtab,
 
     // Fix all external symbols
     fix_external_symbols(*tu, *symtab);
-    LFORTRAN_ASSERT(asr_verify(*tu));
+    // FIXME: this verify must be turned of while running from inside
+    // `array_op`, until the pass is complete, then it will pass again,
+    // otherwise it fails, because during the pass the ASR is not valid
+    //LFORTRAN_ASSERT(asr_verify(*tu));
     symtab->asr_owner = orig_asr_owner;
 
     return mod2;

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -522,6 +522,7 @@ ASR::Module_t* load_module(Allocator &al, SymbolTable *symtab,
                             const std::string &module_name,
                             const Location &loc, bool intrinsic,
                             const std::string &rl_path,
+                            bool run_verify,
                             const std::function<void (const std::string &, const Location &)> err);
 
 ASR::TranslationUnit_t* find_and_load_module(Allocator &al, const std::string &msym,

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -31,8 +31,8 @@ to:
 
 The code below might seem intriguing because of minor but crucial
 details. Generally for any node, first, its children are visited.
-If any child contains operations over arrays then, the a do loop
-pass is added for performing the operation element wise. For stroing
+If any child contains operations over arrays then, the do loop
+pass is added for performing the operation element wise. For storing
 the result, either a new variable is created or a result variable
 available from the parent node is used. Once done, this result variable
 is used by the parent node in place of the child node from which it was
@@ -169,7 +169,7 @@ public:
         // which requires to generate a TransformVisitor.
         ASR::Program_t &xx = const_cast<ASR::Program_t&>(x);
         current_scope = xx.m_symtab;
-        // Updating the symbol table so that the now the name
+        // Updating the symbol table so that now the name
         // of the function (which returned array) now points
         // to the newly created subroutine.
         for( auto& item: replace_vec ) {

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -213,9 +213,12 @@ namespace LFortran {
             std::string remote_sym = func_name;
             SymbolTable* current_scope_copy = current_scope;
             current_scope = unit.m_global_scope;
+            // We tell `load_module` not to run verify, since the ASR might
+            // not be in valid state. We run verify at the end of this pass
+            // anyway, so verify will be run no matter what.
             ASR::Module_t *m = LFortran::ASRUtils::load_module(al, current_scope,
                                             module_name, loc, true,
-                                            rl_path,
+                                            rl_path, false,
                                             [&](const std::string &msg, const Location &) { throw LFortranException(msg); }
                                             );
 
@@ -243,9 +246,12 @@ namespace LFortran {
             std::string remote_sym = func_name;
             SymbolTable* current_scope_copy = current_scope;
             current_scope = unit.m_global_scope;
+            // We tell `load_module` not to run verify, since the ASR might
+            // not be in valid state. We run verify at the end of this pass
+            // anyway, so verify will be run no matter what.
             ASR::Module_t *m = LFortran::ASRUtils::load_module(al, current_scope,
                                             module_name, loc, true,
-                                            rl_path,
+                                            rl_path, false,
                                             [&](const std::string &msg, const Location &) { throw LFortranException(msg); });
 
             ASR::symbol_t *t = m->m_symtab->resolve_symbol(remote_sym);

--- a/src/lpython/semantics/ast_common_visitor.h
+++ b/src/lpython/semantics/ast_common_visitor.h
@@ -1061,7 +1061,7 @@ public:
         SymbolTable *tu_symtab = ASRUtils::get_tu_symtab(current_scope);
         std::string rl_path = get_runtime_library_dir();
         ASR::Module_t *m = ASRUtils::load_module(al, tu_symtab, module_name,
-                loc, true, rl_path,
+                loc, true, rl_path, true,
                 [&](const std::string &msg, const Location &loc) { throw SemanticError(msg, loc); }
                 );
 

--- a/src/lpython/semantics/ast_symboltable_visitor.cpp
+++ b/src/lpython/semantics/ast_symboltable_visitor.cpp
@@ -166,7 +166,7 @@ public:
             std::string rl_path = get_runtime_library_dir();
             ASR::symbol_t* submod_parent = (ASR::symbol_t*)(ASRUtils::load_module(al, global_scope,
                                                 parent_name, x.base.base.loc, false,
-                                                rl_path,
+                                                rl_path, true,
                                                 [&](const std::string &msg, const Location &loc) { throw SemanticError(msg, loc); }
                                                 ));
             ASR::Module_t *m = ASR::down_cast<ASR::Module_t>(submod_parent);
@@ -1437,7 +1437,7 @@ public:
         if (!t) {
             std::string rl_path = get_runtime_library_dir();
             t = (ASR::symbol_t*)(ASRUtils::load_module(al, current_scope->parent,
-                msym, x.base.base.loc, false, rl_path,
+                msym, x.base.base.loc, false, rl_path, true,
                 [&](const std::string &msg, const Location &loc) { throw SemanticError(msg, loc); }
                 ));
         }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -2244,6 +2244,10 @@ public:
                 // with the type
                 tmp = nullptr;
                 return;
+            } else if (call_name == "TypeVar") {
+                // Ignore TypeVar for now, we handle it based on the identifier itself
+                tmp = nullptr;
+                return;
             } else if (call_name == "complex") {
                 int16_t n_args = args.size();
                 ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Complex_t(al, x.base.base.loc,

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -348,12 +348,7 @@ public:
                 } else {
                     this->visit_expr(*s->m_slice);
                     ASR::expr_t *value = ASRUtils::EXPR(tmp);
-                    if (ASR::is_a<ASR::ConstantInteger_t>(*value)) {
-                        ASR::ttype_t *itype = ASRUtils::TYPE(ASR::make_Integer_t(al, loc,
-                                4, nullptr, 0));
-                        dim.m_start = ASR::down_cast<ASR::expr_t>(ASR::make_ConstantInteger_t(al, loc, 1, itype));
-                        dim.m_end = value;
-                    } else if (ASR::is_a<ASR::Var_t>(*value)) {
+                    if (ASR::is_a<ASR::ConstantInteger_t>(*value) || ASR::is_a<ASR::Var_t>(*value)) {
                         ASR::ttype_t *itype = ASRUtils::TYPE(ASR::make_Integer_t(al, loc,
                                 4, nullptr, 0));
                         dim.m_start = ASR::down_cast<ASR::expr_t>(ASR::make_ConstantInteger_t(al, loc, 1, itype));

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -633,7 +633,7 @@ public:
         }
         char *bindc_name=nullptr;
         if (x.m_returns) {
-            if (AST::is_a<AST::Name_t>(*x.m_returns)) {
+            if (AST::is_a<AST::Name_t>(*x.m_returns) || AST::is_a<AST::Subscript_t>(*x.m_returns)) {
                 std::string return_var_name = "_lpython_return_variable";
                 ASR::ttype_t *type = ast_expr_to_asr_type(x.m_returns->base.loc, *x.m_returns);
                 ASR::asr_t *return_var = ASR::make_Variable_t(al, x.m_returns->base.loc,
@@ -659,7 +659,7 @@ public:
                     s_access, deftype, bindc_name);
 
             } else {
-                throw SemanticError("Return variable must be an identifier",
+                throw SemanticError("Return variable must be an identifier (Name AST node) or an array (Subscript AST node)",
                     x.m_returns->base.loc);
             }
         } else {

--- a/src/lpython/semantics/python_ast_to_asr.h
+++ b/src/lpython/semantics/python_ast_to_asr.h
@@ -8,7 +8,8 @@ namespace LFortran::Python {
 
     std::string pickle_python(AST::ast_t &ast, bool colors=false, bool indent=false);
     Result<ASR::TranslationUnit_t*> python_ast_to_asr(Allocator &al,
-        Python::AST::ast_t &ast, diag::Diagnostics &diagnostics, bool main_module);
+        Python::AST::ast_t &ast, diag::Diagnostics &diagnostics, bool main_module,
+        bool symtab_only);
     Result<AST::ast_t*> parse_python_file(Allocator &al,
             const std::string &runtime_library_dir,
             const std::string &infile);

--- a/src/runtime/ltypes/ltypes.py
+++ b/src/runtime/ltypes/ltypes.py
@@ -2,6 +2,10 @@ from inspect import getfullargspec, getcallargs
 import os
 import ctypes
 import platform
+from typing import TypeVar
+
+__slots__ = ["i32", "i64", "f32", "f64", "c32", "c64",
+        "overload", "ccall", "TypeVar"]
 
 # data-types
 


### PR DESCRIPTION
And use it to implement `numpy.zeros()`. 

TODO:
* [x] The ASR seems to work, but it lowers incorrectly to LLVM it seems, because unlike LFortran, here we assign to a local array first, and then copy to the return array.
* [x] Enable the `test_numpy_02.py` in both LPython and CPython