### PR TITLE
Get CPython C interop working with custom C code

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -90,9 +90,17 @@ macro(RUN)
             endif()
         elseif(KIND STREQUAL "cpython")
             # CPython test
+            if (RUN_EXTRAFILES)
+                set(PY_MOD "${name}_mod")
+                add_library(${PY_MOD} SHARED ${RUN_EXTRAFILES})
+                set_target_properties(${PY_MOD} PROPERTIES LINKER_LANGUAGE C)
+            else()
+                set(PY_MOD "")
+            endif()
+
             add_test(${name} python ${CMAKE_CURRENT_BINARY_DIR}/${name}.py)
             set_tests_properties(${name} PROPERTIES
-                ENVIRONMENT PYTHONPATH=${CMAKE_SOURCE_DIR}/../src/runtime/ltypes)
+                ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/../src/runtime/ltypes;LPYTHON_PY_MOD=${PY_MOD}")
             if (RUN_LABELS)
                 set_tests_properties(${name} PROPERTIES LABELS "${RUN_LABELS}")
             endif()
@@ -144,7 +152,7 @@ RUN(NAME test_builtin_round  LABELS cpython llvm)
 RUN(NAME test_math1          LABELS cpython llvm)
 RUN(NAME test_math_02        LABELS cpython llvm)
 RUN(NAME test_c_interop_01   LABELS cpython llvm c)
-RUN(NAME test_c_interop_02   LABELS llvm c
+RUN(NAME test_c_interop_02   LABELS cpython llvm c
         EXTRAFILES test_c_interop_02b.c)
 RUN(NAME test_generics_01    LABELS cpython llvm)
 RUN(NAME test_cmath          LABELS cpython llvm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -100,7 +100,7 @@ macro(RUN)
 
             add_test(${name} python ${CMAKE_CURRENT_BINARY_DIR}/${name}.py)
             set_tests_properties(${name} PROPERTIES
-                ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/../src/runtime/ltypes;LPYTHON_PY_MOD=${PY_MOD}")
+                ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/../src/runtime/ltypes;LPYTHON_PY_MOD_NAME=${PY_MOD};LPYTHON_PY_MOD_PATH=${CMAKE_CURRENT_BINARY_DIR}")
             if (RUN_LABELS)
                 set_tests_properties(${name} PROPERTIES LABELS "${RUN_LABELS}")
             endif()

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -8,6 +8,7 @@ jn=$1
 export PATH="$(pwd)/../src/bin:$PATH"
 
 cmake -DKIND=cpython .
+make $jn
 ctest $jn --output-on-failure
 
 cmake -DKIND=llvm .

--- a/integration_tests/test_c_interop_02.py
+++ b/integration_tests/test_c_interop_02.py
@@ -23,7 +23,7 @@ def test_c_callbacks():
 
     xf32: f32
     xf32 = 3.3
-    assert abs(f_f32_f32(xf32) - (xf32+1)) < 1e-12
+    assert abs(f_f32_f32(xf32) - (xf32+1)) < 1e-6
 
     xi64: i64
     xi64 = 3

--- a/src/runtime/ltypes/ltypes.py
+++ b/src/runtime/ltypes/ltypes.py
@@ -140,12 +140,13 @@ class CTypes:
             else:
                 raise NotImplementedError("Platform not implemented")
         def get_crtlib_path():
-            py_mod = os.environ["LPYTHON_PY_MOD"]
+            py_mod = os.environ["LPYTHON_PY_MOD_NAME"]
             if py_mod == "":
                 return os.path.join(get_rtlib_dir(),
                     get_lib_name("lpython_runtime"))
             else:
-                return get_lib_name(py_mod)
+                py_mod_path = os.environ["LPYTHON_PY_MOD_PATH"]
+                return os.path.join(py_mod_path, get_lib_name(py_mod))
         self.name = f.__name__
         self.args = f.__code__.co_varnames
         self.annotations = f.__annotations__

--- a/src/runtime/ltypes/ltypes.py
+++ b/src/runtime/ltypes/ltypes.py
@@ -130,17 +130,22 @@ class CTypes:
         def get_rtlib_dir():
             current_dir = os.path.dirname(os.path.abspath(__file__))
             return os.path.join(current_dir, "..")
-        def get_crtlib_name():
+        def get_lib_name(name):
             if platform.system() == "Linux":
-                return "liblpython_runtime.so"
+                return "lib" + name + ".so"
             elif platform.system() == "Darwin":
-                return "liblpython_runtime.dylib"
+                return "lib" + name + ".dylib"
             elif platform.system() == "Windows":
-                return "lpython_runtime.dll"
+                return name + ".dll"
             else:
                 raise NotImplementedError("Platform not implemented")
         def get_crtlib_path():
-            return os.path.join(get_rtlib_dir(), get_crtlib_name())
+            py_mod = os.environ["LPYTHON_PY_MOD"]
+            if py_mod == "":
+                return os.path.join(get_rtlib_dir(),
+                    get_lib_name("lpython_runtime"))
+            else:
+                return get_lib_name(py_mod)
         self.name = f.__name__
         self.args = f.__code__.co_varnames
         self.annotations = f.__annotations__


### PR DESCRIPTION
We build it as a shared library and pass in the name using the
LPYTHON_PY_MOD environment variable. If it is empty, we will use the
LPython runtime library.

It discovered a bug in our test, we have to test single precision only
up to eps 1e-6, not 1e-12. We fixed the test.

Depends on #583.