### PR TITLE
Fix args and return type in CPP codegen

### DIFF
--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -584,13 +584,30 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
         last_expr_precedence = 2;
     }
 
+    void visit_ComplexConstructor(const ASR::ComplexConstructor_t &x) {
+        this->visit_expr(*x.m_re);
+        std::string re = src;
+        this->visit_expr(*x.m_im);
+        std::string im = src;
+        src = "std::complex<float>(" + re + ", " + im + ")";
+        if (ASRUtils::extract_kind_from_ttype_t(x.m_type) == 8) {
+            src = "std::complex<double>(" + re + ", " + im + ")";
+        }
+        last_expr_precedence = 2;
+    }
+
     void visit_StringConstant(const ASR::StringConstant_t &x) {
         src = "\"" + std::string(x.m_s) + "\"";
         last_expr_precedence = 2;
     }
 
     void visit_ComplexConstant(const ASR::ComplexConstant_t &x) {
-        src = "std::complex<double>(" + std::to_string(x.m_re) + ", " + std::to_string(x.m_im) + ")";
+        std::string re = std::to_string(x.m_re);
+        std::string im = std::to_string(x.m_im);
+        src = "std::complex<float>(" + re + ", " + im + ")";
+        if (ASRUtils::extract_kind_from_ttype_t(x.m_type) == 8) {
+            src = "std::complex<double>(" + re + ", " + im + ")";
+        }
         last_expr_precedence = 2;
     }
 

--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -139,7 +139,9 @@ public:
             } else if (ASRUtils::is_complex(*v.m_type)) {
                 ASR::Complex_t *t = ASR::down_cast<ASR::Complex_t>(v.m_type);
                 std::string dims = convert_dims(t->n_dims, t->m_dims);
-                sub = format_type(dims, "std::complex<float>", v.m_name, use_ref, dummy);
+                std::string type_name = "std::complex<float>";
+                if (t->m_kind == 8) type_name = "std::complex<double>";
+                sub = format_type(dims, type_name, v.m_name, use_ref, dummy);
             } else if (ASRUtils::is_logical(*v.m_type)) {
                 ASR::Logical_t *t = ASR::down_cast<ASR::Logical_t>(v.m_type);
                 std::string dims = convert_dims(t->n_dims, t->m_dims);
@@ -413,13 +415,23 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
                 sub = "long long ";
             }
         } else if (ASRUtils::is_real(*return_var->m_type)) {
-            sub = "float ";
+            bool is_float = ASR::down_cast<ASR::Real_t>(return_var->m_type)->m_kind == 4;
+            if (is_float) {
+                sub = "float ";
+            } else {
+                sub = "double ";
+            }
         } else if (ASRUtils::is_logical(*return_var->m_type)) {
             sub = "bool ";
         } else if (ASRUtils::is_character(*return_var->m_type)) {
             sub = "std::string ";
         } else if (ASRUtils::is_complex(*return_var->m_type)) {
-            sub = "std::complex<float> ";
+            bool is_float = ASR::down_cast<ASR::Complex_t>(return_var->m_type)->m_kind == 4;
+            if (is_float) {
+                sub = "std::complex<float> ";
+            } else {
+                sub = "std::complex<double> ";
+            }
         } else {
             throw CodeGenError("Return type not supported");
         }

--- a/tests/expr15.py
+++ b/tests/expr15.py
@@ -1,0 +1,23 @@
+def test1() -> f64:
+    x: f64
+    x = 1.0
+    return x
+
+
+def test2() -> c64:
+    x: c64
+    x = complex(2, 2)
+    return x
+
+
+def test3() -> i32:
+    x: c64
+    x = 4j
+    y: c32
+    y = 4j
+    return 0
+
+
+print(test1())
+print(test2())
+print(test3())

