### PR TITLE
adding conda-forge channel in the installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ https://github.com/conda-forge/miniforge/#download
 
 Create a Conda environment:
 
+    conda config --append channels conda-forge
     conda create -n lp llvmdev=11.0.1 bison=3.4 re2c python cmake make toml numpy
     conda activate lp
 


### PR DESCRIPTION
Multiple times when I install, I had to manually insert the channel `conda-forge` to create the environment. 

Even if this channel already exists in the environment, nothing bad will happen. But having this step in the instructions might make life easier for newcomers.