### PR TITLE
Add numpy to virtual env package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ https://github.com/conda-forge/miniforge/#download
 
 Create a Conda environment:
 
-    conda create -n lp llvmdev=11.0.1 bison=3.4 re2c python cmake make toml
+    conda create -n lp llvmdev=11.0.1 bison=3.4 re2c python cmake make toml numpy
     conda activate lp
 
 Install required packages (Linux - 64 bit):

--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -71,7 +71,7 @@ export PATH="$HOME/conda_root/bin:$PATH"
 ```
 Then prepare the environment:
 ```bash
-conda create -n lf -c conda-forge llvmdev=11.0.1 bison=3.4 re2c python cmake make toml
+conda create -n lf -c conda-forge llvmdev=11.0.1 bison=3.4 re2c python cmake make toml numpy
 conda activate lf
 ```
 Clone the LFortran git repository:

--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -71,7 +71,7 @@ export PATH="$HOME/conda_root/bin:$PATH"
 ```
 Then prepare the environment:
 ```bash
-conda create -n lf -c conda-forge llvmdev=11.0.1 bison=3.4 re2c python cmake make toml numpy
+conda create -n lp -c conda-forge llvmdev=11.0.1 bison=3.4 re2c python cmake make toml numpy
 conda activate lf
 ```
 Clone the LFortran git repository:

--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -72,7 +72,7 @@ export PATH="$HOME/conda_root/bin:$PATH"
 Then prepare the environment:
 ```bash
 conda create -n lp -c conda-forge llvmdev=11.0.1 bison=3.4 re2c python cmake make toml numpy
-conda activate lf
+conda activate lp
 ```
 Clone the LFortran git repository:
 ```

--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -10,8 +10,8 @@ Install Conda for example by installing the
 Then create a new environment (you can choose any name, here we chose `lf`) and
 activate it:
 ```bash
-conda create -n lf
-conda activate lf
+conda create -n lp
+conda activate lp
 ```
 Then install LFortran by:
 ```bash
@@ -42,7 +42,7 @@ conda create -n lf python cmake llvmdev
 conda activate lf
 ```
 Then download a tarball from 
-[https://lfortran.org/download/](https://lfortran.org/download/), 
+[https://lfortran.org/download/](https://lfortran.org/download/),
 e.g.:
 ```bash
 wget https://lfortran.github.io/tarballs/dev/lfortran-0.9.0.tar.gz


### PR DESCRIPTION
Integration tests fail when numpy is not installed in the development venv. This PR will ensure that it is installed before any developer runs the test.

See #244 for more information.