### PR TITLE
Fixing `integration_tests/test_numpy_01_1.py` for C backend

### DIFF
--- a/integration_tests/test_numpy_01_1.py
+++ b/integration_tests/test_numpy_01_1.py
@@ -1,0 +1,41 @@
+# This test handles various aspects of local arrays using the `numpy.empty()`
+# function
+from ltypes import f64
+from numpy import empty
+
+def test_local_arrays():
+    a: f64[16]
+    a = empty(16)
+    i: i32
+    for i in range(16):
+        a[i] = i+0.5
+    eps: f64
+    eps = 1e-12
+    print( a[0], (a[0] - 0.5) < eps and (a[0] - 0.5) > -eps )
+    print( a[1], (a[1] - 1.5) < eps and (a[1] - 1.5) > -eps )
+    print( a[10], (a[10] - 10.5) < eps and (a[10] - 10.5) > -eps )
+    print( a[15], (a[15] - 15.5) < eps and (a[15] - 15.5) > -eps )
+
+def f() -> f64[4]:
+    a: f64[4]
+    a = empty(4)
+    i: i32
+    for i in range(4):
+        a[i] = 1.0 * i
+    return a
+
+def test_return_arrays():
+    a: f64[4]
+    a = f()
+    eps: f64
+    eps = 1e-12
+    print( a[0], (a[0] - 0) < eps and (a[0] - 0) > -eps )
+    print( a[1], (a[1] - 1) < eps and (a[1] - 1) > -eps )
+    print( a[2], (a[2] - 2) < eps and (a[2] - 2) > -eps )
+    print( a[3], (a[3] - 3) < eps and (a[3] - 3) > -eps )
+
+def check():
+    test_local_arrays()
+    test_return_arrays()
+
+check()


### PR DESCRIPTION
`integration_tests/test_numpy_01_1.py` is a modified version of `integration_tests/test_numpy_01.py` with `assert` and `abs` removed.

Features to be implemented next,

1. Support for `empty`.
2. Making `assert.h` and `lfortran_intrinsics.h` findable via `clang`.

**Output Code**

```c
#include <assert.h> // Compiles when this line is commented
#include <complex.h>
#include <inttypes.h>
#include <stdio.h>
#include <math.h> // Compiles when this line is commented

#include <lfortran_intrinsics.h>

void _lpython_main_program();

void check();

double* f();

void test_local_arrays();

void test_return_arrays();

void _lpython_main_program()
{
    check();
}

void check()
{
    test_local_arrays();
    test_return_arrays();
}

double* f()
{
    double *_lpython_return_variable;
    double *a; // `malloc` to be added.
    int32_t i;
    for (i=0; i<=4 - 1; i++) {
        a[i + 1-1] = 1.000000*(float)(i);
    }
    _lpython_return_variable = a;
    return _lpython_return_variable;
}

void test_local_arrays()
{
    double *a; // `malloc` to be added.
    double eps;
    int32_t i;
    for (i=0; i<=16 - 1; i++) {
        a[i + 1-1] = (float)(i) + 0.500000;
    }
    eps = 0.000000;
    printf("%lf %d\n", a[0 + 1-1], a[0 + 1-1] - 0.500000 < eps && a[0 + 1-1] - 0.500000 > -eps);
    printf("%lf %d\n", a[1 + 1-1], a[1 + 1-1] - 1.500000 < eps && a[1 + 1-1] - 1.500000 > -eps);
    printf("%lf %d\n", a[10 + 1-1], a[10 + 1-1] - 10.500000 < eps && a[10 + 1-1] - 10.500000 > -eps);
    printf("%lf %d\n", a[15 + 1-1], a[15 + 1-1] - 15.500000 < eps && a[15 + 1-1] - 15.500000 > -eps);
}

void test_return_arrays()
{
    double *a;
    double eps;
    a = f();
    eps = 0.000000;
    printf("%lf %d\n", a[0 + 1-1], a[0 + 1-1] - (float)(0) < eps && a[0 + 1-1] - (float)(0) > -eps);
    printf("%lf %d\n", a[1 + 1-1], a[1 + 1-1] - (float)(1) < eps && a[1 + 1-1] - (float)(1) > -eps);
    printf("%lf %d\n", a[2 + 1-1], a[2 + 1-1] - (float)(2) < eps && a[2 + 1-1] - (float)(2) > -eps);
    printf("%lf %d\n", a[3 + 1-1], a[3 + 1-1] - (float)(3) < eps && a[3 + 1-1] - (float)(3) > -eps);
}

int main(int argc, char* argv[])
{
    _lpython_main_program();
    return 0;
}
```