### PR TITLE
Parser: parse a tuple

### DIFF
--- a/src/lpython/parser/parser.yy
+++ b/src/lpython/parser/parser.yy
@@ -693,6 +693,7 @@ expr
     | TK_FALSE { $$ = BOOL(false, @$); }
     | "(" expr ")" { $$ = $2; }
     | function_call { $$ = $1; }
+    | "(" with_item_list "," expr ")" { $$ = LIST($2, @$); }
     | "[" expr_list_opt "]" { $$ = LIST($2, @$); }
     | "[" expr_list "," "]" { $$ = LIST($2, @$); }
     | "{" expr_list "}" { $$ = SET($2, @$); }


### PR DESCRIPTION
The grammar is without conflicts, one has to go in and extract the
expression list from the tuple.