### PR TITLE
Test basic C interop with custom C code

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -144,6 +144,8 @@ RUN(NAME test_builtin_round  LABELS cpython llvm)
 RUN(NAME test_math1          LABELS cpython llvm)
 RUN(NAME test_math_02        LABELS cpython llvm)
 RUN(NAME test_c_interop_01   LABELS cpython llvm c)
+RUN(NAME test_c_interop_02   LABELS llvm c
+        EXTRAFILES test_c_interop_02b.c)
 RUN(NAME test_generics_01    LABELS cpython llvm)
 RUN(NAME test_cmath          LABELS cpython llvm)
 RUN(NAME test_complex        LABELS cpython llvm)

--- a/integration_tests/test_c_interop_02.py
+++ b/integration_tests/test_c_interop_02.py
@@ -1,0 +1,36 @@
+from ltypes import ccall, f32, f64, i32, i64
+
+@ccall
+def f_f64_f64(x: f64) -> f64:
+    pass
+
+@ccall
+def f_f32_f32(x: f32) -> f32:
+    pass
+
+@ccall
+def f_i64_i64(x: i64) -> i64:
+    pass
+
+@ccall
+def f_i32_i32(x: i32) -> i32:
+    pass
+
+def test_c_callbacks():
+    xf64: f64
+    xf64 = 3.3
+    assert abs(f_f64_f64(xf64) - (xf64+1)) < 1e-12
+
+    xf32: f32
+    xf32 = 3.3
+    assert abs(f_f32_f32(xf32) - (xf32+1)) < 1e-12
+
+    xi64: i64
+    xi64 = 3
+    assert f_i64_i64(xi64) == 4
+
+    xi32: i32
+    xi32 = 3
+    assert f_i32_i32(xi32) == 4
+
+test_c_callbacks()

--- a/integration_tests/test_c_interop_02b.c
+++ b/integration_tests/test_c_interop_02b.c
@@ -1,0 +1,17 @@
+#include "test_c_interop_02b.h"
+
+double f_f64_f64(double x) {
+    return x+1;
+}
+
+float f_f32_f32(float x) {
+    return x+1;
+}
+
+int64_t f_i64_i64(int64_t x) {
+    return x+1;
+}
+
+int32_t f_i32_i32(int32_t x) {
+    return x+1;
+}

--- a/integration_tests/test_c_interop_02b.h
+++ b/integration_tests/test_c_interop_02b.h
@@ -1,0 +1,13 @@
+#ifndef TEST_C_INTEROP_02B
+#define TEST_C_INTEROP_02B
+
+#include <stdint.h>
+
+
+double  f_f64_f64(double  x);
+float   f_f32_f32(float   x);
+int64_t f_i64_i64(int64_t x);
+int32_t f_i32_i32(int32_t x);
+
+
+#endif // TEST_C_INTEROP_02B


### PR DESCRIPTION
For now just the basic i64/i32/f64/f32 types by value, both LLVM and C
backends.