### PR TITLE
Fix type mismatch error message for binary operators

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -818,7 +818,7 @@ public:
             std::string ltype = ASRUtils::type_to_str(ASRUtils::expr_type(left));
             std::string rtype = ASRUtils::type_to_str(ASRUtils::expr_type(right));
             diag.add(diag::Diagnostic(
-                "Not Implemented: type mismatch in binary operator; only Integer, Real, Complex,"
+                "Type mismatch in binary operator; only Integer, Real, Complex,"
                 " Logical combinations and string concatenation/repetition are implemented for now.",
                 diag::Level::Error, diag::Stage::Semantic, {
                     diag::Label("type mismatch (" + ltype + " and " + rtype + ")",

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -818,8 +818,7 @@ public:
             std::string ltype = ASRUtils::type_to_str(ASRUtils::expr_type(left));
             std::string rtype = ASRUtils::type_to_str(ASRUtils::expr_type(right));
             diag.add(diag::Diagnostic(
-                "Type mismatch in binary operator; only Integer, Real, Complex,"
-                " Logical combinations and string concatenation/repetition are implemented for now.",
+                "Type mismatch in binary operator; the types must be compatible",
                 diag::Level::Error, diag::Stage::Semantic, {
                     diag::Label("type mismatch (" + ltype + " and " + rtype + ")",
                             {left->base.loc, right->base.loc})


### PR DESCRIPTION
This PR attempts to fix the error message which is raised when mismatched types are operated on a binary operator.

To reproduce:

Run a following script using lpython: (or modify `examples/expr2.py`)

```python
x = (2+3)*5+”s”
```

This, in the current state of the library, will throw the following error (observe `Not Implemented`):

```python
semantic error: Not Implemented: type mismatch in binary operator; only Integer, Real, Complex, Logical combinations and string concatenation/repetition are implemented for now.
 --> examples/expr2.py:3:9
  |
3 |     x = (2+3)*5+"s"
  |         ^^^^^^^ ^^^ type mismatch (integer and character)
```

Ideally, this should be just a `semantic error` with the corresponding error message. After this PR, the error message would look like:

```python
semantic error: type mismatch in binary operator; only Integer, Real, Complex, Logical combinations and string concatenation/repetition are implemented for now.
 --> examples/expr2.py:3:9
  |
3 |     x = (2+3)*5+"s"
  |         ^^^^^^^ ^^^ type mismatch (integer and character)
```

Thank you @certik for finding this bug, and also helping me with how to reproduce it locally! :)

cc: @certik


