### PR TITLE
CI: Enable failing on error

### DIFF
--- a/ci/test.xsh
+++ b/ci/test.xsh
@@ -1,3 +1,8 @@
+#!/usr/bin/env xonsh
+#
+$RAISE_SUBPROC_ERROR = True
+trace on
+
 # Run some simple compilation tests, works everywhere:
 src/bin/lpython --version
 # Compile and link separately

--- a/integration_tests/test_os.py
+++ b/integration_tests/test_os.py
@@ -1,12 +1,12 @@
 from ltypes import i64
-from os import (open, read, close)
+from os import (open, read, close, O_RDONLY)
 
 def test():
     path: str 
     path = "integration_tests/test_os.py"
     fd: i64
     n: i64
-    fd = open(path, "r")
+    fd = open(path, O_RDONLY)
     n = 100
     print(read(fd, n))
     close(fd) 

--- a/src/runtime/os.py
+++ b/src/runtime/os.py
@@ -1,10 +1,22 @@
 from ltypes import i32, i64, ccall
 
-def open(path: str, flag: str) -> i64:
+O_RDONLY: i32 # = 0 FIXME: Assign the value 0 to O_RDONLY
+# O_WRONLY: i32 = 1
+# O_RDWR  : i32 = 2
+# O_CREAT : i32 = 64
+# O_APPEND: i32 = 1024
+
+
+def open(path: str, flag: i32) -> i64:
     """
     Returns the file descriptor for the newly opened file
     """
-    return _lpython_open(path, flag)
+    sflag: str
+    if flag == O_RDONLY:
+        sflag = "r"
+    else:
+        quit(1) # not implemented yet
+    return _lpython_open(path, sflag)
 
 @ccall
 def _lpython_open(path: str, flag: str) -> i64:


### PR DESCRIPTION
This was introduced when we split the CI script into two, the second one
does not fail on error.