### PR TITLE
Implement numpy functions

### DIFF
--- a/integration_tests/test_numpy_02.py
+++ b/integration_tests/test_numpy_02.py
@@ -48,10 +48,17 @@ def exp(n: i32) -> f64:
 def exp(f: f64) -> f64:
     return e**f
 
+@overload
 def fabs(f: f64) -> f64:
     if f < 0.0:
         return -f
     return f
+
+@overload
+def fabs(n: i32) -> f64:
+    if n < 0:
+        return -1.0*n
+    return 1.0*n
 
 num: i32
 num = TypeVar("num")
@@ -114,9 +121,12 @@ def test_exp():
 def test_fabs():
     a: f64
     a = fabs(-3.7)
+    a2: f64
+    a2 = fabs(-3)
     eps: f64
     eps = 1e-12
     assert abs(a - 3.7) < eps
+    assert abs(a2 - 3.0) < eps
 
 def test_linspace():
     a: f64[4]

--- a/integration_tests/test_numpy_02.py
+++ b/integration_tests/test_numpy_02.py
@@ -1,6 +1,6 @@
 # This test handles actual LPython implementations of functions from the numpy
 # module.
-from ltypes import i32, i64, f64, TypeVar
+from ltypes import i32, i64, f64, TypeVar, overload
 from numpy import empty, int64
 
 e: f64 = 2.718281828459045
@@ -32,8 +32,13 @@ def arange(n: i32) -> i64[n]:
         A[i] = i
     return A
 
+@overload
 def sqrt(n: i32) -> f64:
     return n**(1/2)
+
+@overload
+def sqrt(f: f64) -> f64:
+    return f**(1/2)
 
 def exp(n: i32) -> f64:
     return e**n
@@ -83,10 +88,13 @@ def test_arange():
 
 def test_sqrt():
     a: f64
+    a2: f64
     a = sqrt(2)
+    a2 = sqrt(5.6)
     eps: f64
     eps = 1e-12
     assert abs(a - 1.4142135623730951) < eps
+    assert abs(a2 - 2.3664319132398464) < eps
 
 def test_exp():
     a: f64

--- a/integration_tests/test_numpy_02.py
+++ b/integration_tests/test_numpy_02.py
@@ -40,8 +40,13 @@ def sqrt(n: i32) -> f64:
 def sqrt(f: f64) -> f64:
     return f**(1/2)
 
+@overload
 def exp(n: i32) -> f64:
     return e**n
+
+@overload
+def exp(f: f64) -> f64:
+    return e**f
 
 def fabs(f: f64) -> f64:
     if f < 0.0:
@@ -99,9 +104,12 @@ def test_sqrt():
 def test_exp():
     a: f64
     a = exp(6)
+    a2: f64
+    a2 = exp(5.6)
     eps: f64
     eps = 1e-12
     assert abs(a - 403.4287934927351) < eps
+    assert abs(a2 - 270.42640742615254) < eps
 
 def test_fabs():
     a: f64

--- a/integration_tests/test_numpy_02.py
+++ b/integration_tests/test_numpy_02.py
@@ -30,6 +30,9 @@ def arange(n: i32) -> i64[n]:
         A[i] = i
     return A
 
+def sqrt(n: i32) -> f64:
+    return n**(1/2)
+
 num: i32
 num = TypeVar("num")
 def linspace(start: f64, stop: f64, num: i32) -> f64[num]:
@@ -68,6 +71,13 @@ def test_arange():
     assert a[2] == 2
     assert a[3] == 3
 
+def test_sqrt():
+    a: f64
+    a = sqrt(2)
+    eps: f64
+    eps = 1e-12
+    assert abs(a - 1.4142135623730951) < eps
+
 def test_linspace():
     a: f64[4]
     a = linspace(1., 7., 4)
@@ -82,6 +92,7 @@ def check():
     test_zeros()
     test_ones()
     test_arange()
+    test_sqrt()
     test_linspace()
 
 check()

--- a/integration_tests/test_numpy_02.py
+++ b/integration_tests/test_numpy_02.py
@@ -3,6 +3,8 @@
 from ltypes import i32, i64, f64, TypeVar
 from numpy import empty, int64
 
+e: f64 = 2.718281828459045
+
 n: i32
 n = TypeVar("n")
 
@@ -32,6 +34,9 @@ def arange(n: i32) -> i64[n]:
 
 def sqrt(n: i32) -> f64:
     return n**(1/2)
+
+def exp(n: i32) -> f64:
+    return e**n
 
 num: i32
 num = TypeVar("num")
@@ -78,6 +83,13 @@ def test_sqrt():
     eps = 1e-12
     assert abs(a - 1.4142135623730951) < eps
 
+def test_exp():
+    a: f64
+    a = exp(6)
+    eps: f64
+    eps = 1e-12
+    assert abs(a - 403.4287934927351) < eps
+
 def test_linspace():
     a: f64[4]
     a = linspace(1., 7., 4)
@@ -93,6 +105,7 @@ def check():
     test_ones()
     test_arange()
     test_sqrt()
+    test_exp()
     test_linspace()
 
 check()

--- a/integration_tests/test_numpy_02.py
+++ b/integration_tests/test_numpy_02.py
@@ -38,6 +38,11 @@ def sqrt(n: i32) -> f64:
 def exp(n: i32) -> f64:
     return e**n
 
+def fabs(f: f64) -> f64:
+    if f < 0.0:
+        return -f
+    return f
+
 num: i32
 num = TypeVar("num")
 def linspace(start: f64, stop: f64, num: i32) -> f64[num]:
@@ -90,6 +95,13 @@ def test_exp():
     eps = 1e-12
     assert abs(a - 403.4287934927351) < eps
 
+def test_fabs():
+    a: f64
+    a = fabs(-3.7)
+    eps: f64
+    eps = 1e-12
+    assert abs(a - 3.7) < eps
+
 def test_linspace():
     a: f64[4]
     a = linspace(1., 7., 4)
@@ -106,6 +118,7 @@ def check():
     test_arange()
     test_sqrt()
     test_exp()
+    test_fabs()
     test_linspace()
 
 check()


### PR DESCRIPTION
- [x] `np.sqrt(n)` for `n: i32`
- [x]  `np.sqrt(n)` for `n: f64`
- [ ] `np.sqrt(a)` for `a: f64[n]`
- [x] `np.exp(n)` for `n: i32`
- [x] `np.exp(n)` for `n: f64`
- [ ] `np.exp(a)` for `a: f64[n]`
- [x] `np.fabs(n)` for `n: f64`
- [x] `np.fabs(n)` for `n: i32`
- [ ] `np.fabs(a)` for `a: f64[n]`
- [ ] `np.add(a, b)` for `a: f64[n]` and `b: f64[n]`
- [ ] `np.subtract(a, b)` for `a: f64[n]` and `b: f64[n]`
- [ ] `np.multiply(a, b)` for `a: f64[n]` and `b: f64[n]`
- [ ] `np.divide(a, b)` for `a: f64[n]` and `b: f64[n]`
- [ ] `np.array_equal(a, b)` for `a: f64[n]` and `b: f64[n]`