### PR TITLE
Overload math degrees and radians to support more ltypes

### DIFF
--- a/integration_tests/test_math.py
+++ b/integration_tests/test_math.py
@@ -30,13 +30,25 @@ def test_isqrt():
 
 
 def test_degrees():
+
     i: f64
+
+    # Check for integer
+    i = degrees(32)
+    assert abs(i - 1833.4649444186343) < eps
+    
+    # Check for float
     i = degrees(32.2)
     assert abs(i - 1844.924100321251) < eps
-
-
+  
 def test_radians():
     i: f64
+
+    # Check for integer
+    i = radians(100)
+    assert abs(i - 1.7453292519943295) < eps
+
+    # Check for float
     i = radians(100.1)
     assert abs(i - 1.7470745812463238) < eps
 
@@ -124,7 +136,6 @@ def test_log1p():
 
 def test_expm1():
     assert expm1(1.0) - 1.71828182845904509 < eps
-
 
 def check():
     test_factorial_1()

--- a/src/runtime/math.py
+++ b/src/runtime/math.py
@@ -1,4 +1,4 @@
-from ltypes import i32, f64, ccall
+from ltypes import i8, i16, i32, f32, f64, ccall
 
 
 pi: f64 = 3.141592653589793238462643383279502884197
@@ -21,7 +21,6 @@ def factorial(x: i32) -> i32:
     for i in range(1, x+1):
         result *= i
     return result
-
 
 @overload
 def floor(x: i32) -> i32:
@@ -118,20 +117,95 @@ def isqrt(n: i32) -> i32:
             high = mid
     return low
 
+# degrees
+# supported data types: i8, i16, i32, i64, f32, f64
 
+@overload
+def degrees(x: i8) -> f64:
+    """
+    Convert angle `x` from radians to degrees.
+    """
+    return x * 180.0 / pi
+
+@overload
+def degrees(x: i16) -> f64:
+    """
+    Convert angle `x` from radians to degrees.
+    """
+    return x * 180.0 / pi
+
+@overload
+def degrees(x: i32) -> f64:
+    """
+    Convert angle `x` from radians to degrees.
+    """
+    return x * 180.0 / pi
+
+@overload
+def degrees(x: i64) -> f64:
+    """
+    Convert angle `x` from radians to degrees.
+    """
+    return x * 180.0 / pi
+
+@overload
+def degrees(x: f32) -> f64:
+    """
+    Convert angle `x` from radians to degrees.
+    """
+    return x * 180.0 / pi
+
+@overload
 def degrees(x: f64) -> f64:
     """
     Convert angle `x` from radians to degrees.
     """
     return x * 180.0 / pi
 
+# radians
+# supported data types: i8, i16, i32, i64, f32, f64
 
-def radians(x: f64) -> f64:
+@overload
+def radians(x: i8) -> f64:
     """
     Convert angle `x` from degrees to radians.
     """
     return x * pi / 180.0
 
+@overload
+def radians(x: i16) -> f64:
+    """
+    Convert angle `x` from degrees to radians.
+    """
+    return x * pi / 180.0
+
+@overload
+def radians(x: i32) -> f64:
+    """
+    Convert angle `x` from degrees to radians.
+    """
+    return x * pi / 180.0
+
+@overload
+def radians(x: i64) -> f64:
+    """
+    Convert angle `x` from degrees to radians.
+    """
+    return x * pi / 180.0
+
+@overload
+def radians(x: f32) -> f64:
+    """
+    Convert angle `x` from degrees to radians.
+    """
+    return x * pi / 180.0
+
+@overload
+def radians(x: f64) -> f64:
+    """
+    Convert angle `x` from degrees to radians.
+    """
+    return x * pi / 180.0
 
 def fabs(x: f64) -> f64:
     """


### PR DESCRIPTION
This PR includes changes to overload `degrees` and `radians` functions to support `i8, i16, i32, i64, f32, f64` ltypes. Relevant test code is added to `test_math.py`.