### PR TITLE
Handle integer printing in the llvm backend

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3579,6 +3579,14 @@ public:
             if (ASRUtils::is_integer(*t) ||
                 ASR::is_a<ASR::Logical_t>(*ASRUtils::type_get_past_pointer(t))) {
                 switch( a_kind ) {
+                    case 1 : {
+                        fmt.push_back("%d");
+                        break;
+                    }
+                    case 2 : {
+                        fmt.push_back("%d");
+                        break;
+                    }
                     case 4 : {
                         fmt.push_back("%d");
                         break;
@@ -3589,7 +3597,7 @@ public:
                     }
                     default: {
                         throw CodeGenError(R"""(Printing support is available only
-                                            for 32, and 64 bit integer kinds.)""",
+                                            for 8, 16, 32, and 64 bit integer kinds.)""",
                                             x.base.base.loc);
                     }
                 }

--- a/tests/ltypes.py
+++ b/tests/ltypes.py
@@ -1,0 +1,19 @@
+def test_i8():
+    i: i8
+    i = 5
+    print(i)
+
+def test_i16():
+    i: i16
+    i = 4
+    print(i)
+
+def test_i32():
+    i: i32
+    i = 3
+    print(i)
+
+def test_i64():
+    i: i64
+    i = 2
+    print(i)

--- a/tests/reference/llvm-ltypes-1402bca.json
+++ b/tests/reference/llvm-ltypes-1402bca.json
@@ -1,0 +1,13 @@
+{
+    "basename": "llvm-ltypes-1402bca",
+    "cmd": "lpython --no-color --show-llvm {infile} -o {outfile}",
+    "infile": "tests/ltypes.py",
+    "infile_hash": "daac081f5e376233adabe24304126763178cfd3a6286c361b7955446",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "llvm-ltypes-1402bca.stdout",
+    "stdout_hash": "cafb6dc418ad5ddc1ef709741df5c2ee0a45fcdee41b49c50f121ffb",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/llvm-ltypes-1402bca.stdout
+++ b/tests/reference/llvm-ltypes-1402bca.stdout
@@ -1,0 +1,62 @@
+; ModuleID = 'LFortran'
+source_filename = "LFortran"
+
+@0 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
+@1 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
+@2 = private unnamed_addr constant [6 x i8] c"%lld\0A\00", align 1
+@3 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
+
+define void @test_i16() {
+.entry:
+  %i = alloca i16, align 2
+  store i16 4, i16* %i, align 2
+  %0 = load i16, i16* %i, align 2
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i32 0, i32 0), i16 %0)
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret void
+}
+
+define void @test_i32() {
+.entry:
+  %i = alloca i32, align 4
+  store i32 3, i32* %i, align 4
+  %0 = load i32, i32* %i, align 4
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @1, i32 0, i32 0), i32 %0)
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret void
+}
+
+define void @test_i64() {
+.entry:
+  %i = alloca i64, align 8
+  store i64 2, i64* %i, align 4
+  %0 = load i64, i64* %i, align 4
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i64 %0)
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret void
+}
+
+define void @test_i8() {
+.entry:
+  %i = alloca i8, align 1
+  store i8 5, i8* %i, align 1
+  %0 = load i8, i8* %i, align 1
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @3, i32 0, i32 0), i8 %0)
+  br label %return
+
+return:                                           ; preds = %.entry
+  ret void
+}
+
+declare void @_lfortran_printf(i8*, ...)
+
+define i32 @main() {
+.entry:
+  ret i32 0
+}

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -167,6 +167,10 @@ ast = true
 asr = true
 
 [[test]]
+filename = "ltypes.py"
+llvm = true
+
+[[test]]
 filename = "../integration_tests/test_builtin.py"
 asr = true
 


### PR DESCRIPTION
```python
def f():
  i1: i8
  i1 = 4
  print(i1)
  i2: i16
  i2 = 2
  print(i2)


f()
```
Before this PR it gives,
```console
% lpython a.py && ./a.out
code generation error: Printing support is available only
                                            for 32, and 64 bit integer kinds.
 --> a.py:4:3
  |
4 |   print(i1)
  |   ^^^^^^^^^ 



```
Now it prints correctly,
```console
% lpython a.py && ./a.out
4
2
```