### PR TITLE
Fix argument parser in pass manager

### DIFF
--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -201,7 +201,7 @@ namespace LCompilers {
             std::string current_pass = "";
             for( size_t i = 0; i < arg_pass.size(); i++ ) {
                 char ch = arg_pass[i];
-                if( ch != ' ' ) {
+                if( ch != ' ' && ch != ',' ) {
                     current_pass.push_back(ch);
                 }
                 if( ch == ',' || i == arg_pass.size() - 1 ) {


### PR DESCRIPTION
`,` was included in the previous string of pass input. Fixed that here.

Corresponding LFortran MR - https://gitlab.com/lfortran/lfortran/-/merge_requests/1814