### PR TITLE
CI: clean the integration_tests directory

### DIFF
--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+git clean -dfx
+
 # Append "-j4" or "-j" to run in parallel
 jn=$1
 


### PR DESCRIPTION
This is just a temporary solution to make it easier to use the test
suite. The ideal solution would be to not use git, but rather build in a
build directory and erase it before running.