### PR TITLE
Use the new parser from the driver

### DIFF
--- a/examples/expr2.py
+++ b/examples/expr2.py
@@ -1,10 +1,1 @@
-def main0():
-    x: i32
-    x = (2+3)*5
-    print(x)
-
-main0()
-
-# Not implemented yet in LPython:
-#if __name__ == "__main__":
-#    main()
+(a*z+3+2*x + 3*y - x/(z**2-4) - x**(y**z)) * (a*z+3+2*x + 3*y - x/(z**2-4) - x**(y**z))

--- a/src/lpython/parser/tokenizer.re
+++ b/src/lpython/parser/tokenizer.re
@@ -38,6 +38,24 @@ bool lex_dec(const unsigned char *s, const unsigned char *e, uint64_t &u)
     return true;
 }
 
+void lex_dec_int_large(Allocator &al, const unsigned char *s,
+    const unsigned char *e, BigInt::BigInt &u)
+{                                                           
+    uint64_t ui;                   
+    if (lex_dec(s, e, ui)) {                                       
+        if (ui <= BigInt::MAX_SMALL_INT) {
+            u.from_smallint(ui);
+            return;
+        }
+    }       
+    const unsigned char *start = s;                                   
+    Str num;                                     
+    num.p = (char*)start;                       
+    num.n = e-start;                                
+    u.from_largeint(al, num);      
+}                
+
+
 // Tokenizes integer of the kind 0x1234 into `prefix` and `u`
 // s ... the start of the integer
 // e ... the character after the end
@@ -73,12 +91,9 @@ void lex_int(Allocator &al, const unsigned char *s,
         num.n = e-s;
         u.from_largeint(al, num);
     } else {
+        lex_dec_int_large(al, s, e, u);
         prefix.p = nullptr;
         prefix.n = 0;
-        Str num;
-        num.p = (char*)s;
-        num.n = e-s;
-        u.from_largeint(al, num);
     }
     return;
 }


### PR DESCRIPTION
Right now it is hardwired, we need to optionally use it when a flag such as `--new-parser` is enabled, otherwise use the old parser. And we need to use it for all parsing, so that we can easily test it with semantics also.

Example:
```
$ lpython --show-ast examples/expr2.py 
(Module [(Expr (BinOp (BinOp (BinOp (BinOp (BinOp (BinOp (BinOp (Name a Load) Mult (Name z Load)) Add (ConstantInt 4611686019840876766 ())) Add (BinOp (ConstantInt 4611686019840876786 ()) Mult (Name x Load))) Add (BinOp (ConstantInt 4611686019840876826 ()) Mult (Name y Load))) Sub (BinOp (Name x Load) Div (BinOp (BinOp (Name z Load) Pow (ConstantInt 4611686019840876886 ())) Sub (ConstantInt 4611686019840876906 ())))) Sub (BinOp (Name x Load) Pow (BinOp (Name y Load) Pow (Name z Load)))) Mult (BinOp (BinOp (BinOp (BinOp (BinOp (BinOp (Name a Load) Mult (Name z Load)) Add (ConstantInt 4611686019840877036 ())) Add (BinOp (ConstantInt 4611686019840877056 ()) Mult (Name x Load))) Add (BinOp (ConstantInt 4611686019840877096 ()) Mult (Name y Load))) Sub (BinOp (Name x Load) Div (BinOp (BinOp (Name z Load) Pow (ConstantInt 4611686019840877156 ())) Sub (ConstantInt 4611686019840877176 ())))) Sub (BinOp (Name x Load) Pow (BinOp (Name y Load) Pow (Name z Load))))))] [])
```