### PR TITLE
Uniform semantic errors in string slicing .

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1636,6 +1636,9 @@ public:
             AST::Slice_t *sl = AST::down_cast<AST::Slice_t>(x.m_slice);
             if (sl->m_lower != nullptr) {
                 this->visit_expr(*sl->m_lower);
+                if (!ASRUtils::is_integer(*ASRUtils::expr_type(ASRUtils::EXPR(tmp)))) {
+                    throw SemanticError("slice indices must be integers or None", tmp->loc);
+                }
                 ai.m_left = index_add_one(x.base.base.loc, ASRUtils::EXPR(tmp));
             }
             if (sl->m_upper != nullptr) {
@@ -1647,6 +1650,9 @@ public:
             }
             if (sl->m_step != nullptr) {
                 this->visit_expr(*sl->m_step);
+                if (!ASRUtils::is_integer(*ASRUtils::expr_type(ASRUtils::EXPR(tmp)))) {
+                    throw SemanticError("slice indices must be integers or None", tmp->loc);
+                }
                 ai.m_step = index_add_one(x.base.base.loc, ASRUtils::EXPR(tmp));
             }
             if (ASR::is_a<ASR::List_t>(*type)) {

--- a/tests/errors/test_str_slicing2.py
+++ b/tests/errors/test_str_slicing2.py
@@ -1,0 +1,6 @@
+def f():
+    s: str
+    s = "abcd"
+    print(s[1.5:3])
+
+f()

--- a/tests/errors/test_str_slicing3.py
+++ b/tests/errors/test_str_slicing3.py
@@ -1,0 +1,6 @@
+def f():
+    s: str
+    s = "abcd"
+    print(s[1:3:0.5])
+
+f()

--- a/tests/reference/asr-test_str_slicing2-2f07e9a.json
+++ b/tests/reference/asr-test_str_slicing2-2f07e9a.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_str_slicing2-2f07e9a",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_str_slicing2.py",
+    "infile_hash": "eb9027d2b6ec0aba9cc78aeedc1b0b36972ff36b076fecf547eeb014",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_str_slicing2-2f07e9a.stderr",
+    "stderr_hash": "48a9286126c2333bdf5237358bd4ad27acac4a16a78069c9bd36d089",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_str_slicing2-2f07e9a.stderr
+++ b/tests/reference/asr-test_str_slicing2-2f07e9a.stderr
@@ -1,0 +1,5 @@
+semantic error: slice indices must be integers or None
+ --> tests/errors/test_str_slicing2.py:4:13
+  |
+4 |     print(s[1.5:3])
+  |             ^^^ 

--- a/tests/reference/asr-test_str_slicing3-fe6a03c.json
+++ b/tests/reference/asr-test_str_slicing3-fe6a03c.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_str_slicing3-fe6a03c",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_str_slicing3.py",
+    "infile_hash": "b223abc3ec96fe91876fa188259f151d61383687776e8975df45b139",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_str_slicing3-fe6a03c.stderr",
+    "stderr_hash": "5f7553d1509bed25d5137abc4fc2cb1d2cb983a1fab81d8d178ed197",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_str_slicing3-fe6a03c.stderr
+++ b/tests/reference/asr-test_str_slicing3-fe6a03c.stderr
@@ -1,0 +1,5 @@
+semantic error: slice indices must be integers or None
+ --> tests/errors/test_str_slicing3.py:4:17
+  |
+4 |     print(s[1:3:0.5])
+  |                 ^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -374,6 +374,14 @@ filename = "errors/test_str_slicing.py"
 asr = true
 
 [[test]]
+filename = "errors/test_str_slicing2.py"
+asr = true
+
+[[test]]
+filename = "errors/test_str_slicing3.py"
+asr = true
+
+[[test]]
 filename = "errors/test_annassign_type_mismatch.py"
 asr = true
 


### PR DESCRIPTION
Semantic error thrown only for upper index on master , error messages for lower index and step value added.  
```
s="abcdefg"
print(s[1.5:7])
semantic error: slice indices must be integers or None
 --> try.py:4:13
  |
4 |     print(s[1.5:7])
  |             ^^^ 

print(s[1:7:0.5])
semantic error: slice indices must be integers or None
 --> try.py:4:17
  |
4 |     print(s[1:7:0.5])
  |                 ^^^ 

```
Test and reference files ( for invalid upper index ) had been added in #347 , so I'll add them if they are essentially required. 

