### PR TITLE
Degrees radians overload to support more ltypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Compile LPython:
 
 ```bash
 cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_LLVM=yes -DWITH_STACKTRACE=yes -DWITH_LFORTRAN_BINARY_MODFILES=no .
-cmake --build . -j16
+cmake --build . -j$(nproc)
 ```
 
 ## Tests:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ Compile LPython:
 
 ```bash
 cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_LLVM=yes -DWITH_STACKTRACE=yes -DWITH_LFORTRAN_BINARY_MODFILES=no .
+# For Linux
 cmake --build . -j$(nproc)
+# For MacOS
+cmake --build . -j$(sysctl -n hm.logicalcpu)
 ```
 
 ## Tests:

--- a/integration_tests/test_math.py
+++ b/integration_tests/test_math.py
@@ -30,13 +30,25 @@ def test_isqrt():
 
 
 def test_degrees():
+
     i: f64
+
+    # Check for integer
+    i = degrees(32)
+    assert abs(i - 1833.4649444186343) < eps
+    
+    # Check for float
     i = degrees(32.2)
     assert abs(i - 1844.924100321251) < eps
-
-
+  
 def test_radians():
     i: f64
+
+    # Check for integer
+    i = radians(100)
+    assert abs(i - 1.7453292519943295) < eps
+
+    # Check for float
     i = radians(100.1)
     assert abs(i - 1.7470745812463238) < eps
 
@@ -124,7 +136,6 @@ def test_log1p():
 
 def test_expm1():
     assert expm1(1.0) - 1.71828182845904509 < eps
-
 
 def check():
     test_factorial_1()

--- a/src/runtime/math.py
+++ b/src/runtime/math.py
@@ -22,6 +22,21 @@ def factorial(x: i32) -> i32:
         result *= i
     return result
 
+@overload
+def trunc(x: i32)-> i32:
+    return x
+
+@overload
+def trunc(x: i64)-> i64:
+    return x
+
+@overload
+def trunc(x: f32) -> i32:
+    return int(x)
+
+@overload
+def trunc(x: f64) -> i64:
+    return int(x)
 
 @overload
 def floor(x: i32) -> i32:
@@ -118,20 +133,95 @@ def isqrt(n: i32) -> i32:
             high = mid
     return low
 
+# degrees
+# supported data types: i8, i16, i32, i64, f32, f64
 
+@overload
+def degrees(x: i8) -> f64:
+    """
+    Convert angle `x` from radians to degrees.
+    """
+    return x * 180.0 / pi
+
+@overload
+def degrees(x: i16) -> f64:
+    """
+    Convert angle `x` from radians to degrees.
+    """
+    return x * 180.0 / pi
+
+@overload
+def degrees(x: i32) -> f64:
+    """
+    Convert angle `x` from radians to degrees.
+    """
+    return x * 180.0 / pi
+
+@overload
+def degrees(x: i64) -> f64:
+    """
+    Convert angle `x` from radians to degrees.
+    """
+    return x * 180.0 / pi
+
+@overload
+def degrees(x: f32) -> f64:
+    """
+    Convert angle `x` from radians to degrees.
+    """
+    return x * 180.0 / pi
+
+@overload
 def degrees(x: f64) -> f64:
     """
     Convert angle `x` from radians to degrees.
     """
     return x * 180.0 / pi
 
+# radians
+# supported data types: i8, i16, i32, i64, f32, f64
 
-def radians(x: f64) -> f64:
+@overload
+def radians(x: i8) -> f64:
     """
     Convert angle `x` from degrees to radians.
     """
     return x * pi / 180.0
 
+@overload
+def radians(x: i16) -> f64:
+    """
+    Convert angle `x` from degrees to radians.
+    """
+    return x * pi / 180.0
+
+@overload
+def radians(x: i32) -> f64:
+    """
+    Convert angle `x` from degrees to radians.
+    """
+    return x * pi / 180.0
+
+@overload
+def radians(x: i64) -> f64:
+    """
+    Convert angle `x` from degrees to radians.
+    """
+    return x * pi / 180.0
+
+@overload
+def radians(x: f32) -> f64:
+    """
+    Convert angle `x` from degrees to radians.
+    """
+    return x * pi / 180.0
+
+@overload
+def radians(x: f64) -> f64:
+    """
+    Convert angle `x` from degrees to radians.
+    """
+    return x * pi / 180.0
 
 def fabs(x: f64) -> f64:
     """


### PR DESCRIPTION
This PR has changes that overloads `degrees` and `radians` in `math.py` to support `i8, i16, i32, i64, f32, f64` ltypes. Releavant test code is added to `test_math.py`.