--- a/tests/reference/cpp-expr15-1661c0d.json
+++ b/tests/reference/cpp-expr15-1661c0d.json
@@ -1,0 +1,13 @@
+{
+    "basename": "cpp-expr15-1661c0d",
+    "cmd": "lpython --no-color --show-cpp {infile}",
+    "infile": "tests/expr15.py",
+    "infile_hash": "0a9f0093849adc31926191348bc2dd8a6b1b5d63645b673b75632650",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "cpp-expr15-1661c0d.stdout",
+    "stdout_hash": "c5c1432ba6bba06295a9872b29999f019e7b1070bf64c34b8e0fcb9e",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/cpp-expr15-1661c0d.stdout
+++ b/tests/reference/cpp-expr15-1661c0d.stdout
@@ -1,0 +1,80 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <cassert>
+#include <cmath>
+#include <complex>
+#include <Kokkos_Core.hpp>
+#include <lfortran_intrinsics.h>
+
+template <typename T>
+Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
+{
+    Kokkos::View<T*> r("r", v.size());
+    for (size_t i=0; i < v.size(); i++) {
+        r(i) = v[i];
+    }
+    return r;
+}
+
+void _lpython_main_program()
+{
+    std::cout << test1() << std::endl;
+    std::cout << test2() << std::endl;
+    std::cout << test3() << std::endl;
+}
+
+double test1()
+{
+    double _lpython_return_variable;
+    double x;
+    x = 1.000000;
+    _lpython_return_variable = x;
+    return _lpython_return_variable;
+}
+
+std::complex<double> test2()
+{
+    std::complex<double> _lpython_return_variable;
+    std::complex<double> x;
+    x = __lpython_overloaded_9__complex(2, 2);
+    _lpython_return_variable = x;
+    return _lpython_return_variable;
+}
+
+int test3()
+{
+    int _lpython_return_variable;
+    std::complex<double> x;
+    std::complex<float> y;
+    x = std::complex<double>(0.000000, 4.000000);
+    y = std::complex<double>(0.000000, 4.000000);
+    _lpython_return_variable = 0;
+    return _lpython_return_variable;
+}
+
+std::complex<double> __lpython_overloaded_9__complex(int x, int y)
+{
+    std::complex<double> _lpython_return_variable;
+    _lpython_return_variable = std::complex<double>(x) + std::complex<double>(y)*std::complex<double>(0.000000, 1.000000);
+    return _lpython_return_variable;
+}
+
+float _lfortran_caimag(std::complex<float> x);
+
+double _lfortran_zaimag(std::complex<double> x);
+
+namespace {
+
+void main2() {
+        _lpython_main_program();
+}
+
+}
+int main(int argc, char* argv[])
+{
+    Kokkos::initialize(argc, argv);
+    main2();
+    Kokkos::finalize();
+    return 0;
+}

--- a/tests/reference/cpp-expr7-529bd53.json
+++ b/tests/reference/cpp-expr7-529bd53.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr7-529bd53.stdout",
-    "stdout_hash": "c4443a728ef176d6a1ac0690df2f450becccf43e161ffbf7c7ce2f4d",
+    "stdout_hash": "ffa3635df3217693ebcee996bd25a1dba620b52d741a3f0d0cdb2f6f",
     "stderr": "cpp-expr7-529bd53.stderr",
     "stderr_hash": "28509dd59a386eebd632340a550d14299cd2a921ef6dc3ac7dbe7fe9",
     "returncode": 0

--- a/tests/reference/cpp-expr7-529bd53.stdout
+++ b/tests/reference/cpp-expr7-529bd53.stdout
@@ -53,7 +53,7 @@ int __lpython_overloaded_0__pow(int x, int y)
 
 float _lfortran_caimag(std::complex<float> x);
 
-float _lfortran_zaimag(std::complex<float> x);
+double _lfortran_zaimag(std::complex<double> x);
 
 namespace {
 

--- a/tests/reference/cpp-expr8-704cece.json
+++ b/tests/reference/cpp-expr8-704cece.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr8-704cece.stdout",
-    "stdout_hash": "965a3a497afbc42b3e6813fe1bac9bb9bf8c666d3e0458c480e1a89f",
+    "stdout_hash": "edb5949762120648068bb4c134c869f40a7cc92d124f22f7ef74592e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr8-704cece.stdout
+++ b/tests/reference/cpp-expr8-704cece.stdout
@@ -56,7 +56,7 @@ int __lpython_overloaded_2___lpython_floordiv(int a, int b)
 
 float _lfortran_caimag(std::complex<float> x);
 
-float _lfortran_zaimag(std::complex<float> x);
+double _lfortran_zaimag(std::complex<double> x);
 
 namespace {
 

--- a/tests/reference/cpp-test_builtin_pow-56b3f92.json
+++ b/tests/reference/cpp-test_builtin_pow-56b3f92.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-test_builtin_pow-56b3f92.stdout",
-    "stdout_hash": "ec051e1246f67bca316339512635d88947172e2c9b1f2d18c460fbdd",
+    "stdout_hash": "cecc9373ec8ed7078ec19f4aea0ec169b2c35df6a34baa73627e3d7c",
     "stderr": "cpp-test_builtin_pow-56b3f92.stderr",
     "stderr_hash": "180e1adfbb0d9c63a2fffa31951bbd629b3f1950cf0d97ca1389efe5",
     "returncode": 0

--- a/tests/reference/cpp-test_builtin_pow-56b3f92.stdout
+++ b/tests/reference/cpp-test_builtin_pow-56b3f92.stdout
@@ -89,7 +89,7 @@ void test_pow()
     c1 = __lpython_overloaded_9__pow(c1, 4);
 }
 
-float __lpython_overloaded_0__abs(double x)
+double __lpython_overloaded_0__abs(double x)
 {
     double _lpython_return_variable;
     if (x >= 0.000000) {
@@ -123,7 +123,7 @@ float __lpython_overloaded_2__pow(float x, float y)
     return _lpython_return_variable;
 }
 
-float __lpython_overloaded_3__pow(double x, double y)
+double __lpython_overloaded_3__pow(double x, double y)
 {
     double _lpython_return_variable;
     _lpython_return_variable = std::pow(x, y);
@@ -144,14 +144,14 @@ float __lpython_overloaded_5__pow(float x, int y)
     return _lpython_return_variable;
 }
 
-float __lpython_overloaded_6__pow(int x, double y)
+double __lpython_overloaded_6__pow(int x, double y)
 {
     double _lpython_return_variable;
     _lpython_return_variable = std::pow((float)(x), y);
     return _lpython_return_variable;
 }
 
-float __lpython_overloaded_7__pow(double x, int y)
+double __lpython_overloaded_7__pow(double x, int y)
 {
     double _lpython_return_variable;
     _lpython_return_variable = std::pow(x, (float)(y));
@@ -169,9 +169,9 @@ int __lpython_overloaded_8__pow(bool x, bool y)
     return _lpython_return_variable;
 }
 
-std::complex<float> __lpython_overloaded_9__complex(int x, int y)
+std::complex<double> __lpython_overloaded_9__complex(int x, int y)
 {
-    std::complex<float> _lpython_return_variable;
+    std::complex<double> _lpython_return_variable;
     _lpython_return_variable = std::complex<double>(x) + std::complex<double>(y)*std::complex<double>(0.000000, 1.000000);
     return _lpython_return_variable;
 }
@@ -185,7 +185,7 @@ std::complex<float> __lpython_overloaded_9__pow(std::complex<float> c, int y)
 
 float _lfortran_caimag(std::complex<float> x);
 
-float _lfortran_zaimag(std::complex<float> x);
+double _lfortran_zaimag(std::complex<double> x);
 
 namespace {
 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -125,6 +125,10 @@ filename = "expr14.py"
 llvm = true
 
 [[test]]
+filename = "expr15.py"
+cpp = true
+
+[[test]]
 filename = "expr_01.py"
 ast = true
 asr = true


### PR DESCRIPTION
Also covers: https://gitlab.com/lfortran/lfortran/-/merge_requests/1728