### PR TITLE
Implement the intrinsic platform() module

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -176,6 +176,7 @@ RUN(NAME structs_01          LABELS cpython llvm c)
 RUN(NAME structs_02          LABELS llvm c)
 RUN(NAME structs_03          LABELS llvm c)
 RUN(NAME test_str_to_int     LABELS cpython llvm)
+RUN(NAME test_platform       LABELS cpython llvm)
 
 # Just CPython
 RUN(NAME test_builtin_bin    LABELS cpython)

--- a/integration_tests/test_platform.py
+++ b/integration_tests/test_platform.py
@@ -1,0 +1,9 @@
+from platform import python_implementation
+
+def test_platform1():
+    s: str
+    s = python_implementation()
+    print("Python Implementation:", s)
+    assert s == "CPython" or s == "LPython"
+
+test_platform1()

--- a/src/runtime/platform.py
+++ b/src/runtime/platform.py
@@ -1,0 +1,2 @@
+def python_implementation() -> str:
+    return "LPython"


### PR DESCRIPTION
For now just python_implementation() is implemented.

Fixes #644.