### PR TITLE
use nproc to utilise max processing units

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Compile LPython:
 
 ```bash
 cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_LLVM=yes -DWITH_STACKTRACE=yes -DWITH_LFORTRAN_BINARY_MODFILES=no .
-cmake --build . -j16
+cmake --build . -j$(nproc)
 ```
 
 ## Tests:


### PR DESCRIPTION
Using nproc so that there is better compatibility with different build machines and different CPUs