### PR TITLE
Fix the `dedent` token generation in new tokenizer

### DIFF
--- a/src/lpython/parser/tokenizer.re
+++ b/src/lpython/parser/tokenizer.re
@@ -148,7 +148,8 @@ int Tokenizer::lex(Allocator &al, YYSTYPE &yylval, Location &loc, diag::Diagnost
     } else if(dedent == 2) {
         // Reduce the indent to `last_indent_length`
         long int sum = 0;
-        for (auto& n : indent_length) sum += n;
+        // for (auto& n : indent_length) sum += n;
+        sum = indent_length.back();
         if(sum != last_indent_length) {
             indent_length.pop_back();
             loc.first = loc.last;

--- a/src/lpython/parser/tokenizer.re
+++ b/src/lpython/parser/tokenizer.re
@@ -147,10 +147,7 @@ int Tokenizer::lex(Allocator &al, YYSTYPE &yylval, Location &loc, diag::Diagnost
         }
     } else if(dedent == 2) {
         // Reduce the indent to `last_indent_length`
-        long int sum = 0;
-        // for (auto& n : indent_length) sum += n;
-        sum = indent_length.back();
-        if(sum != last_indent_length) {
+        if((long int)indent_length.back() != last_indent_length) {
             indent_length.pop_back();
             loc.first = loc.last;
             return yytokentype::TK_DEDENT;

--- a/tests/reference/tokens-indent2-e702789.json
+++ b/tests/reference/tokens-indent2-e702789.json
@@ -1,0 +1,13 @@
+{
+    "basename": "tokens-indent2-e702789",
+    "cmd": "lpython --no-color --show-tokens {infile} -o {outfile}",
+    "infile": "tests/tokens/indent2.py",
+    "infile_hash": "8f79ea4e1f8564b61e3dfc63e2a3e9b44e9ae161753ea8a8710de206",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "tokens-indent2-e702789.stdout",
+    "stdout_hash": "9b0fe0e5eea973771b66bc5d1c8af9a695ceb73fbd81c8f309465f72",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/tokens-indent2-e702789.json
+++ b/tests/reference/tokens-indent2-e702789.json
@@ -2,11 +2,11 @@
     "basename": "tokens-indent2-e702789",
     "cmd": "lpython --no-color --show-tokens {infile} -o {outfile}",
     "infile": "tests/tokens/indent2.py",
-    "infile_hash": "8f79ea4e1f8564b61e3dfc63e2a3e9b44e9ae161753ea8a8710de206",
+    "infile_hash": "0bf5680f2c0bd9241c0622181be765f900672a0d54ca6366fd5842ff",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "tokens-indent2-e702789.stdout",
-    "stdout_hash": "9b0fe0e5eea973771b66bc5d1c8af9a695ceb73fbd81c8f309465f72",
+    "stdout_hash": "d21868282c9ca047305e18e15d2961166902b5eecba2f8d905d7d219",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/tokens-indent2-e702789.stdout
+++ b/tests/reference/tokens-indent2-e702789.stdout
@@ -1,0 +1,27 @@
+(KEYWORD "class") 0:4
+(TOKEN "identifier" Test) 6:9
+(TOKEN ":") 10:10
+(NEWLINE) 11:11
+(TOKEN "indent") 12:15
+(KEYWORD "def") 16:18
+(TOKEN "identifier" foo) 20:22
+(TOKEN "(") 23:23
+(TOKEN ")") 24:24
+(TOKEN ":") 25:25
+(NEWLINE) 26:26
+(TOKEN "indent") 27:34
+(KEYWORD "if") 35:36
+(TOKEN "string" "foo") 38:42
+(TOKEN ":") 43:43
+(NEWLINE) 44:44
+(TOKEN "indent") 45:56
+(KEYWORD "return") 57:62
+(TOKEN "string" "foo") 64:68
+(NEWLINE) 69:69
+(TOKEN "dedent") 70:77
+(KEYWORD "return") 78:83
+(TOKEN "string" "bar") 85:89
+(NEWLINE) 90:90
+(TOKEN "dedent") 90:90
+(TOKEN "dedent") 90:90
+(EOF) 91:91

--- a/tests/reference/tokens-indent2-e702789.stdout
+++ b/tests/reference/tokens-indent2-e702789.stdout
@@ -6,22 +6,25 @@
 (KEYWORD "def") 16:18
 (TOKEN "identifier" foo) 20:22
 (TOKEN "(") 23:23
-(TOKEN ")") 24:24
-(TOKEN ":") 25:25
-(NEWLINE) 26:26
-(TOKEN "indent") 27:34
-(KEYWORD "if") 35:36
-(TOKEN "string" "foo") 38:42
-(TOKEN ":") 43:43
-(NEWLINE) 44:44
-(TOKEN "indent") 45:56
-(KEYWORD "return") 57:62
-(TOKEN "string" "foo") 64:68
-(NEWLINE) 69:69
-(TOKEN "dedent") 70:77
-(KEYWORD "return") 78:83
-(TOKEN "string" "bar") 85:89
-(NEWLINE) 90:90
-(TOKEN "dedent") 90:90
-(TOKEN "dedent") 90:90
-(EOF) 91:91
+(TOKEN "identifier" a) 24:24
+(TOKEN ")") 25:25
+(TOKEN ":") 26:26
+(NEWLINE) 27:27
+(TOKEN "indent") 28:35
+(KEYWORD "if") 36:37
+(TOKEN "identifier" a) 39:39
+(TOKEN "==") 41:42
+(TOKEN "string" "foo") 44:48
+(TOKEN ":") 49:49
+(NEWLINE) 50:50
+(TOKEN "indent") 51:62
+(KEYWORD "return") 63:68
+(TOKEN "string" "foo") 70:74
+(NEWLINE) 75:75
+(TOKEN "dedent") 76:83
+(KEYWORD "return") 84:89
+(TOKEN "string" "bar") 91:95
+(NEWLINE) 96:96
+(TOKEN "dedent") 96:96
+(TOKEN "dedent") 96:96
+(EOF) 97:97

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -235,6 +235,10 @@ filename = "tokens/indent1.py"
 tokens = true
 
 [[test]]
+filename = "tokens/indent2.py"
+tokens = true
+
+[[test]]
 filename = "../integration_tests/test_max_min.py"
 asr = true
 

--- a/tests/tokens/indent2.py
+++ b/tests/tokens/indent2.py
@@ -1,5 +1,5 @@
 class Test:
-    def foo():
-        if 'foo':
+    def foo(a):
+        if a == 'foo':
             return 'foo'
         return 'bar'

--- a/tests/tokens/indent2.py
+++ b/tests/tokens/indent2.py
@@ -1,0 +1,5 @@
+class Test:
+    def foo():
+        if 'foo':
+            return 'foo'
+        return 'bar'


### PR DESCRIPTION
The tokenizer was throwing an error when the last line of the source code was dedented by one level less than the previous level. I debugged and fixed it.

Closes #358 