### PR TITLE
ASR: Sync Libasr

### DIFF
--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -202,7 +202,7 @@ int emit_cpp(const std::string &infile,
 
     diagnostics.diagnostics.clear();
     auto res = LFortran::asr_to_cpp(al, *asr, diagnostics,
-        compiler_options.platform);
+        compiler_options.platform, 0);
     std::cerr << diagnostics.render(input, lm, compiler_options);
     if (!res.ok) {
         LFORTRAN_ASSERT(diagnostics.has_error())
@@ -243,7 +243,7 @@ int emit_c(const std::string &infile,
 
     diagnostics.diagnostics.clear();
     auto res = LFortran::asr_to_c(al, *asr, diagnostics,
-        compiler_options.platform);
+        compiler_options.platform, 0);
     std::cerr << diagnostics.render(input, lm, compiler_options);
     if (!res.ok) {
         LFORTRAN_ASSERT(diagnostics.has_error())

--- a/src/libasr/CMakeLists.txt
+++ b/src/libasr/CMakeLists.txt
@@ -23,7 +23,7 @@ set(SRC
     codegen/asr_to_wasm.cpp
     codegen/wasm_to_wat.cpp
     codegen/wasm_utils.cpp
-
+    
     pass/param_to_const.cpp
     pass/do_loops.cpp
     pass/for_all.cpp

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -242,6 +242,7 @@ ASR::asr_t* getDerivedRef_t(Allocator& al, const Location& loc,
     ASR::ttype_t* member_type = member_variable->m_type;
     switch( member_type->type ) {
         case ASR::ttypeType::Derived: {
+            // Sync: Probably failing at the following two lines
             ASR::Derived_t* der = ASR::down_cast<ASR::Derived_t>(member_type);
             ASR::DerivedType_t* der_type = ASR::down_cast<ASR::DerivedType_t>(der->m_derived_type);
             if( current_scope->resolve_symbol(std::string(der_type->m_name)) == nullptr ) {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -609,7 +609,7 @@ static inline std::string type_python_1dim_helper(const std::string & res,
     }
 
     if( ASRUtils::expr_value(e->m_end) ) {
-        int64_t end_dim;
+        int64_t end_dim = -1;
         ASRUtils::extract_value(ASRUtils::expr_value(e->m_end), end_dim);
         return res + "[" + std::to_string(end_dim + 1) + "]";
     }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -38,49 +38,6 @@ static inline ASR::ttype_t* TYPE(const ASR::asr_t *f)
     return ASR::down_cast<ASR::ttype_t>(f);
 }
 
-static inline char *symbol_name(const ASR::symbol_t *f)
-{
-    switch (f->type) {
-        case ASR::symbolType::Program: {
-            return ASR::down_cast<ASR::Program_t>(f)->m_name;
-        }
-        case ASR::symbolType::Module: {
-            return ASR::down_cast<ASR::Module_t>(f)->m_name;
-        }
-        case ASR::symbolType::Subroutine: {
-            return ASR::down_cast<ASR::Subroutine_t>(f)->m_name;
-        }
-        case ASR::symbolType::Function: {
-            return ASR::down_cast<ASR::Function_t>(f)->m_name;
-        }
-        case ASR::symbolType::GenericProcedure: {
-            return ASR::down_cast<ASR::GenericProcedure_t>(f)->m_name;
-        }
-        case ASR::symbolType::DerivedType: {
-            return ASR::down_cast<ASR::DerivedType_t>(f)->m_name;
-        }
-        case ASR::symbolType::Variable: {
-            return ASR::down_cast<ASR::Variable_t>(f)->m_name;
-        }
-        case ASR::symbolType::ExternalSymbol: {
-            return ASR::down_cast<ASR::ExternalSymbol_t>(f)->m_name;
-        }
-        case ASR::symbolType::ClassProcedure: {
-            return ASR::down_cast<ASR::ClassProcedure_t>(f)->m_name;
-        }
-        case ASR::symbolType::CustomOperator: {
-            return ASR::down_cast<ASR::CustomOperator_t>(f)->m_name;
-        }
-        case ASR::symbolType::AssociateBlock: {
-            return ASR::down_cast<ASR::AssociateBlock_t>(f)->m_name;
-        }
-        case ASR::symbolType::Block: {
-            return ASR::down_cast<ASR::Block_t>(f)->m_name;
-        }
-        default : throw LFortranException("Not implemented");
-    }
-}
-
 static inline ASR::symbol_t *symbol_get_past_external(ASR::symbol_t *f)
 {
     if (f->type == ASR::symbolType::ExternalSymbol) {
@@ -196,6 +153,16 @@ static inline std::string type_to_str(const ASR::ttype_t *t)
     }
 }
 
+static inline std::string binop_to_str(const ASR::binopType t) {
+    switch (t) {
+        case (ASR::binopType::Add): { return " + "; }
+        case (ASR::binopType::Sub): { return " - "; }
+        case (ASR::binopType::Mul): { return "*"; }
+        case (ASR::binopType::Div): { return "/"; }
+        default : throw LFortranException("Cannot represent the binary operator as a string");
+    }
+}
+
 static inline std::string cmpop_to_str(const ASR::cmpopType t) {
     switch (t) {
         case (ASR::cmpopType::Eq): { return " == "; }
@@ -221,6 +188,49 @@ static inline std::string logicalbinop_to_str_python(const ASR::logicalbinopType
 static inline ASR::expr_t* expr_value(ASR::expr_t *f)
 {
     return ASR::expr_value0(f);
+}
+
+static inline char *symbol_name(const ASR::symbol_t *f)
+{
+    switch (f->type) {
+        case ASR::symbolType::Program: {
+            return ASR::down_cast<ASR::Program_t>(f)->m_name;
+        }
+        case ASR::symbolType::Module: {
+            return ASR::down_cast<ASR::Module_t>(f)->m_name;
+        }
+        case ASR::symbolType::Subroutine: {
+            return ASR::down_cast<ASR::Subroutine_t>(f)->m_name;
+        }
+        case ASR::symbolType::Function: {
+            return ASR::down_cast<ASR::Function_t>(f)->m_name;
+        }
+        case ASR::symbolType::GenericProcedure: {
+            return ASR::down_cast<ASR::GenericProcedure_t>(f)->m_name;
+        }
+        case ASR::symbolType::DerivedType: {
+            return ASR::down_cast<ASR::DerivedType_t>(f)->m_name;
+        }
+        case ASR::symbolType::Variable: {
+            return ASR::down_cast<ASR::Variable_t>(f)->m_name;
+        }
+        case ASR::symbolType::ExternalSymbol: {
+            return ASR::down_cast<ASR::ExternalSymbol_t>(f)->m_name;
+        }
+        case ASR::symbolType::ClassProcedure: {
+            return ASR::down_cast<ASR::ClassProcedure_t>(f)->m_name;
+        }
+        case ASR::symbolType::CustomOperator: {
+            return ASR::down_cast<ASR::CustomOperator_t>(f)->m_name;
+        }
+        case ASR::symbolType::AssociateBlock: {
+            return ASR::down_cast<ASR::AssociateBlock_t>(f)->m_name;
+        }
+        case ASR::symbolType::Block: {
+            return ASR::down_cast<ASR::Block_t>(f)->m_name;
+        }
+        default : throw LFortranException("Not implemented");
+    }
 }
 
 static inline SymbolTable *symbol_parent_symtab(const ASR::symbol_t *f)
@@ -1020,6 +1030,21 @@ static inline ASR::ttype_t* duplicate_type(Allocator& al, const ASR::ttype_t* t,
         }
         default : throw LFortranException("Not implemented");
     }
+}
+
+inline bool is_same_type_pointer(ASR::ttype_t* source, ASR::ttype_t* dest) {
+    bool is_source_pointer = is_pointer(source), is_dest_pointer = is_pointer(dest);
+    if( (!is_source_pointer && !is_dest_pointer) ||
+        (is_source_pointer && is_dest_pointer) ) {
+        return false;
+    }
+    if( is_source_pointer && !is_dest_pointer ) {
+        ASR::ttype_t* temp = source;
+        source = dest;
+        dest = temp;
+    }
+    bool res = source->type == ASR::down_cast<ASR::Pointer_t>(dest)->m_type->type;
+    return res;
 }
 
             inline int extract_kind_str(char* m_n, char *&kind_str) {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1032,6 +1032,21 @@ static inline ASR::ttype_t* duplicate_type(Allocator& al, const ASR::ttype_t* t,
     }
 }
 
+inline bool is_same_type_pointer(ASR::ttype_t* source, ASR::ttype_t* dest) {
+    bool is_source_pointer = is_pointer(source), is_dest_pointer = is_pointer(dest);
+    if( (!is_source_pointer && !is_dest_pointer) ||
+        (is_source_pointer && is_dest_pointer) ) {
+        return false;
+    }
+    if( is_source_pointer && !is_dest_pointer ) {
+        ASR::ttype_t* temp = source;
+        source = dest;
+        dest = temp;
+    }
+    bool res = source->type == ASR::down_cast<ASR::Pointer_t>(dest)->m_type->type;
+    return res;
+}
+
 inline int extract_kind_str(char* m_n, char *&kind_str) {
     char *p = m_n;
     while (*p != '\0') {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1032,21 +1032,6 @@ static inline ASR::ttype_t* duplicate_type(Allocator& al, const ASR::ttype_t* t,
     }
 }
 
-inline bool is_same_type_pointer(ASR::ttype_t* source, ASR::ttype_t* dest) {
-    bool is_source_pointer = is_pointer(source), is_dest_pointer = is_pointer(dest);
-    if( (!is_source_pointer && !is_dest_pointer) ||
-        (is_source_pointer && is_dest_pointer) ) {
-        return false;
-    }
-    if( is_source_pointer && !is_dest_pointer ) {
-        ASR::ttype_t* temp = source;
-        source = dest;
-        dest = temp;
-    }
-    bool res = source->type == ASR::down_cast<ASR::Pointer_t>(dest)->m_type->type;
-    return res;
-}
-
             inline int extract_kind_str(char* m_n, char *&kind_str) {
                 char *p = m_n;
                 while (*p != '\0') {

--- a/src/libasr/codegen/asr_to_c.cpp
+++ b/src/libasr/codegen/asr_to_c.cpp
@@ -150,7 +150,7 @@ public:
                 ASR::Logical_t *t = ASR::down_cast<ASR::Logical_t>(v.m_type);
                 dims = convert_dims_c(t->n_dims, t->m_dims);
                 sub = format_type_c(dims, "bool", v.m_name, use_ref, dummy);
-            }else if (ASRUtils::is_character(*v.m_type)) {
+            } else if (ASRUtils::is_character(*v.m_type)) {
                 ASR::Character_t *t = ASR::down_cast<ASR::Character_t>(v.m_type);
                 std::string dims = convert_dims_c(t->n_dims, t->m_dims);
                 sub = format_type_c(dims, "char *", v.m_name, use_ref, dummy);

--- a/src/libasr/codegen/asr_to_c.cpp
+++ b/src/libasr/codegen/asr_to_c.cpp
@@ -131,16 +131,7 @@ public:
                 headers.insert("inttypes");
                 ASR::Integer_t *t = ASR::down_cast<ASR::Integer_t>(v.m_type);
                 dims = convert_dims_c(t->n_dims, t->m_dims);
-                std::string type_name;
-                if (t->m_kind == 1) {
-                    type_name = "int8_t";
-                } else if (t->m_kind == 2) {
-                    type_name = "int16_t";
-                } else if (t->m_kind == 4) {
-                    type_name = "int32_t";
-                } else if (t->m_kind == 8) {
-                    type_name = "int64_t";
-                }
+                std::string type_name = "int" + std::to_string(t->m_kind * 8) + "_t";
                 sub = format_type_c(dims, type_name, v.m_name, use_ref, dummy);
             } else if (ASRUtils::is_real(*v.m_type)) {
                 ASR::Real_t *t = ASR::down_cast<ASR::Real_t>(v.m_type);

--- a/src/libasr/codegen/asr_to_c.h
+++ b/src/libasr/codegen/asr_to_c.h
@@ -7,7 +7,8 @@
 namespace LFortran {
 
     Result<std::string> asr_to_c(Allocator &al, ASR::TranslationUnit_t &asr,
-        diag::Diagnostics &diagnostics, Platform &platform);
+        diag::Diagnostics &diagnostics, Platform &platform,
+        int64_t default_lower_bound);
 
 } // namespace LFortran
 

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -89,12 +89,14 @@ public:
     std::set<std::string> headers;
 
     SymbolTable* global_scope;
+    int64_t lower_bound;
 
     BaseCCPPVisitor(diag::Diagnostics &diag, Platform &platform,
-            bool gen_stdstring, bool gen_stdcomplex, bool is_c) : diag{diag},
+            bool gen_stdstring, bool gen_stdcomplex, bool is_c,
+            int64_t default_lower_bound) : diag{diag},
             platform{platform},
         gen_stdstring{gen_stdstring}, gen_stdcomplex{gen_stdcomplex},
-        is_c{is_c}, global_scope{nullptr} {}
+        is_c{is_c}, global_scope{nullptr}, lower_bound{default_lower_bound} {}
 
     void visit_TranslationUnit(const ASR::TranslationUnit_t &x) {
         global_scope = x.m_global_scope;
@@ -598,10 +600,7 @@ R"(#include <stdio.h>
                 src = "/* FIXME right index */";
             }
             out += src;
-            if( m_dims[i].m_start ) {
-                this->visit_expr(*m_dims[i].m_start);
-                out += " - " + src;
-            }
+            out += " - " + std::to_string(lower_bound);
             if (i < x.n_args-1) out += "][";
         }
         out += "]";

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -242,7 +242,7 @@ R"(#include <stdio.h>
         for (size_t i=0; i<x.n_args; i++) {
             ASR::Variable_t *arg = LFortran::ASRUtils::EXPR2VAR(x.m_args[i]);
             LFORTRAN_ASSERT(ASRUtils::is_arg_dummy(arg->m_intent));
-            sub += self().convert_variable_decl(*arg);
+            sub += self().convert_variable_decl(*arg, false);
             if (i < x.n_args-1) sub += ", ";
         }
         sub += ")";
@@ -306,7 +306,7 @@ R"(#include <stdio.h>
         for (size_t i=0; i<x.n_args; i++) {
             ASR::Variable_t *arg = LFortran::ASRUtils::EXPR2VAR(x.m_args[i]);
             LFORTRAN_ASSERT(LFortran::ASRUtils::is_arg_dummy(arg->m_intent));
-            sub += self().convert_variable_decl(*arg);
+            sub += self().convert_variable_decl(*arg, false);
             if (i < x.n_args-1) sub += ", ";
         }
         sub += ")";

--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -13,33 +13,6 @@
 
 namespace LFortran {
 
-std::string convert_dims(size_t n_dims, ASR::dimension_t *m_dims)
-{
-    std::string dims;
-    for (size_t i=0; i<n_dims; i++) {
-        ASR::expr_t *start = m_dims[i].m_start;
-        ASR::expr_t *end = m_dims[i].m_end;
-        if (!start && !end) {
-            dims += "*";
-        } else if (start && end) {
-            if (ASR::is_a<ASR::IntegerConstant_t>(*start) && ASR::is_a<ASR::IntegerConstant_t>(*end)) {
-                ASR::IntegerConstant_t *s = ASR::down_cast<ASR::IntegerConstant_t>(start);
-                ASR::IntegerConstant_t *e = ASR::down_cast<ASR::IntegerConstant_t>(end);
-                if (s->m_n == 1) {
-                    dims += "[" + std::to_string(e->m_n) + "]";
-                } else {
-                    throw CodeGenError("Lower dimension must be 1 for now");
-                }
-            } else {
-                dims += "[ /* FIXME symbolic dimensions */ ]";
-            }
-        } else {
-            throw CodeGenError("Dimension type not supported");
-        }
-    }
-    return dims;
-}
-
 std::string format_type(const std::string &dims, const std::string &type,
         const std::string &name, bool use_ref, bool dummy)
 {
@@ -64,8 +37,36 @@ std::string format_type(const std::string &dims, const std::string &type,
 class ASRToCPPVisitor : public BaseCCPPVisitor<ASRToCPPVisitor>
 {
 public:
-    ASRToCPPVisitor(diag::Diagnostics &diag, Platform &platform)
-        : BaseCCPPVisitor(diag, platform, true, true, false) {}
+    ASRToCPPVisitor(diag::Diagnostics &diag, Platform &platform,
+                    int64_t default_lower_bound)
+        : BaseCCPPVisitor(diag, platform, true, true, false,
+                          default_lower_bound) {}
+
+    std::string convert_dims(size_t n_dims, ASR::dimension_t *m_dims)
+    {
+        std::string dims;
+        for (size_t i=0; i<n_dims; i++) {
+            ASR::expr_t *start = m_dims[i].m_start;
+            ASR::expr_t *end = m_dims[i].m_end;
+            if (!start && !end) {
+                dims += "*";
+            } else if (start && end) {
+                ASR::expr_t* start_value = ASRUtils::expr_value(start);
+                ASR::expr_t* end_value = ASRUtils::expr_value(end);
+                if( start_value && end_value ) {
+                    int64_t start_int = -1, end_int = -1;
+                    ASRUtils::extract_value(start_value, start_int);
+                    ASRUtils::extract_value(end_value, end_int);
+                    dims += "[" + std::to_string(end_int - start_int + 1) + "]";
+                } else {
+                    dims += "[ /* FIXME symbolic dimensions */ ]";
+                }
+            } else {
+                throw CodeGenError("Dimension type not supported");
+            }
+        }
+        return dims;
+    }
 
     std::string convert_variable_decl(const ASR::Variable_t &v, bool use_static=true)
     {
@@ -443,10 +444,11 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 };
 
 Result<std::string> asr_to_cpp(Allocator &al, ASR::TranslationUnit_t &asr,
-    diag::Diagnostics &diagnostics, Platform &platform)
+    diag::Diagnostics &diagnostics, Platform &platform,
+    int64_t default_lower_bound)
 {
     pass_unused_functions(al, asr, true);
-    ASRToCPPVisitor v(diagnostics, platform);
+    ASRToCPPVisitor v(diagnostics, platform, default_lower_bound);
     try {
         v.visit_asr((ASR::asr_t &)asr);
     } catch (const CodeGenError &e) {

--- a/src/libasr/codegen/asr_to_cpp.h
+++ b/src/libasr/codegen/asr_to_cpp.h
@@ -7,7 +7,7 @@
 namespace LFortran {
 
     Result<std::string> asr_to_cpp(Allocator &al, ASR::TranslationUnit_t &asr,
-        diag::Diagnostics &diagnostics, Platform &platform);
+        diag::Diagnostics &diagnostics, Platform &platform, int64_t default_lower_bound);
 
 } // namespace LFortran
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -51,6 +51,7 @@
 #include <libasr/codegen/llvm_array_utils.h>
 
 // Uncomment for ASR printing below
+//#include <lfortran/pickle.h>
 // #include <lpython/pickle.h>
 
 #if LLVM_VERSION_MAJOR >= 11
@@ -3019,7 +3020,7 @@ public:
                 break;
             }
             default : {
-                throw CodeGenError("Comparison operator not implemented.",
+                throw CodeGenError("Comparison operator not implemented",
                         x.base.base.loc);
             }
         }
@@ -3063,7 +3064,7 @@ public:
                 break;
             }
             default : {
-                throw CodeGenError("Comparison operator not implemented.",
+                throw CodeGenError("Comparison operator not implemented",
                         x.base.base.loc);
             }
         }
@@ -5026,7 +5027,7 @@ public:
         }
         int output_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
         uint64_t ptr_loads_copy = ptr_loads;
-        ptr_loads = ptr_loads_copy -
+        ptr_loads = 2 - // Sync: instead of 2 - , should this be ptr_loads_copy -
                     (ASRUtils::expr_type(x.m_v)->type ==
                      ASR::ttypeType::Pointer);
         visit_expr_wrapper(x.m_v);
@@ -5093,7 +5094,7 @@ public:
             return ;
         }
         uint64_t ptr_loads_copy = ptr_loads;
-        ptr_loads = ptr_loads_copy -
+        ptr_loads = 2 - // Sync: instead of 2 - , should this be ptr_loads_copy -
                     (ASRUtils::expr_type(x.m_v)->type ==
                      ASR::ttypeType::Pointer);
         visit_expr_wrapper(x.m_v);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -41,18 +41,12 @@
 #include <libasr/asr.h>
 #include <libasr/containers.h>
 #include <libasr/codegen/asr_to_llvm.h>
-#include <libasr/pass/do_loops.h>
-#include <libasr/pass/for_all.h>
 #include <libasr/pass/nested_vars.h>
 #include <libasr/pass/pass_manager.h>
 #include <libasr/exception.h>
 #include <libasr/asr_utils.h>
 #include <libasr/codegen/llvm_utils.h>
 #include <libasr/codegen/llvm_array_utils.h>
-
-// Uncomment for ASR printing below
-//#include <lfortran/pickle.h>
-// #include <lpython/pickle.h>
 
 #if LLVM_VERSION_MAJOR >= 11
 #    define FIXED_VECTOR_TYPE llvm::FixedVectorType
@@ -1258,7 +1252,8 @@ public:
         std::vector<llvm::Value*> idx_vec = {
             llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
             llvm::ConstantInt::get(context, llvm::APInt(32, member_idx))};
-        if( ASR::is_a<ASR::DerivedRef_t>(*x.m_v) ) {
+        if( ASR::is_a<ASR::DerivedRef_t>(*x.m_v) &&
+            is_nested_pointer(tmp) ) {
             tmp = builder->CreateLoad(tmp);
         }
         llvm::Value* tmp1 = CreateGEP(tmp, idx_vec);
@@ -2597,13 +2592,19 @@ public:
         }
     }
 
+    bool is_nested_pointer(llvm::Value* val) {
+        // TODO: Remove this in future
+        // Related issue, https://github.com/lcompilers/lpython/pull/707#issuecomment-1169773106.
+        return val->getType()->isPointerTy() &&
+               val->getType()->getContainedType(0)->isPointerTy();
+    }
+
     void visit_CLoc(const ASR::CLoc_t& x) {
         uint64_t ptr_loads_copy = ptr_loads;
         ptr_loads = 0;
         this->visit_expr(*x.m_arg);
         ptr_loads = ptr_loads_copy;
-        if( tmp->getType()->isPointerTy() &&
-            tmp->getType()->getContainedType(0)->isPointerTy() ) {
+        if( is_nested_pointer(tmp) ) {
             tmp = builder->CreateLoad(tmp);
         }
         if( arr_descr->is_array(tmp) ) {
@@ -2615,8 +2616,7 @@ public:
 
 
     llvm::Value* GetPointerCPtrUtil(llvm::Value* llvm_tmp) {
-        if( llvm_tmp->getType()->isPointerTy() &&
-            llvm_tmp->getType()->getContainedType(0)->isPointerTy() ) {
+        if( is_nested_pointer(llvm_tmp) ) {
             llvm_tmp = builder->CreateLoad(llvm_tmp);
         }
         if( arr_descr->is_array(llvm_tmp) ) {

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -17,6 +17,11 @@ namespace LFortran {
 
 namespace {
 
+    // This exception is used to abort the visitor pattern when an error occurs.
+    class CodeGenAbort
+    {
+    };
+
     // Local exception that is only used in this file to exit the visitor
     // pattern and caught later (not propagated outside)
     class CodeGenError {
@@ -24,52 +29,128 @@ namespace {
         diag::Diagnostic d;
 
     public:
-        CodeGenError(const std::string &msg) : d{diag::Diagnostic(msg, diag::Level::Error, diag::Stage::CodeGen)} {}
+        CodeGenError(const std::string &msg)
+            : d{diag::Diagnostic(msg, diag::Level::Error, diag::Stage::CodeGen)}
+        { }
+
+        CodeGenError(const std::string &msg, const Location &loc)
+            : d{diag::Diagnostic(msg, diag::Level::Error, diag::Stage::CodeGen, {
+                diag::Label("", {loc})
+            })}
+        { }
     };
 
 }  // namespace
 
+
+struct import_func{
+    std::string name;
+    std::vector<uint8_t> param_types, result_types;
+};
+
+
 class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
    public:
     Allocator &m_al;
-    ASR::Variable_t *return_var;
+    diag::Diagnostics &diag;
 
-    Vec<uint8_t> m_preamble;
+    ASR::Variable_t *return_var;
+    bool is_return_visited;
+
     Vec<uint8_t> m_type_section;
+    Vec<uint8_t> m_import_section;
     Vec<uint8_t> m_func_section;
     Vec<uint8_t> m_export_section;
     Vec<uint8_t> m_code_section;
+    Vec<uint8_t> m_data_section;
 
     uint32_t cur_func_idx;
+    uint32_t no_of_functions;
+    uint32_t no_of_imports;
+    uint32_t no_of_data_segments;  
+    uint32_t last_str_len;
+    uint32_t avail_mem_loc;
+    
     std::map<std::string, int32_t> m_var_name_idx_map;
     std::map<std::string, int32_t> m_func_name_idx_map;
 
    public:
-    ASRToWASMVisitor(Allocator &al) : m_al{al} {
+    ASRToWASMVisitor(Allocator &al, diag::Diagnostics &diagnostics): m_al(al), diag(diagnostics) {
         cur_func_idx = 0;
-        m_preamble.reserve(m_al, 1024 * 128);
+        avail_mem_loc = 0;
+        no_of_functions = 0;
+        no_of_imports = 0;
+        no_of_data_segments = 0;
         m_type_section.reserve(m_al, 1024 * 128);
+        m_import_section.reserve(m_al, 1024 * 128);
         m_func_section.reserve(m_al, 1024 * 128);
         m_export_section.reserve(m_al, 1024 * 128);
         m_code_section.reserve(m_al, 1024 * 128);
+        m_data_section.reserve(m_al, 1024 * 128);
     }
 
     void visit_TranslationUnit(const ASR::TranslationUnit_t &x) {
+        uint32_t len_idx_type_section = wasm::emit_len_placeholder(m_type_section, m_al);
+        uint32_t len_idx_import_section = wasm::emit_len_placeholder(m_import_section, m_al);
+        uint32_t len_idx_func_section = wasm::emit_len_placeholder(m_func_section, m_al);
+        uint32_t len_idx_export_section = wasm::emit_len_placeholder(m_export_section, m_al);
+        uint32_t len_idx_code_section = wasm::emit_len_placeholder(m_code_section, m_al);
+        uint32_t len_idx_data_section = wasm::emit_len_placeholder(m_data_section, m_al);
+
         // the main program:
         for (auto &item : x.m_global_scope->get_scope()) {
             if (ASR::is_a<ASR::Program_t>(*item.second)) {
                 visit_symbol(*item.second);
             }
         }
+
+        wasm::emit_u32_b32_idx(m_type_section, m_al, len_idx_type_section, cur_func_idx); // cur_func_idx indicates the total (imported + defined) no of functions
+        wasm::emit_u32_b32_idx(m_import_section, m_al, len_idx_import_section, no_of_imports);
+        wasm::emit_u32_b32_idx(m_func_section, m_al, len_idx_func_section, no_of_functions);
+        wasm::emit_u32_b32_idx(m_export_section, m_al, len_idx_export_section, no_of_functions);
+        wasm::emit_u32_b32_idx(m_code_section, m_al, len_idx_code_section, no_of_functions);
+        wasm::emit_u32_b32_idx(m_data_section, m_al, len_idx_data_section, no_of_data_segments);
     }
 
-    void visit_Program(const ASR::Program_t &x) {
-        wasm::emit_header(m_preamble, m_al);  // emit header and version
+    void emit_imports(){
+        std::vector<import_func> import_funcs = {
+            {"print_i32", { wasm::type::i32 }, {}},
+            {"print_i64", { wasm::type::i64 }, {}},
+            {"print_f32", { wasm::type::f32 }, {}},
+            {"print_f64", { wasm::type::f64 }, {}},
+            {"print_str", { wasm::type::i32, wasm::type::i32 }, {}},
+            {"flush_buf", {}, {}}
+        };
 
-        uint32_t len_idx_type_section = wasm::emit_len_placeholder(m_type_section, m_al);
-        uint32_t len_idx_func_section = wasm::emit_len_placeholder(m_func_section, m_al);
-        uint32_t len_idx_export_section = wasm::emit_len_placeholder(m_export_section, m_al);
-        uint32_t len_idx_code_section = wasm::emit_len_placeholder(m_code_section, m_al);
+        for(auto import_func:import_funcs){
+            wasm::emit_import_fn(m_import_section, m_al, "js", import_func.name, cur_func_idx);
+            // add their types to type section
+            wasm::emit_b8(m_type_section, m_al, 0x60);  // type section
+
+            wasm::emit_u32(m_type_section, m_al, import_func.param_types.size());
+            for(auto &param_type:import_func.param_types){
+                wasm::emit_b8(m_type_section, m_al, param_type);
+            }
+
+            wasm::emit_u32(m_type_section, m_al, import_func.result_types.size());
+            for(auto &result_type:import_func.result_types){
+                wasm::emit_b8(m_type_section, m_al, result_type);
+            }
+
+            m_func_name_idx_map[import_func.name] = cur_func_idx++;
+            no_of_imports++;
+        }
+
+        wasm::emit_import_mem(m_import_section, m_al, "js", "memory", 10U /* min page limit */, 10U /* max page limit */);
+        no_of_imports++;
+    }
+    
+    
+    void visit_Program(const ASR::Program_t &x) {
+        
+        emit_imports();
+
+        no_of_functions = 0;
 
         for (auto &item : x.m_symtab->get_scope()) {
             if (ASR::is_a<ASR::Subroutine_t>(*item.second)) {
@@ -78,89 +159,156 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             if (ASR::is_a<ASR::Function_t>(*item.second)) {
                 ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(item.second);
                 visit_Function(*s);
+                no_of_functions++;
             }
         }
 
-        wasm::emit_u32_b32_idx(m_type_section, len_idx_type_section, cur_func_idx);
-        wasm::emit_u32_b32_idx(m_func_section, len_idx_func_section, cur_func_idx);
-        wasm::emit_u32_b32_idx(m_export_section, len_idx_export_section, cur_func_idx);
-        wasm::emit_u32_b32_idx(m_code_section, len_idx_code_section, cur_func_idx);
-    }
+        // Generate main program code
+        sprintf(x.m_name, "_lcompilers_main");
+        m_var_name_idx_map.clear(); // clear all previous variable and their indices
+        wasm::emit_b8(m_type_section, m_al, 0x60);  // new type declaration starts here
+        m_func_name_idx_map[x.m_name] = cur_func_idx;
 
-    void visit_Function(const ASR::Function_t &x) {
-        wasm::emit_b8(m_type_section, m_al, 0x60);  // type section
-
-        uint32_t len_idx_type_section_param_types_list = wasm::emit_len_placeholder(m_type_section, m_al);
-        int curIdx = 0;
-        for (size_t i = 0; i < x.n_args; i++) {
-            ASR::Variable_t *arg = LFortran::ASRUtils::EXPR2VAR(x.m_args[i]);
-            LFORTRAN_ASSERT(LFortran::ASRUtils::is_arg_dummy(arg->m_intent));
-            if (ASR::is_a<ASR::Integer_t>(*arg->m_type)) {
-                // checking for array is currently omitted
-                bool is_int32 = ASR::down_cast<ASR::Integer_t>(arg->m_type)->m_kind == 4;
-                if (is_int32) {
-                    wasm::emit_b8(m_type_section, m_al, 0x7F);  // i32
-                } else {
-                    wasm::emit_b8(m_type_section, m_al, 0x7E);  // i64
-                }
-                m_var_name_idx_map[arg->m_name] = curIdx++;
-            } else {
-                throw CodeGenError("Parameters other than integer not yet supported");
-            }
-        }
-        wasm::fixup_len(m_type_section, len_idx_type_section_param_types_list);
-
-        uint32_t len_idx_type_section_return_types_list = wasm::emit_len_placeholder(m_type_section, m_al);
-        return_var = LFortran::ASRUtils::EXPR2VAR(x.m_return_var);
-        if (ASRUtils::is_integer(*return_var->m_type)) {
-            bool is_int32 = ASR::down_cast<ASR::Integer_t>(return_var->m_type)->m_kind == 4;
-            if (is_int32) {
-                wasm::emit_b8(m_type_section, m_al, 0x7F);  // i32
-            } else {
-                wasm::emit_b8(m_type_section, m_al, 0x7E);  // i64
-            }
-        } else {
-            throw CodeGenError("Return type not supported");
-        }
-        wasm::fixup_len(m_type_section, len_idx_type_section_return_types_list);
-
+        wasm::emit_u32(m_type_section, m_al, 0U); // emit parameter types length = 0
+        wasm::emit_u32(m_type_section, m_al, 0U); // emit result types length = 0
+        
+        /********************* Function Body Starts Here *********************/
         uint32_t len_idx_code_section_func_size = wasm::emit_len_placeholder(m_code_section, m_al);
+        
+        /********************* Local Vars Types List *********************/
         uint32_t len_idx_code_section_local_vars_list = wasm::emit_len_placeholder(m_code_section, m_al);
-        int local_vars_cnt = 0;
+        int local_vars_cnt = 0, cur_idx = 0;
         for (auto &item : x.m_symtab->get_scope()) {
             if (ASR::is_a<ASR::Variable_t>(*item.second)) {
                 ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(item.second);
-                if (v->m_intent == LFortran::ASRUtils::intent_local || v->m_intent == LFortran::ASRUtils::intent_return_var) {
-                    if (ASR::is_a<ASR::Integer_t>(*v->m_type)) {
-                        wasm::emit_u32(m_code_section, m_al, 1);    // count of local vars of this type
-                        bool is_int32 = ASR::down_cast<ASR::Integer_t>(v->m_type)->m_kind == 4;
-                        if (is_int32) {
-                            wasm::emit_b8(m_code_section, m_al, 0x7F);  // i32
-                        } else {
-                            wasm::emit_b8(m_code_section, m_al, 0x7E);  // i64
-                        }
-                        m_var_name_idx_map[v->m_name] = curIdx++;
-                        local_vars_cnt++;
-                    } else {
-                        throw CodeGenError("Variables other than integer not yet supported");
-                    }
-                }
+                wasm::emit_u32(m_code_section, m_al, 1U);    // count of local vars of this type
+                emit_var_type(m_code_section, v); // emit the type of this var
+                m_var_name_idx_map[v->m_name] = cur_idx++;
+                local_vars_cnt++;
             }
         }
         // fixup length of local vars list
-        wasm::emit_u32_b32_idx(m_code_section, len_idx_code_section_local_vars_list, local_vars_cnt);
+        wasm::emit_u32_b32_idx(m_code_section, m_al, len_idx_code_section_local_vars_list, local_vars_cnt);
 
         for (size_t i = 0; i < x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
         }
 
         wasm::emit_expr_end(m_code_section, m_al);
-        wasm::fixup_len(m_code_section, len_idx_code_section_func_size);
+        wasm::fixup_len(m_code_section, m_al, len_idx_code_section_func_size);
 
         wasm::emit_u32(m_func_section, m_al, cur_func_idx);
 
         wasm::emit_export_fn(m_export_section, m_al, x.m_name, cur_func_idx);
-        m_func_name_idx_map[x.m_name] = cur_func_idx++;
+
+        cur_func_idx++;
+        no_of_functions++;
+    }
+
+    void emit_var_type(Vec<uint8_t> &code, ASR::Variable_t *v){
+        if (ASRUtils::is_integer(*v->m_type)) {
+            // checking for array is currently omitted
+            ASR::Integer_t* v_int = ASR::down_cast<ASR::Integer_t>(v->m_type);
+            if (v_int->m_kind == 4) {
+                wasm::emit_b8(code, m_al, wasm::type::i32);
+            }
+            else if (v_int->m_kind == 8) {
+                wasm::emit_b8(code, m_al, wasm::type::i64);
+            }
+            else{
+                throw CodeGenError("Integers of kind 4 and 8 only supported");
+            }
+        } else if (ASRUtils::is_real(*v->m_type)) {
+            // checking for array is currently omitted
+            ASR::Real_t* v_float = ASR::down_cast<ASR::Real_t>(v->m_type);
+            if (v_float->m_kind == 4) {
+                wasm::emit_b8(code, m_al, wasm::type::f32);
+            }
+            else if(v_float->m_kind == 8){
+                wasm::emit_b8(code, m_al, wasm::type::f64);
+            } 
+            else {
+                throw CodeGenError("Floating Points of kind 4 and 8 only supported");
+            }
+        } else if (ASRUtils::is_logical(*v->m_type)) {
+            // checking for array is currently omitted
+            ASR::Logical_t* v_logical = ASR::down_cast<ASR::Logical_t>(v->m_type);
+            if (v_logical->m_kind == 4) {
+                wasm::emit_b8(code, m_al, wasm::type::i32);
+            }
+            else if(v_logical->m_kind == 8){
+                wasm::emit_b8(code, m_al, wasm::type::i64);
+            } 
+            else {
+                throw CodeGenError("Logicals of kind 4 and 8 only supported");
+            }
+        } else {
+            throw CodeGenError("Param, Result, Var Types other than integer, floating point and logical not yet supported");
+        }
+    }
+
+    void visit_Function(const ASR::Function_t &x) {
+        m_var_name_idx_map.clear(); // clear all previous variable and their indices
+
+        wasm::emit_b8(m_type_section, m_al, 0x60);  // new type declaration starts here
+        
+        m_func_name_idx_map[x.m_name] = cur_func_idx; // add func to map early to support recursive func calls
+
+        /********************* Parameter Types List *********************/
+        uint32_t len_idx_type_section_param_types_list = wasm::emit_len_placeholder(m_type_section, m_al);
+        int cur_idx = 0;
+        for (size_t i = 0; i < x.n_args; i++) {
+            ASR::Variable_t *arg = LFortran::ASRUtils::EXPR2VAR(x.m_args[i]);
+            LFORTRAN_ASSERT(LFortran::ASRUtils::is_arg_dummy(arg->m_intent));
+            emit_var_type(m_type_section, arg);
+            m_var_name_idx_map[arg->m_name] = cur_idx++;
+        }
+        wasm::fixup_len(m_type_section, m_al, len_idx_type_section_param_types_list);
+
+        /********************* Result Types List *********************/
+        uint32_t len_idx_type_section_return_types_list = wasm::emit_len_placeholder(m_type_section, m_al);
+        return_var = LFortran::ASRUtils::EXPR2VAR(x.m_return_var);
+        emit_var_type(m_type_section, return_var);
+        wasm::fixup_len(m_type_section, m_al, len_idx_type_section_return_types_list);
+        is_return_visited = false; // for every function initialize is_return_visited to false
+
+        /********************* Function Body Starts Here *********************/
+        uint32_t len_idx_code_section_func_size = wasm::emit_len_placeholder(m_code_section, m_al);
+        
+        /********************* Local Vars Types List *********************/
+        uint32_t len_idx_code_section_local_vars_list = wasm::emit_len_placeholder(m_code_section, m_al);
+        int local_vars_cnt = 0;
+        for (auto &item : x.m_symtab->get_scope()) {
+            if (ASR::is_a<ASR::Variable_t>(*item.second)) {
+                ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(item.second);
+                if (v->m_intent == LFortran::ASRUtils::intent_local || v->m_intent == LFortran::ASRUtils::intent_return_var) {
+                    wasm::emit_u32(m_code_section, m_al, 1U);    // count of local vars of this type
+                    emit_var_type(m_code_section, v); // emit the type of this var
+                    m_var_name_idx_map[v->m_name] = cur_idx++;
+                    local_vars_cnt++;
+                }
+            }
+        }
+        // fixup length of local vars list
+        wasm::emit_u32_b32_idx(m_code_section, m_al, len_idx_code_section_local_vars_list, local_vars_cnt);
+
+        for (size_t i = 0; i < x.n_body; i++) {
+            this->visit_stmt(*x.m_body[i]);
+        }
+
+        if(!is_return_visited){
+            ASR::Return_t temp;
+            visit_Return(temp);
+        }
+
+        wasm::emit_expr_end(m_code_section, m_al);
+        wasm::fixup_len(m_code_section, m_al, len_idx_code_section_func_size);
+
+        wasm::emit_u32(m_func_section, m_al, cur_func_idx);
+
+        wasm::emit_export_fn(m_export_section, m_al, x.m_name, cur_func_idx);
+
+        cur_func_idx++;
     }
 
     void visit_Assignment(const ASR::Assignment_t &x) {
@@ -168,7 +316,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         // this->visit_expr(*x.m_target);
         if (ASR::is_a<ASR::Var_t>(*x.m_target)) {
             ASR::Variable_t *asr_target = LFortran::ASRUtils::EXPR2VAR(x.m_target);
-
+            LFORTRAN_ASSERT(m_var_name_idx_map.find(asr_target->m_name) != m_var_name_idx_map.end());
             wasm::emit_set_local(m_code_section, m_al, m_var_name_idx_map[asr_target->m_name]);
         } else if (ASR::is_a<ASR::ArrayRef_t>(*x.m_target)) {
             throw CodeGenError("Assignment: Arrays not yet supported");
@@ -178,9 +326,12 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void visit_IntegerBinOp(const ASR::IntegerBinOp_t &x) {
+        if (x.m_value) { 
+            visit_expr(*x.m_value); 
+            return; 
+        }
         this->visit_expr(*x.m_left);
         this->visit_expr(*x.m_right);
-
         ASR::Integer_t *i = ASR::down_cast<ASR::Integer_t>(x.m_type);
         if (i->m_kind == 4) {
             switch (x.m_op) {
@@ -197,7 +348,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                     break;
                 };
                 case ASR::binopType::Div: {
-                    wasm::emit_i32_div(m_code_section, m_al);
+                    wasm::emit_i32_div_s(m_code_section, m_al);
                     break;
                 };
                 default:
@@ -218,7 +369,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                     break;
                 };
                 case ASR::binopType::Div: {
-                    wasm::emit_i64_div(m_code_section, m_al);
+                    wasm::emit_i64_div_s(m_code_section, m_al);
                     break;
                 };
                 default:
@@ -229,23 +380,124 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         }
     }
 
+    void visit_RealBinOp(const ASR::RealBinOp_t &x) {
+        if (x.m_value) { 
+            visit_expr(*x.m_value); 
+            return; 
+        }
+        this->visit_expr(*x.m_left);
+        this->visit_expr(*x.m_right);
+        ASR::Real_t *f = ASR::down_cast<ASR::Real_t>(x.m_type);
+        if (f->m_kind == 4) {
+            switch (x.m_op) {
+                case ASR::binopType::Add: {
+                    wasm::emit_f32_add(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Sub: {
+                    wasm::emit_f32_sub(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Mul: {
+                    wasm::emit_f32_mul(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Div: {
+                    wasm::emit_f32_div(m_code_section, m_al);
+                    break;
+                };
+                default:
+                    throw CodeGenError("RealBinop: Pow Operation not yet implemented");
+            }
+        } else if (f->m_kind == 8) {
+            switch (x.m_op) {
+                case ASR::binopType::Add: {
+                    wasm::emit_f64_add(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Sub: {
+                    wasm::emit_f64_sub(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Mul: {
+                    wasm::emit_f64_mul(m_code_section, m_al);
+                    break;
+                };
+                case ASR::binopType::Div: {
+                    wasm::emit_f64_div(m_code_section, m_al);
+                    break;
+                };
+                default:
+                    throw CodeGenError("RealBinop: Pow Operation not yet implemented");
+            }
+        } else {
+            throw CodeGenError("RealBinop: Real kind not supported");
+        }
+    }
+
+    void visit_IntegerUnaryMinus(const ASR::IntegerUnaryMinus_t &x) {
+         if (x.m_value) { 
+            visit_expr(*x.m_value); 
+            return; 
+        }
+        ASR::Integer_t *i = ASR::down_cast<ASR::Integer_t>(x.m_type);
+        // there seems no direct unary-minus inst in wasm, so subtracting from 0
+        if(i->m_kind == 4){
+            wasm::emit_i32_const(m_code_section, m_al, 0);
+            this->visit_expr(*x.m_arg);
+            wasm::emit_i32_sub(m_code_section, m_al);
+        }
+        else if(i->m_kind == 8){
+            wasm::emit_i64_const(m_code_section, m_al, 0LL);
+            this->visit_expr(*x.m_arg);
+            wasm::emit_i64_sub(m_code_section, m_al);
+        }
+        else{
+            throw CodeGenError("IntegerUnaryMinus: Only kind 4 and 8 supported");
+        }
+    }
+
+    void visit_RealUnaryMinus(const ASR::RealUnaryMinus_t &x) {
+         if (x.m_value) { 
+            visit_expr(*x.m_value); 
+            return; 
+        }
+        ASR::Real_t *f = ASR::down_cast<ASR::Real_t>(x.m_type);
+        if(f->m_kind == 4){
+            this->visit_expr(*x.m_arg);
+            wasm::emit_f32_neg(m_code_section, m_al);
+        }
+        else if(f->m_kind == 8){
+            this->visit_expr(*x.m_arg);
+            wasm::emit_f64_neg(m_code_section, m_al);
+        }
+        else{
+            throw CodeGenError("RealUnaryMinus: Only kind 4 and 8 supported");
+        }
+    }
+
     void visit_Var(const ASR::Var_t &x) {
         const ASR::symbol_t *s = ASRUtils::symbol_get_past_external(x.m_v);
         auto v = ASR::down_cast<ASR::Variable_t>(s);
         switch (v->m_type->type) {
             case ASR::ttypeType::Integer:
-                // currently omitting check for 64 bit integers
+            case ASR::ttypeType::Logical:
+            case ASR::ttypeType::Real: {
+                LFORTRAN_ASSERT(m_var_name_idx_map.find(v->m_name) != m_var_name_idx_map.end());
                 wasm::emit_get_local(m_code_section, m_al, m_var_name_idx_map[v->m_name]);
                 break;
-
+            }
+            
             default:
-                throw CodeGenError("Variable type not supported");
+                throw CodeGenError("Only Integer and Float Variable types currently supported");
         }
     }
 
     void visit_Return(const ASR::Return_t & /* x */) {
+        LFORTRAN_ASSERT(m_var_name_idx_map.find(return_var->m_name) != m_var_name_idx_map.end());
         wasm::emit_get_local(m_code_section, m_al, m_var_name_idx_map[return_var->m_name]);
-        wasm::emit_b8(m_code_section, m_al, 0x0F);
+        wasm::emit_b8(m_code_section, m_al, 0x0F); // return instruction
+        is_return_visited = true;
     }
 
     void visit_IntegerConstant(const ASR::IntegerConstant_t &x) {
@@ -256,10 +508,58 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                 wasm::emit_i32_const(m_code_section, m_al, val);
                 break;
             }
+            case 8: {
+                wasm::emit_i64_const(m_code_section, m_al, val);
+                break;
+            }
             default: {
-                throw CodeGenError("Constant Integer: Only kind 4 currently supported");
+                throw CodeGenError("Constant Integer: Only kind 4 and 8 supported");
             }
         }
+    }
+
+    void visit_RealConstant(const ASR::RealConstant_t &x) {
+        double val = x.m_r;
+        int a_kind = ((ASR::Real_t *)(&(x.m_type->base)))->m_kind;
+        switch (a_kind) {
+            case 4: {
+                wasm::emit_f32_const(m_code_section, m_al, val);
+                break;
+            }
+            case 8: {
+                wasm::emit_f64_const(m_code_section, m_al, val);
+                break;
+            }
+            default: {
+                throw CodeGenError("Constant Real: Only kind 4 and 8 supported");
+            }
+        }
+    }
+
+    void visit_LogicalConstant(const ASR::LogicalConstant_t &x) {
+        bool val = x.m_value;
+        int a_kind = ((ASR::Logical_t *)(&(x.m_type->base)))->m_kind;
+        switch (a_kind) {
+            case 4: {
+                wasm::emit_i32_const(m_code_section, m_al, val);
+                break;
+            }
+            case 8: {
+                wasm::emit_i64_const(m_code_section, m_al, val);
+                break;
+            }
+            default: {
+                throw CodeGenError("Constant Logical: Only kind 4 and 8 supported");
+            }
+        }
+    }
+
+    void visit_StringConstant(const ASR::StringConstant_t &x){
+        // Todo: Add a check here if there is memory available to store the given string
+        wasm::emit_str_const(m_data_section, m_al, avail_mem_loc, x.m_s);
+        last_str_len = strlen(x.m_s);
+        avail_mem_loc += last_str_len;
+        no_of_data_segments++;
     }
 
     void visit_FunctionCall(const ASR::FunctionCall_t &x) {
@@ -269,80 +569,201 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             visit_expr(*x.m_args[i].m_value);
         }
 
+        LFORTRAN_ASSERT(m_func_name_idx_map.find(fn->m_name) != m_func_name_idx_map.end())
         wasm::emit_call(m_code_section, m_al, m_func_name_idx_map[fn->m_name]);
+    }
+
+    template <typename T>
+    void handle_print(const T &x){
+        for (size_t i=0; i<x.n_values; i++) {
+            this->visit_expr(*x.m_values[i]);
+            ASR::expr_t *v = x.m_values[i];
+            ASR::ttype_t *t = ASRUtils::expr_type(v);
+            int a_kind = ASRUtils::extract_kind_from_ttype_t(t);
+
+            if (ASRUtils::is_integer(*t)) {
+                switch( a_kind ) {
+                    case 4 : {
+                        // the value is already on stack. call JavaScript print_i32
+                        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_i32"]);
+                        break;
+                    }
+                    case 8 : {
+                        // the value is already on stack. call JavaScript print_i64
+                        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_i64"]);
+                        break;
+                    }
+                    default: {
+                        throw CodeGenError(R"""(Printing support is currently available only
+                                            for 32, and 64 bit integer kinds.)""");
+                    }
+                }
+            } else if (ASRUtils::is_real(*t)) {
+                switch( a_kind ) {
+                    case 4 : {
+                        // the value is already on stack. call JavaScript print_f32
+                        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_f32"]);
+                        break;
+                    }
+                    case 8 : {
+                        // the value is already on stack. call JavaScript print_f64
+                        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_f64"]);
+                        break;
+                    }
+                    default: {
+                        throw CodeGenError(R"""(Printing support is available only
+                                            for 32, and 64 bit real kinds.)""");
+                    }
+                }
+            } else if (t->type == ASR::ttypeType::Character) {
+                // push string location and its size on function stack
+                wasm::emit_i32_const(m_code_section, m_al, avail_mem_loc - last_str_len);
+                wasm::emit_i32_const(m_code_section, m_al, last_str_len);
+
+                // call JavaScript printStr
+                wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_str"]);
+                
+            } 
+        }
+
+        // call JavaScript Flush
+        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["flush_buf"]);
+    }
+
+    void visit_Print(const ASR::Print_t &x){
+        if (x.m_fmt != nullptr) {
+            diag.codegen_warning_label("format string in `print` is not implemented yet and it is currently treated as '*'",
+                {x.m_fmt->base.loc}, "treated as '*'");
+        }
+        handle_print(x);
+    }
+
+    void visit_FileWrite(const ASR::FileWrite_t &x) {
+        if (x.m_fmt != nullptr) {
+            diag.codegen_warning_label("format string in `print` is not implemented yet and it is currently treated as '*'",
+                {x.m_fmt->base.loc}, "treated as '*'");
+        }
+        if (x.m_unit != nullptr) {
+            diag.codegen_error_label("unit in write() is not implemented yet",
+                {x.m_unit->base.loc}, "not implemented");
+            throw CodeGenAbort();
+        }
+        handle_print(x);
+    }
+
+    void visit_FileRead(const ASR::FileRead_t &x) {
+        if (x.m_fmt != nullptr) {
+            diag.codegen_warning_label("format string in read() is not implemented yet and it is currently treated as '*'",
+                {x.m_fmt->base.loc}, "treated as '*'");
+        }
+        if (x.m_unit != nullptr) {
+            diag.codegen_error_label("unit in read() is not implemented yet",
+                {x.m_unit->base.loc}, "not implemented");
+            throw CodeGenAbort();
+        }
+        diag.codegen_error_label("The intrinsic function read() is not implemented yet in the LLVM backend",
+            {x.base.base.loc}, "not implemented");
+        throw CodeGenAbort();
+    }
+
+    void print_msg(std::string msg) {
+        ASR::StringConstant_t n;
+        n.m_s = new char[msg.length() + 1];
+        strcpy(n.m_s, msg.c_str());
+        visit_StringConstant(n);
+        wasm::emit_i32_const(m_code_section, m_al, avail_mem_loc - last_str_len);
+        wasm::emit_i32_const(m_code_section, m_al, last_str_len);
+        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_str"]);
+        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["flush_buf"]);
+    }
+
+    void exit() {
+        // exit_code would be on stack, so add it to JavaScript Output buffer by printing it.
+        // this exit code would be read by JavaScript glue code
+        wasm::emit_call(m_code_section, m_al, m_func_name_idx_map["print_i32"]);
+        wasm::emit_unreachable(m_code_section, m_al); // raise trap/exception
+    }
+
+    void visit_Stop(const ASR::Stop_t &x) {
+        print_msg("STOP");
+        if (x.m_code && ASRUtils::expr_type(x.m_code)->type == ASR::ttypeType::Integer) {
+            this->visit_expr(*x.m_code);
+        } else {
+            wasm::emit_i32_const(m_code_section, m_al, 0); // zero exit code
+        }
+        exit();
+    }
+
+    void visit_ErrorStop(const ASR::ErrorStop_t & /* x */) {
+        print_msg("ERROR STOP");
+        wasm::emit_i32_const(m_code_section, m_al, 1); // non-zero exit code
+        exit();
+    }
+
+    void visit_If(const ASR::If_t &x) {
+        this->visit_expr(*x.m_test);
+        wasm::emit_b8(m_code_section, m_al, 0x04);
+        wasm::emit_b8(m_code_section, m_al, 0x40); // empty block type
+        for (size_t i=0; i<x.n_body; i++) {
+            this->visit_stmt(*x.m_body[i]);
+        }
+        if(x.n_orelse){
+            wasm::emit_b8(m_code_section, m_al, 0x05); // starting of else
+            for (size_t i=0; i<x.n_orelse; i++) {
+                this->visit_stmt(*x.m_orelse[i]);
+            }
+        }
+        wasm::emit_expr_end(m_code_section, m_al);
     }
 };
 
-Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr, Allocator &al) {
-    ASRToWASMVisitor v(al);
+Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr, Allocator &al, diag::Diagnostics &diagnostics) {
+    ASRToWASMVisitor v(al, diagnostics);
     Vec<uint8_t> wasm_bytes;
     
     pass_wrap_global_stmts_into_function(al, asr, "f");
     pass_replace_do_loops(al, asr);
     
     try {
-        wasm::emit_u32(v.m_type_section, v.m_al, 1);
-        wasm::emit_u32(v.m_func_section, v.m_al, 3);
-        wasm::emit_u32(v.m_export_section, v.m_al, 7);
-        wasm::emit_u32(v.m_code_section, v.m_al, 10);
-
-        uint32_t len_idx_type_section = wasm::emit_len_placeholder(v.m_type_section, v.m_al);
-        uint32_t len_idx_func_section = wasm::emit_len_placeholder(v.m_func_section, v.m_al);
-        uint32_t len_idx_export_section = wasm::emit_len_placeholder(v.m_export_section, v.m_al);
-        uint32_t len_idx_code_section = wasm::emit_len_placeholder(v.m_code_section, v.m_al);
-
         v.visit_asr((ASR::asr_t &)asr);
-
-        wasm::fixup_len(v.m_type_section, len_idx_type_section);
-        wasm::fixup_len(v.m_func_section, len_idx_func_section);
-        wasm::fixup_len(v.m_export_section, len_idx_export_section);
-        wasm::fixup_len(v.m_code_section, len_idx_code_section);
-
     } catch (const CodeGenError &e) {
-        Error error;
-        return error;
+        diagnostics.diagnostics.push_back(e.d);
+        return Error();
     }
 
     {
-        wasm_bytes.reserve(al, v.m_preamble.size() + v.m_type_section.size() + v.m_func_section.size() + v.m_export_section.size() + v.m_code_section.size());
-        for (auto &byte : v.m_preamble) {
-            wasm_bytes.push_back(al, byte);
-        }
-        for (auto &byte : v.m_type_section) {
-            wasm_bytes.push_back(al, byte);
-        }
-        for (auto &byte : v.m_func_section) {
-            wasm_bytes.push_back(al, byte);
-        }
-        for (auto &byte : v.m_export_section) {
-            wasm_bytes.push_back(al, byte);
-        }
-        for (auto &byte : v.m_code_section) {
-            wasm_bytes.push_back(al, byte);
-        }
+        wasm_bytes.reserve(al, 8U /* preamble size */ + 8U /* (section id + section size) */ * 6U /* number of sections */ 
+            + v.m_type_section.size() + v.m_import_section.size() + v.m_func_section.size() 
+            + v.m_export_section.size() + v.m_code_section.size() + v.m_data_section.size());
+        
+        wasm::emit_header(wasm_bytes, al);  // emit header and version
+        wasm::encode_section(wasm_bytes, v.m_type_section, al, 1U);
+        wasm::encode_section(wasm_bytes, v.m_import_section, al, 2U);
+        wasm::encode_section(wasm_bytes, v.m_func_section, al, 3U);
+        wasm::encode_section(wasm_bytes, v.m_export_section, al, 7U);
+        wasm::encode_section(wasm_bytes, v.m_code_section, al, 10U);
+        wasm::encode_section(wasm_bytes, v.m_data_section, al, 11U);
     }
 
     return wasm_bytes;
 }
 
-Result<int> asr_to_wasm(ASR::TranslationUnit_t &asr, Allocator &al, const std::string &filename, bool time_report) {
+Result<int> asr_to_wasm(ASR::TranslationUnit_t &asr, Allocator &al, const std::string &filename,
+    bool time_report, diag::Diagnostics &diagnostics) {
     int time_visit_asr = 0;
     int time_save = 0;
 
     auto t1 = std::chrono::high_resolution_clock::now();
-    Result<Vec<uint8_t>> wasm = asr_to_wasm_bytes_stream(asr, al);
+    Result<Vec<uint8_t>> wasm = asr_to_wasm_bytes_stream(asr, al, diagnostics);
     auto t2 = std::chrono::high_resolution_clock::now();
     time_visit_asr = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     if (!wasm.ok) {
-        Error error;
-        return error;
+        return wasm.error;
     }
 
     {
         auto t1 = std::chrono::high_resolution_clock::now();
-        FILE *fp = fopen(filename.c_str(), "wb");
-        fwrite(wasm.result.data(), sizeof(uint8_t), wasm.result.size(), fp);
-        fclose(fp);
+        wasm::save_bin(wasm.result, filename);
         auto t2 = std::chrono::high_resolution_clock::now();
         time_save = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     }

--- a/src/libasr/codegen/asr_to_wasm.h
+++ b/src/libasr/codegen/asr_to_wasm.h
@@ -6,11 +6,11 @@
 namespace LFortran {
 
     // Generates a wasm binary stream from ASR
-    Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr, Allocator &al);
+    Result<Vec<uint8_t>> asr_to_wasm_bytes_stream(ASR::TranslationUnit_t &asr, Allocator &al, diag::Diagnostics &diagnostics);
 
     // Generates a wasm binary to `filename`
     Result<int> asr_to_wasm(ASR::TranslationUnit_t &asr, Allocator &al,
-            const std::string &filename, bool time_report);
+            const std::string &filename, bool time_report, diag::Diagnostics &diagnostics);
 
 } // namespace LFortran
 

--- a/src/libasr/codegen/evaluator.cpp
+++ b/src/libasr/codegen/evaluator.cpp
@@ -157,6 +157,13 @@ LLVMEvaluator::LLVMEvaluator(const std::string &t)
     LLVMInitializeX86AsmPrinter();
     LLVMInitializeX86AsmParser();
 #endif
+#ifdef HAVE_TARGET_WASM
+    LLVMInitializeWebAssemblyTarget();
+    LLVMInitializeWebAssemblyTargetInfo();
+    LLVMInitializeWebAssemblyTargetMC();
+    LLVMInitializeWebAssemblyAsmPrinter();
+    LLVMInitializeWebAssemblyAsmParser();
+#endif
 
     context = std::make_unique<llvm::LLVMContext>();
 
@@ -423,6 +430,9 @@ void LLVMEvaluator::print_targets()
 #ifdef HAVE_TARGET_X86
     LLVMInitializeX86TargetInfo();
 #endif
+#ifdef HAVE_TARGET_WASM
+    LLVMInitializeWebAssemblyTargetInfo();
+#endif    
     llvm::raw_ostream &os = llvm::outs();
     llvm::TargetRegistry::printRegisteredTargetsForVersion(os);
 }

--- a/src/libasr/codegen/wasm_assembler.h
+++ b/src/libasr/codegen/wasm_assembler.h
@@ -6,37 +6,26 @@
 namespace LFortran {
 namespace wasm {
 
-std::vector<uint8_t> encode_signed_leb128(int32_t n) {
-    std::vector<uint8_t> out;
-    auto more = true;
-    do {
-        uint8_t byte = n & 0x7f;
-        n >>= 7;
-        more = !((((n == 0) && ((byte & 0x40) == 0)) ||
-                  ((n == -1) && ((byte & 0x40) != 0))));
-        if (more) {
-            byte |= 0x80;
-        }
-        out.emplace_back(byte);
-    } while (more);
-    return out;
-}
+enum type {
+    i32 = 0x7F,
+    i64 = 0x7E,
+    f32 = 0x7D,
+    f64 = 0x7C
+};
 
-std::vector<uint8_t> encode_unsigned_leb128(uint32_t n) {
-    std::vector<uint8_t> out;
+void emit_leb128_u32(Vec<uint8_t> &code, Allocator &al, uint32_t n) { // for u32
     do {
         uint8_t byte = n & 0x7f;
         n >>= 7;
         if (n != 0) {
             byte |= 0x80;
         }
-        out.emplace_back(byte);
+        code.push_back(al, byte);
     } while (n != 0);
-    return out;
 }
 
-void emit_signed_leb128(Vec<uint8_t> &code, Allocator &al, int32_t n) {
-    auto more = true;
+void emit_leb128_i32(Vec<uint8_t> &code, Allocator &al, int32_t n) { // for i32
+    bool more = true;
     do {
         uint8_t byte = n & 0x7f;
         n >>= 7;
@@ -49,15 +38,34 @@ void emit_signed_leb128(Vec<uint8_t> &code, Allocator &al, int32_t n) {
     } while (more);
 }
 
-void emit_unsigned_leb128(Vec<uint8_t> &code, Allocator &al, uint32_t n) {
+void emit_leb128_i64(Vec<uint8_t> &code, Allocator &al, int64_t n) { // for i64
+    bool more = true;
     do {
         uint8_t byte = n & 0x7f;
         n >>= 7;
-        if (n != 0) {
+        more = !((((n == 0) && ((byte & 0x40) == 0)) ||
+                  ((n == -1) && ((byte & 0x40) != 0))));
+        if (more) {
             byte |= 0x80;
         }
         code.push_back(al, byte);
-    } while (n != 0);
+    } while (more);
+}
+
+void emit_ieee754_f32(Vec<uint8_t> &code, Allocator &al, float z) { // for f32
+    uint8_t encoded_float[sizeof(z)];
+    std::memcpy(&encoded_float, &z, sizeof(z));
+    for(auto &byte:encoded_float){
+        code.push_back(al, byte);
+    }
+}
+
+void emit_ieee754_f64(Vec<uint8_t> &code, Allocator &al, double z) { // for f64
+    uint8_t encoded_float[sizeof(z)];
+    std::memcpy(&encoded_float, &z, sizeof(z));
+    for(auto &byte:encoded_float){
+        code.push_back(al, byte);
+    }
 }
 
 // function to emit header of Wasm Binary Format
@@ -72,28 +80,54 @@ void emit_header(Vec<uint8_t> &code, Allocator &al) {
     code.push_back(al, 0x00);
 }
 
-// function to emit unsigned 32 bit integer
-void emit_u32(Vec<uint8_t> &code, Allocator &al, uint32_t x) {
-    emit_unsigned_leb128(code, al, x);
-}
-
-// function to emit signed 32 bit integer
-void emit_i32(Vec<uint8_t> &code, Allocator &al, int32_t x) {
-    emit_signed_leb128(code, al, x);
-}
-
 // function to append a given bytecode to the end of the code
 void emit_b8(Vec<uint8_t> &code, Allocator &al, uint8_t x) {
     code.push_back(al, x);
 }
 
-void emit_u32_b32_idx(Vec<uint8_t> &code, uint32_t idx,
+// function to emit unsigned 32 bit integer
+void emit_u32(Vec<uint8_t> &code, Allocator &al, uint32_t x) {
+    emit_leb128_u32(code, al, x);
+}
+
+// function to emit signed 32 bit integer
+void emit_i32(Vec<uint8_t> &code, Allocator &al, int32_t x) {
+    emit_leb128_i32(code, al, x);
+}
+
+// function to emit signed 64 bit integer
+void emit_i64(Vec<uint8_t> &code, Allocator &al, int64_t x) {
+    emit_leb128_i64(code, al, x);
+}
+
+// function to emit 32 bit float
+void emit_f32(Vec<uint8_t> &code, Allocator &al, float x) {
+    emit_ieee754_f32(code, al, x);
+}
+
+// function to emit 64 bit float
+void emit_f64(Vec<uint8_t> &code, Allocator &al, double x) {
+    emit_ieee754_f64(code, al, x);
+}
+
+// function to emit string
+void emit_str(Vec<uint8_t> &code, Allocator &al, std::string text){
+    std::vector<uint8_t> text_bytes(text.size());
+    std::memcpy(text_bytes.data(), text.data(), text.size());
+    emit_u32(code, al, text_bytes.size());
+    for(auto &byte:text_bytes)
+        emit_b8(code, al, byte);
+}
+
+void emit_u32_b32_idx(Vec<uint8_t> &code, Allocator &al, uint32_t idx,
                       uint32_t section_size) {
     /*
     Encodes the integer `i` using LEB128 and adds trailing zeros to always
     occupy 4 bytes. Stores the int `i` at the index `idx` in `code`.
     */
-    std::vector<uint8_t> num = encode_unsigned_leb128(section_size);
+    Vec<uint8_t> num;
+    num.reserve(al, 4);
+    emit_leb128_u32(num, al, section_size);
     std::vector<uint8_t> num_4b = {0x80, 0x80, 0x80, 0x00};
     assert(num.size() <= 4);
     for (uint32_t i = 0; i < num.size(); i++) {
@@ -105,9 +139,9 @@ void emit_u32_b32_idx(Vec<uint8_t> &code, uint32_t idx,
 }
 
 // function to fixup length at the given length index
-void fixup_len(Vec<uint8_t> &code, uint32_t len_idx) {
+void fixup_len(Vec<uint8_t> &code, Allocator &al, uint32_t len_idx) {
     uint32_t section_len = code.size() - len_idx - 4u;
-    emit_u32_b32_idx(code, len_idx, section_len);
+    emit_u32_b32_idx(code, al, len_idx, section_len);
 }
 
 // function to emit length placeholder
@@ -120,15 +154,39 @@ uint32_t emit_len_placeholder(Vec<uint8_t> &code, Allocator &al) {
     return len_idx;
 }
 
-// function to emit a i32.const instruction
-void emit_i32_const(Vec<uint8_t> &code, Allocator &al, int32_t x) {
-    code.push_back(al, 0x41);
-    emit_i32(code, al, x);
+void emit_export_fn(Vec<uint8_t> &code, Allocator &al, const std::string& name,
+                    uint32_t idx) {
+    emit_str(code, al, name);
+    emit_b8(code, al, 0x00); // for exporting function
+    emit_u32(code, al, idx);
 }
 
-// function to emit end of wasm expression
-void emit_expr_end(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x0B);
+void emit_import_fn(Vec<uint8_t> &code, Allocator &al, const std::string &mod_name,
+                const std::string& fn_name, uint32_t type_idx) 
+{
+    emit_str(code, al, mod_name);
+    emit_str(code, al, fn_name);
+    emit_b8(code, al, 0x00); // for importing function
+    emit_u32(code, al, type_idx);
+}
+
+void emit_import_mem(Vec<uint8_t> &code, Allocator &al, const std::string &mod_name,
+                 const std::string& mem_name, uint32_t min_limit, uint32_t /* max_limit */) {
+    emit_str(code, al, mod_name);
+    emit_str(code, al, mem_name);
+    emit_b8(code, al, 0x02); // for importing memory
+    emit_b8(code, al, 0x00); // for specifying min page limit of memory
+    // max page limit can also be specifid, but currently omitting it.
+    emit_u32(code, al, min_limit);
+}
+
+void encode_section(Vec<uint8_t> &des, Vec<uint8_t> &section_content, Allocator &al, uint32_t section_id){
+    // every section in WebAssembly is encoded by adding its section id, followed by the content size and lastly the contents
+    emit_u32(des, al, section_id);
+    emit_u32(des, al, section_content.size());
+    for(auto &byte:section_content){
+        des.push_back(al, byte);
+    }
 }
 
 // function to emit get local variable at given index
@@ -143,57 +201,314 @@ void emit_set_local(Vec<uint8_t> &code, Allocator &al, uint32_t idx) {
     emit_u32(code, al, idx);
 }
 
-// function to emit i32.add instruction
-void emit_i32_add(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x6A);
-}
-
-// function to emit i32.sub instruction
-void emit_i32_sub(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x6B);
-}
-
-// function to emit i32.mul instruction
-void emit_i32_mul(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x6C);
-}
-
-// function to emit i32.div instruction
-void emit_i32_div(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x6D);
-}
-
-void emit_i64_add(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x7C);
-}
-
-void emit_i64_sub(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x7D);
-}
-
-void emit_i64_mul(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x7E);
-}
-
-void emit_i64_div(Vec<uint8_t> &code, Allocator &al) {
-    code.push_back(al, 0x7F);
-}
-
 // function to emit call instruction
 void emit_call(Vec<uint8_t> &code, Allocator &al, uint32_t idx) {
     code.push_back(al, 0x10);
     emit_u32(code, al, idx);
 }
 
-void emit_export_fn(Vec<uint8_t> &code, Allocator &al, const std::string& name,
-                    uint32_t idx) {
-    std::vector<uint8_t> name_bytes(name.size());
-    std::memcpy(name_bytes.data(), name.data(), name.size());
-    emit_u32(code, al, name_bytes.size());
-    for(auto &byte:name_bytes)
-        emit_b8(code, al, byte);
-    emit_b8(code, al, 0x00);
-    emit_u32(code, al, idx);
+// function to emit end of wasm expression
+void emit_expr_end(Vec<uint8_t> &code, Allocator &al) {
+    code.push_back(al, 0x0B);
+}
+
+/**************************** Integer Operations ****************************/
+
+// function to emit a i32.const instruction
+void emit_i32_const(Vec<uint8_t> &code, Allocator &al, int32_t x) {
+    code.push_back(al, 0x41);
+    emit_i32(code, al, x);
+}
+
+// function to emit i32.clz instruction
+void emit_i32_clz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x67); }
+
+// function to emit i32.ctz instruction
+void emit_i32_ctz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x68); }
+
+// function to emit i32.popcnt instruction
+void emit_i32_popcnt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x69); }
+
+// function to emit i32.add instruction
+void emit_i32_add(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6A); }
+
+// function to emit i32.sub instruction
+void emit_i32_sub(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6B); }
+
+// function to emit i32.mul instruction
+void emit_i32_mul(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6C); }
+
+// function to emit i32.div_s instruction
+void emit_i32_div_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6D); }
+
+// function to emit i32.div_u instruction
+void emit_i32_div_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6E); }
+
+// function to emit i32.rem_s instruction
+void emit_i32_rem_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x6F); }
+
+// function to emit i32.rem_u instruction
+void emit_i32_rem_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x70); }
+
+// function to emit i32.and instruction
+void emit_i32_and(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x71); }
+
+// function to emit i32.or instruction
+void emit_i32_or(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x72); }
+
+// function to emit i32.xor instruction
+void emit_i32_xor(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x73); }
+
+// function to emit i32.shl instruction
+void emit_i32_shl(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x74); }
+
+// function to emit i32.shr_s instruction
+void emit_i32_shr_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x75); }
+
+// function to emit i32.shr_u instruction
+void emit_i32_shr_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x76); }
+
+// function to emit i32.rotl instruction
+void emit_i32_rotl(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x77); }
+
+// function to emit i32.rotr instruction
+void emit_i32_rotr(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x78); }
+
+
+// function to emit a i64.const instruction
+void emit_i64_const(Vec<uint8_t> &code, Allocator &al, int64_t x) {
+    code.push_back(al, 0x42);
+    emit_i64(code, al, x);
+}
+
+// function to emit i64.clz instruction
+void emit_i64_clz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x79); }
+
+// function to emit i64.ctz instruction
+void emit_i64_ctz(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7A); }
+
+// function to emit i64.popcnt instruction
+void emit_i64_popcnt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7B); }
+
+// function to emit i64.add instruction
+void emit_i64_add(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7C); }
+
+// function to emit i64.sub instruction
+void emit_i64_sub(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7D); }
+
+// function to emit i64.mul instruction
+void emit_i64_mul(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7E); }
+
+// function to emit i64.div_s instruction
+void emit_i64_div_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x7F); }
+
+// function to emit i64.div_u instruction
+void emit_i64_div_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x80); }
+
+// function to emit i64.rem_s instruction
+void emit_i64_rem_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x81); }
+
+// function to emit i64.rem_u instruction
+void emit_i64_rem_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x82); }
+
+// function to emit i64.and instruction
+void emit_i64_and(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x83); }
+
+// function to emit i64.or instruction
+void emit_i64_or(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x84); }
+
+// function to emit i64.xor instruction
+void emit_i64_xor(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x85); }
+
+// function to emit i64.shl instruction
+void emit_i64_shl(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x86); }
+
+// function to emit i64.shr_s instruction
+void emit_i64_shr_s(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x87); }
+
+// function to emit i64.shr_u instruction
+void emit_i64_shr_u(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x88); }
+
+// function to emit i64.rotl instruction
+void emit_i64_rotl(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x89); }
+
+// function to emit i64.rotr instruction
+void emit_i64_rotr(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8A); }
+
+
+
+/**************************** Floating Point Operations ****************************/
+
+// function to emit a f32.const instruction
+void emit_f32_const(Vec<uint8_t> &code, Allocator &al, float x) {
+    code.push_back(al, 0x43);
+    emit_f32(code, al, x);
+}
+
+// function to emit f32.abs instruction
+void emit_f32_abs(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8B); }
+
+// function to emit f32.neg instruction
+void emit_f32_neg(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8C); }
+
+// function to emit f32.ceil instruction
+void emit_f32_ceil(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8D); }
+
+// function to emit f32.floor instruction
+void emit_f32_floor(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8E); }
+
+// function to emit f32.trunc instruction
+void emit_f32_trunc(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x8F); }
+
+// function to emit f32.nearest instruction
+void emit_f32_nearest(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x90); }
+
+// function to emit f32.sqrt instruction
+void emit_f32_sqrt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x91); }
+
+// function to emit f32.add instruction
+void emit_f32_add(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x92); }
+
+// function to emit f32.sub instruction
+void emit_f32_sub(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x93); }
+
+// function to emit f32.mul instruction
+void emit_f32_mul(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x94); }
+
+// function to emit f32.div instruction
+void emit_f32_div(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x95); }
+
+// function to emit f32.min instruction
+void emit_f32_min(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x96); }
+
+// function to emit f32.max instruction
+void emit_f32_max(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x97); }
+
+// function to emit f32.copysign instruction
+void emit_f32_copysign(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x98); }
+
+
+// function to emit a f64.const instruction
+void emit_f64_const(Vec<uint8_t> &code, Allocator &al, double x) {
+    code.push_back(al, 0x44);
+    emit_f64(code, al, x);
+}
+
+// function to emit f64.abs instruction
+void emit_f64_abs(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x99); }
+
+// function to emit f64.neg instruction
+void emit_f64_neg(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9A); }
+
+// function to emit f64.ceil instruction
+void emit_f64_ceil(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9B); }
+
+// function to emit f64.floor instruction
+void emit_f64_floor(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9C); }
+
+// function to emit f64.trunc instruction
+void emit_f64_trunc(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9D); }
+
+// function to emit f64.nearest instruction
+void emit_f64_nearest(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9E); }
+
+// function to emit f64.sqrt instruction
+void emit_f64_sqrt(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0x9F); }
+
+// function to emit f64.add instruction
+void emit_f64_add(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA0); }
+
+// function to emit f64.sub instruction
+void emit_f64_sub(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA1); }
+
+// function to emit f64.mul instruction
+void emit_f64_mul(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA2); }
+
+// function to emit f64.div instruction
+void emit_f64_div(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA3); }
+
+// function to emit f64.min instruction
+void emit_f64_min(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA4); }
+
+// function to emit f64.max instruction
+void emit_f64_max(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA5); }
+
+// function to emit f64.copysign instruction
+void emit_f64_copysign(Vec<uint8_t> &code, Allocator &al) { code.push_back(al, 0xA6); }
+
+
+// function to emit string
+void emit_str_const(Vec<uint8_t> &code, Allocator &al, uint32_t mem_idx, const std::string &text) {
+    emit_u32(code, al, 0U); // for active mode of memory with default mem_idx of 0
+    emit_i32_const(code, al, (int32_t)mem_idx); // specifying memory location as instructions
+    emit_expr_end(code, al); // end instructions
+    emit_str(code, al, text);
+}
+
+
+void emit_unreachable(Vec<uint8_t> &code, Allocator &al){
+    code.push_back(al, 0x00);
+}
+
+void save_js_glue(std::string filename){
+    std::string js_glue = 
+R"(function define_imports(memory, outputBuffer, stdout_print) {
+    const printNum = (num) => outputBuffer.push(num.toString());
+    const printStr = (startIdx, strSize) => outputBuffer.push(
+        new TextDecoder("utf8").decode(new Uint8Array(memory.buffer, startIdx, strSize)));
+    const flushBuffer = () => {
+        stdout_print(outputBuffer.join(" ") + "\n");
+        outputBuffer.length = 0;
+    }
+    var imports = {
+        js: {
+            memory: memory,
+            /* functions */
+            print_i32: printNum,
+            print_i64: printNum,
+            print_f32: printNum,
+            print_f64: printNum,
+            print_str: printStr,
+            flush_buf: flushBuffer,
+        },
+    };
+    return imports;
+}
+
+async function run_wasm(bytes, imports) {
+    var res;
+    try { res = await WebAssembly.instantiate(bytes, imports); }
+    catch (e) { console.log(e); return 1 /* non-zero return value */; }
+    const { _lcompilers_main } = res.instance.exports;
+    try { _lcompilers_main() }
+    catch (e) { return 1; }
+    return 0;
+}
+
+async function execute_code(bytes, stdout_print) {
+    var outputBuffer = [];
+    var memory = new WebAssembly.Memory({ initial: 10, maximum: 100 }); // initial 640Kb and max 6.4Mb
+    var imports = define_imports(memory, outputBuffer, stdout_print);
+    const exec_status = await run_wasm(bytes, imports);
+    return (exec_status ? outputBuffer[0] : 0); // the last element denotes the actual execution status
+}
+
+const fs = require("fs");
+const wasmBuffer = fs.readFileSync(")" + filename + 
+R"(");
+execute_code(wasmBuffer, (text) => process.stdout.write(text)).then().catch((e) => console.log(e))
+)";
+    filename += ".js";
+    std::ofstream out(filename);
+    out << js_glue;
+    out.close();
+}
+
+void save_bin(Vec<uint8_t> &code, std::string filename){
+    std::ofstream out(filename);
+    out.write((const char*) code.p, code.size());
+    out.close();
+    save_js_glue(filename);
 }
 
 }  // namespace wasm

--- a/src/libasr/codegen/wasm_to_wat.cpp
+++ b/src/libasr/codegen/wasm_to_wat.cpp
@@ -27,7 +27,7 @@ void WASMDecoder::load_file(std::string filename) {
 
 void WASMDecoder::decode_type_section(uint32_t offset) {
     // read type section contents
-    uint32_t no_of_func_types = read_unsigned_num(wasm_bytes, offset);
+    uint32_t no_of_func_types = read_u32(wasm_bytes, offset);
     DEBUG("no_of_func_types: " + std::to_string(no_of_func_types));
     func_types.resize(al, no_of_func_types);
 
@@ -38,71 +38,120 @@ void WASMDecoder::decode_type_section(uint32_t offset) {
         offset++;
 
         // read result type 1
-        uint32_t no_of_params = read_unsigned_num(wasm_bytes, offset);
+        uint32_t no_of_params = read_u32(wasm_bytes, offset);
         func_types.p[i].param_types.resize(al, no_of_params);
 
         for (uint32_t j = 0; j < no_of_params; j++) {
-            func_types.p[i].param_types.p[j] = wasm_bytes[offset++];
+            func_types.p[i].param_types.p[j] = read_b8(wasm_bytes, offset);
         }
 
-        uint32_t no_of_results = read_unsigned_num(wasm_bytes, offset);
+        uint32_t no_of_results = read_u32(wasm_bytes, offset);
         func_types.p[i].result_types.resize(al, no_of_results);
 
         for (uint32_t j = 0; j < no_of_results; j++) {
-            func_types.p[i].result_types.p[j] = wasm_bytes[offset++];
+            func_types.p[i].result_types.p[j] = read_b8(wasm_bytes, offset);
+        }
+    }
+}
+
+void WASMDecoder::decode_imports_section(uint32_t offset) {
+    // read imports section contents
+    uint32_t no_of_imports = read_u32(wasm_bytes, offset);
+    DEBUG("no_of_imports: " + std::to_string(no_of_imports));
+    imports.resize(al, no_of_imports);
+
+    for (uint32_t i = 0; i < no_of_imports; i++) {
+        uint32_t mod_name_size = read_u32(wasm_bytes, offset);
+        imports.p[i].mod_name.resize(mod_name_size); // do not pass al to this resize as it is std::string.resize()
+        for (uint32_t j = 0; j < mod_name_size; j++) {
+            imports.p[i].mod_name[j] = read_b8(wasm_bytes, offset);
+        }
+        
+        uint32_t name_size = read_u32(wasm_bytes, offset);
+        imports.p[i].name.resize(name_size); // do not pass al to this resize as it is std::string.resize()
+        for (uint32_t j = 0; j < name_size; j++) {
+            imports.p[i].name[j] = read_b8(wasm_bytes, offset);
+        }
+
+        imports.p[i].kind = read_b8(wasm_bytes, offset);
+
+        switch (imports.p[i].kind)
+        {
+            case 0x00: {
+                imports.p[i].type_idx = read_u32(wasm_bytes, offset);
+                break;
+            }
+            case 0x02: {
+                uint8_t byte = read_b8(wasm_bytes, offset);
+                if(byte == 0x00){
+                    imports.p[i].mem_page_size_limits.first = read_u32(wasm_bytes, offset);
+                    imports.p[i].mem_page_size_limits.second = imports.p[i].mem_page_size_limits.first;
+                }
+                else {
+                    LFORTRAN_ASSERT(byte == 0x01);
+                    imports.p[i].mem_page_size_limits.first = read_u32(wasm_bytes, offset);
+                    imports.p[i].mem_page_size_limits.second = read_u32(wasm_bytes, offset);
+                }
+                break;
+            }
+            
+            default: {
+                std::cout << "Only importing functions and memory are currently supported" << std::endl;
+                LFORTRAN_ASSERT(false);
+            }
         }
     }
 }
 
 void WASMDecoder::decode_function_section(uint32_t offset) {
     // read function section contents
-    uint32_t no_of_indices = read_unsigned_num(wasm_bytes, offset);
+    uint32_t no_of_indices = read_u32(wasm_bytes, offset);
     DEBUG("no_of_indices: " + std::to_string(no_of_indices));
     type_indices.resize(al, no_of_indices);
 
     for (uint32_t i = 0; i < no_of_indices; i++) {
-        type_indices.p[i] = read_unsigned_num(wasm_bytes, offset);
+        type_indices.p[i] = read_u32(wasm_bytes, offset);
     }
 }
 
 void WASMDecoder::decode_export_section(uint32_t offset) {
     // read export section contents
-    uint32_t no_of_exports = read_unsigned_num(wasm_bytes, offset);
+    uint32_t no_of_exports = read_u32(wasm_bytes, offset);
     DEBUG("no_of_exports: " + std::to_string(no_of_exports));
     exports.resize(al, no_of_exports);
 
     for (uint32_t i = 0; i < no_of_exports; i++) {
-        uint32_t name_size = read_unsigned_num(wasm_bytes, offset);
+        uint32_t name_size = read_u32(wasm_bytes, offset);
         exports.p[i].name.resize(name_size); // do not pass al to this resize as it is std::string.resize()
         for (uint32_t j = 0; j < name_size; j++) {
-            exports.p[i].name[j] = wasm_bytes[offset++];
+            exports.p[i].name[j] = read_b8(wasm_bytes, offset);
         }
         DEBUG("export name: " + exports.p[i].name);
-        exports.p[i].kind = wasm_bytes[offset++];
+        exports.p[i].kind = read_b8(wasm_bytes, offset);
         DEBUG("export kind: " + std::to_string(exports.p[i].kind));
-        exports.p[i].index = read_unsigned_num(wasm_bytes, offset);
+        exports.p[i].index = read_u32(wasm_bytes, offset);
         DEBUG("export index: " + std::to_string(exports.p[i].index));
     }
 }
 
 void WASMDecoder::decode_code_section(uint32_t offset) {
     // read code section contents
-    uint32_t no_of_codes = read_unsigned_num(wasm_bytes, offset);
+    uint32_t no_of_codes = read_u32(wasm_bytes, offset);
     DEBUG("no_of_codes: " + std::to_string(no_of_codes));
     codes.resize(al, no_of_codes);
 
     for (uint32_t i = 0; i < no_of_codes; i++) {
-        codes.p[i].size = read_unsigned_num(wasm_bytes, offset);
+        codes.p[i].size = read_u32(wasm_bytes, offset);
         uint32_t code_start_offset = offset;
-        uint32_t no_of_locals = read_unsigned_num(wasm_bytes, offset);
+        uint32_t no_of_locals = read_u32(wasm_bytes, offset);
         DEBUG("no_of_locals: " + std::to_string(no_of_locals));
         codes.p[i].locals.resize(al, no_of_locals);
 
         DEBUG("Entering loop");
         for (uint32_t j = 0U; j < no_of_locals; j++) {
-            codes.p[i].locals.p[j].count = read_unsigned_num(wasm_bytes, offset);
+            codes.p[i].locals.p[j].count = read_u32(wasm_bytes, offset);
             DEBUG("count: " + std::to_string(codes.p[i].locals.p[j].count));
-            codes.p[i].locals.p[j].type = wasm_bytes[offset++];
+            codes.p[i].locals.p[j].type = read_b8(wasm_bytes, offset);
             DEBUG("type: " + std::to_string(codes.p[i].locals.p[j].type));
         }
         DEBUG("Exiting loop");
@@ -114,17 +163,48 @@ void WASMDecoder::decode_code_section(uint32_t offset) {
     }
 }
 
+void WASMDecoder::decode_data_section(uint32_t offset) {
+    // read code section contents
+    uint32_t no_of_data_segments = read_u32(wasm_bytes, offset);
+    DEBUG("no_of_data_segments: " + std::to_string(no_of_data_segments));
+    data_segments.resize(al, no_of_data_segments);
+
+    for (uint32_t i = 0; i < no_of_data_segments; i++) {
+        uint32_t num = read_u32(wasm_bytes, offset);
+        if(num != 0){
+            throw LFortran::LFortranException("Only active default memory (index = 0) is currently supported");
+        }
+
+        {
+            WASM_INSTS_VISITOR::WATVisitor v = WASM_INSTS_VISITOR::WATVisitor(wasm_bytes, offset, "", "");
+            v.decode_instructions();
+            data_segments.p[i].insts = v.src;
+            offset = v.offset;
+        }
+
+        uint32_t text_size = read_u32(wasm_bytes, offset);
+        data_segments.p[i].text.resize(text_size); // do not pass al to this resize as it is std::string.resize()
+        for (uint32_t j = 0; j < text_size; j++) {
+            data_segments.p[i].text[j] = read_b8(wasm_bytes, offset);
+        }
+    }
+}
+
 void WASMDecoder::decode_wasm() {
     // first 8 bytes are magic number and wasm version number
     // currently, in this first version, we are skipping them
     uint32_t index = 8U;
 
     while (index < wasm_bytes.size()) {
-        uint32_t section_id = read_unsigned_num(wasm_bytes, index);
-        uint32_t section_size = read_unsigned_num(wasm_bytes, index);
+        uint32_t section_id = read_u32(wasm_bytes, index);
+        uint32_t section_size = read_u32(wasm_bytes, index);
         switch (section_id) {
             case 1U:
                 decode_type_section(index);
+                // exit(0);
+                break;
+            case 2U:
+                decode_imports_section(index);
                 // exit(0);
                 break;
             case 3U:
@@ -137,6 +217,10 @@ void WASMDecoder::decode_wasm() {
                 break;
             case 10U:
                 decode_code_section(index);
+                // exit(0)
+                break;
+            case 11U:
+                decode_data_section(index);
                 // exit(0)
                 break;
             default:
@@ -152,10 +236,33 @@ void WASMDecoder::decode_wasm() {
 
 std::string WASMDecoder::get_wat() {
     std::string result = "(module";
+    std::string indent = "\n    ";
+    for(uint32_t i = 0U; i < func_types.size(); i++){
+        result += indent + "(type (;" + std::to_string(i)+ ";) (func (param";
+        for (uint32_t j = 0; j < func_types[i].param_types.size(); j++) {
+            result += " " + var_type_to_string[func_types[i].param_types.p[j]];
+        }
+        result += ") (result";
+        for (uint32_t j = 0; j < func_types[i].result_types.size(); j++) {
+            result += " " + var_type_to_string[func_types[i].result_types.p[j]];
+        }
+        result += ")))";
+    }
+
+    for(uint32_t i = 0; i < imports.size(); i++){
+        result += indent + "(import \"" + imports[i].mod_name + "\" \"" + imports[i].name + "\" ";
+        if(imports[i].kind == 0x00){
+            result += "(func (;" + std::to_string(i) + ";) (type " + std::to_string(imports[i].type_idx) + ")))";
+        }
+        else if(imports[i].kind == 0x02){
+            result += "(memory (;0;) " + std::to_string(imports[i].mem_page_size_limits.first) + "))";
+        }
+    }
+
     for (uint32_t i = 0; i < type_indices.size(); i++) {
-        result += "\n    (func $" + std::to_string(i);
-        result += "\n        (param";
         uint32_t func_index = type_indices.p[i];
+        result += indent + "(func $" + std::to_string(func_index);
+        result += " (type " + std::to_string(func_index) + ") (param";
         for (uint32_t j = 0; j < func_types[func_index].param_types.size(); j++) {
             result += " " + var_type_to_string[func_types[func_index].param_types.p[j]];
         }
@@ -164,7 +271,7 @@ std::string WASMDecoder::get_wat() {
             result += " " + var_type_to_string[func_types[func_index].result_types.p[j]];
         }
         result += ")";
-        result += "\n        (local";
+        result += indent + "    (local";
         for (uint32_t j = 0; j < codes.p[i].locals.size(); j++) {
             for (uint32_t k = 0; k < codes.p[i].locals.p[j].count; k++) {
                 result += " " + var_type_to_string[codes.p[i].locals.p[j].type];
@@ -173,18 +280,22 @@ std::string WASMDecoder::get_wat() {
         result += ")";
 
         {
-            WASM_INSTS_VISITOR::WATVisitor v = WASM_INSTS_VISITOR::WATVisitor();
-            v.indent = "\n        ";
-            v.decode_instructions(wasm_bytes, codes.p[i].insts_start_index);
+            WASM_INSTS_VISITOR::WATVisitor v = WASM_INSTS_VISITOR::WATVisitor(wasm_bytes, codes.p[i].insts_start_index, "", indent + "    ");
+            v.decode_instructions();
             result += v.src;
         }
 
-        result += "\n    )";
+        result += indent + ")";
     }
 
     for (uint32_t i = 0; i < exports.size(); i++) {
-        result += "\n    (export \"" + exports.p[i].name + "\" (" + kind_to_string[exports.p[i].kind] + " $" + std::to_string(exports.p[i].index) + "))";
+        result += indent + "(export \"" + exports.p[i].name + "\" (" + kind_to_string[exports.p[i].kind] + " $" + std::to_string(exports.p[i].index) + "))";
     }
+
+    for(uint32_t i = 0; i < data_segments.size(); i++){
+        result += indent + "(data (;" + std::to_string(i) + ";) (" + data_segments[i].insts + ") \"" + data_segments[i].text + "\")"; 
+    }
+
     result += "\n)\n";
 
     return result;

--- a/src/libasr/codegen/wasm_to_wat.h
+++ b/src/libasr/codegen/wasm_to_wat.h
@@ -11,29 +11,49 @@ class WATVisitor : public BaseWASMVisitor<WATVisitor> {
    public:
     std::string src, indent;
 
-    WATVisitor() : src(""), indent("") {}
+    WATVisitor(Vec<uint8_t> &code, uint32_t offset, std::string src, std::string indent) : BaseWASMVisitor(code, offset), src(src), indent(indent) {}
 
+    void visit_Unreachable() { src += indent + "unreachable"; }
     void visit_Return() { src += indent + "return"; }
-
     void visit_Call(uint32_t func_index) { src += indent + "call " + std::to_string(func_index); }
-
     void visit_LocalGet(uint32_t localidx) { src += indent + "local.get " + std::to_string(localidx); }
-
     void visit_LocalSet(uint32_t localidx) { src += indent + "local.set " + std::to_string(localidx); }
+    void visit_EmtpyBlockType() {}
+    void visit_If() {
+        src += indent + "if";
+        {
+            WATVisitor v = WATVisitor(code, offset, "", indent + "    ");
+            v.decode_instructions();
+            src += v.src;
+            offset = v.offset;
+        }
+        src += indent + "end";
+    }
+    void visit_Else() { src += indent + "\b\b\b\b" + "else"; }
 
-    void visit_I32Const(int value) { src += indent + "i32.const " + std::to_string(value); }
-
+    void visit_I32Const(int32_t value) { src += indent + "i32.const " + std::to_string(value); }
     void visit_I32Add() { src += indent + "i32.add"; }
-    void visit_I64Add() { src += indent + "i64.add"; }
-
     void visit_I32Sub() { src += indent + "i32.sub"; }
-    void visit_I64Sub() { src += indent + "i64.sub"; }
-
     void visit_I32Mul() { src += indent + "i32.mul"; }
-    void visit_I64Mul() { src += indent + "i64.mul"; }
-
     void visit_I32DivS() { src += indent + "i32.div_s"; }
+
+    void visit_I64Const(int64_t value) { src += indent + "i64.const " + std::to_string(value); }
+    void visit_I64Add() { src += indent + "i64.add"; }
+    void visit_I64Sub() { src += indent + "i64.sub"; }
+    void visit_I64Mul() { src += indent + "i64.mul"; }
     void visit_I64DivS() { src += indent + "i64.div_s"; }
+
+    void visit_F32Const(float value) { src += indent + "f32.const " + std::to_string(value); }
+    void visit_F32Add() { src += indent + "f32.add"; }
+    void visit_F32Sub() { src += indent + "f32.sub"; }
+    void visit_F32Mul() { src += indent + "f32.mul"; }
+    void visit_F32DivS() { src += indent + "f32.div_s"; }
+    
+    void visit_F64Const(double value) { src += indent + "f64.const " + std::to_string(value); }
+    void visit_F64Add() { src += indent + "f64.add"; }
+    void visit_F64Sub() { src += indent + "f64.sub"; }
+    void visit_F64Mul() { src += indent + "f64.mul"; }
+    void visit_F64DivS() { src += indent + "f64.div_s"; }
 };
 
 }  // namespace WASM_INSTS_VISITOR
@@ -49,9 +69,11 @@ class WASMDecoder {
     Vec<uint8_t> wasm_bytes;
 
     Vec<wasm::FuncType> func_types;
+    Vec<wasm::Import> imports;
     Vec<uint32_t> type_indices;
     Vec<wasm::Export> exports;
     Vec<wasm::Code> codes;
+    Vec<wasm::Data> data_segments;
 
     WASMDecoder(Allocator &al) : al(al) {
         var_type_to_string = {{0x7F, "i32"}, {0x7E, "i64"}, {0x7D, "f32"}, {0x7C, "f64"}};
@@ -66,9 +88,11 @@ class WASMDecoder {
 
     void load_file(std::string filename);
     void decode_type_section(uint32_t offset);
+    void decode_imports_section(uint32_t offset);
     void decode_function_section(uint32_t offset);
     void decode_export_section(uint32_t offset);
     void decode_code_section(uint32_t offset);
+    void decode_data_section(uint32_t offset);
     void decode_wasm();
     std::string get_wat();
 };

--- a/src/libasr/codegen/wasm_utils.h
+++ b/src/libasr/codegen/wasm_utils.h
@@ -33,19 +33,36 @@ struct Code {
     uint32_t insts_start_index;
 };
 
-uint32_t decode_unsigned_leb128(Vec<uint8_t> &code, uint32_t &offset);
+struct Import {
+    std::string mod_name;
+    std::string name;
+    uint8_t kind;
+    union {
+        uint32_t type_idx;
+        std::pair<uint32_t, uint32_t> mem_page_size_limits;
+    };
+};
 
-int32_t decode_signed_leb128(Vec<uint8_t> &code, uint32_t &offset);
+struct Data {
+    std::string insts;
+    std::string text;
+};
 
-uint8_t read_byte(Vec<uint8_t> &code, uint32_t &offset);
+uint32_t decode_leb128_u32(Vec<uint8_t> &code, uint32_t &offset);
+int32_t decode_leb128_i32(Vec<uint8_t> &code, uint32_t &offset);
+int64_t decode_leb128_i64(Vec<uint8_t> &code, uint32_t &offset);
 
-float read_float(Vec<uint8_t> & code, uint32_t & offset);
+uint8_t read_b8(Vec<uint8_t> &code, uint32_t &offset);
 
-double read_double(Vec<uint8_t> & code, uint32_t & offset);
+float read_f32(Vec<uint8_t> & code, uint32_t & offset);
 
-int32_t read_signed_num(Vec<uint8_t> &code, uint32_t &offset);
+double read_f64(Vec<uint8_t> & code, uint32_t & offset);
 
-uint32_t read_unsigned_num(Vec<uint8_t> &code, uint32_t &offset);
+uint32_t read_u32(Vec<uint8_t> &code, uint32_t &offset);
+
+int32_t read_i32(Vec<uint8_t> &code, uint32_t &offset);
+
+int64_t read_i64(Vec<uint8_t> &code, uint32_t &offset);
 
 void hexdump(void *ptr, int buflen);
 

--- a/src/libasr/pass/inline_function_calls.cpp
+++ b/src/libasr/pass/inline_function_calls.cpp
@@ -136,7 +136,6 @@ public:
         scope->erase_symbol("~empty_block");
     }
 
-
     void visit_FunctionCall(const ASR::FunctionCall_t& x) {
         // If this node is visited by any other visitor
         // or it is being visited while inlining another function call
@@ -346,7 +345,7 @@ public:
                 set_empty_block(current_scope, func->base.base.loc);
                 uint64_t block_call_label = label_generator->get_unique_label();
                 ASR::stmt_t* block_call = ASRUtils::STMT(ASR::make_BlockCall_t(al, x.base.base.loc,
-                                                         block_call_label, empty_block));
+                                                        block_call_label, empty_block));
                 label_generator->add_node_with_unique_label((ASR::asr_t*) block_call,
                                                             block_call_label);
                 return_replacer.set_goto_label(block_call_label);

--- a/src/libasr/pass/loop_vectorise.cpp
+++ b/src/libasr/pass/loop_vectorise.cpp
@@ -154,7 +154,7 @@ public:
         }
         ASR::do_loop_head_t vectorised_loop_head;
         vectorised_loop_head.m_start = loop_start;
-        int64_t vector_length_int;
+        int64_t vector_length_int = -1;
         ASRUtils::extract_value(vector_length, vector_length_int);
         // TODO: Add tests for loop sizes not divisible by vector_length.
         vectorised_loop_head.m_end = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.m_head.m_v->base.loc,

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -4,8 +4,9 @@
 #include <libasr/asr.h>
 #include <libasr/string_utils.h>
 #include <libasr/alloc.h>
+#include <lfortran/utils.h>
 // TODO: Remove lpython/lfortran includes, make it compiler agnostic
-#include <lpython/utils.h>
+// #include <lpython/utils.h>
 #include <libasr/pass/do_loops.h>
 #include <libasr/pass/for_all.h>
 #include <libasr/pass/implied_do_loops.h>
@@ -30,6 +31,8 @@
 
 #include <map>
 #include <vector>
+
+#include <iostream>
 
 namespace LCompilers {
 

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -39,8 +39,6 @@
 #include <map>
 #include <vector>
 
-#include <iostream>
-
 namespace LCompilers {
 
     enum ASRPass {

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -4,9 +4,16 @@
 #include <libasr/asr.h>
 #include <libasr/string_utils.h>
 #include <libasr/alloc.h>
-#include <lfortran/utils.h>
+
 // TODO: Remove lpython/lfortran includes, make it compiler agnostic
-// #include <lpython/utils.h>
+#if __has_include(<lfortran/utils.h>)
+    #include <lfortran/utils.h>
+#endif
+
+#if __has_include(<lpython/utils.h>)
+    #include <lpython/utils.h>
+#endif
+
 #include <libasr/pass/do_loops.h>
 #include <libasr/pass/for_all.h>
 #include <libasr/pass/implied_do_loops.h>

--- a/src/libasr/wasm_instructions.txt
+++ b/src/libasr/wasm_instructions.txt
@@ -1,9 +1,10 @@
+0x40 ⇒ emtpy_block_type
 0x00 ⇒ unreachable
 0x01 ⇒ nop
 -- 0x02 bt:blocktype (in:instr)* 0x0B ⇒ block bt in* end
 -- 0x03 bt:blocktype (in:instr)* 0x0B ⇒ loop bt in* end
--- 0x04 bt:blocktype (in:instr)* 0x0B ⇒ if bt in* else 𝜖 end
--- 0x05 (in2:instr)* 0x0B ⇒ else bt in*1 else in*2 end
+0x04 ⇒ if
+0x05 ⇒ else
 0x0C u32:labelidx:𝑙 ⇒ br 𝑙
 0x0D u32:labelidx:𝑙 ⇒ br_if 𝑙
 -- 0x0E 𝑙*:vec(labelidx) 𝑙𝑁:labelidx ⇒ br_table 𝑙* 𝑙𝑁

--- a/tests/reference/cpp-assert1-ba60925.json
+++ b/tests/reference/cpp-assert1-ba60925.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-assert1-ba60925.stdout",
-    "stdout_hash": "0d55633e9fc6c730c143ffb38d0e3c0ea8d6ac7c4b58906557c9ff3f",
+    "stdout_hash": "8b282cfeb74b4f1210b23a62fa9387d3e9ccf972db1f50e3d85bc06b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-assert1-ba60925.stdout
+++ b/tests/reference/cpp-assert1-ba60925.stdout
@@ -17,6 +17,12 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void test_assert();
+namespace {
+}
+
+// Implementations
 void test_assert()
 {
     int a;

--- a/tests/reference/cpp-doconcurrentloop_01-4e9f274.json
+++ b/tests/reference/cpp-doconcurrentloop_01-4e9f274.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-doconcurrentloop_01-4e9f274.stdout",
-    "stdout_hash": "c83c092da6f47e5d8e0d1aec0e6d802915909b0a45fbe2a89c87d861",
+    "stdout_hash": "1fd2ff609df3374483feb7926035378b8f6162f0817e5c9fd8cb66f6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-doconcurrentloop_01-4e9f274.json
+++ b/tests/reference/cpp-doconcurrentloop_01-4e9f274.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-doconcurrentloop_01-4e9f274.stdout",
-    "stdout_hash": "49cff3a01c86b8ce904637d1cd2815a9a2e61ba23d7a640c2946a26c",
+    "stdout_hash": "c83c092da6f47e5d8e0d1aec0e6d802915909b0a45fbe2a89c87d861",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-doconcurrentloop_01-4e9f274.stdout
+++ b/tests/reference/cpp-doconcurrentloop_01-4e9f274.stdout
@@ -32,9 +32,9 @@ void _lpython_main_program()
 
 void main0()
 {
-    Kokkos::View<float[ /* FIXME symbolic dimensions */ ]> a("a");
-    Kokkos::View<float[ /* FIXME symbolic dimensions */ ]> b("b");
-    Kokkos::View<float[ /* FIXME symbolic dimensions */ ]> c("c");
+    Kokkos::View<float[10000]> a("a");
+    Kokkos::View<float[10000]> b("b");
+    Kokkos::View<float[10000]> c("c");
     int nsize;
     float scalar;
     scalar =   1.00000000000000000e+01;
@@ -52,7 +52,7 @@ void triad(const Kokkos::View<float*> &a, const Kokkos::View<float*> &b, float s
     int N;
     N = 1234;
     Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, N - 1+1), KOKKOS_LAMBDA(const long i) {
-        c[i] = a[i] + scalar*b[i];
+        c[i - 0] = a[i - 0] + scalar*b[i - 0];
     });
 }
 

--- a/tests/reference/cpp-doconcurrentloop_01-4e9f274.stdout
+++ b/tests/reference/cpp-doconcurrentloop_01-4e9f274.stdout
@@ -17,6 +17,14 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void _lpython_main_program();
+void main0();
+void triad(const Kokkos::View<float*> &a, const Kokkos::View<float*> &b, float scalar, const Kokkos::View<float*> &c);
+namespace {
+}
+
+// Implementations
 void _lpython_main_program()
 {
     main0();

--- a/tests/reference/cpp-expr12-fd2ea87.json
+++ b/tests/reference/cpp-expr12-fd2ea87.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr12-fd2ea87.stdout",
-    "stdout_hash": "4388c01dad00d8dfd263ff7280f63f1b0d6041a6c4febf0f141db513",
+    "stdout_hash": "35c946cfdef6a2bd02ef28b0605f2c1d821af3326b9e529b0220b0ec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr12-fd2ea87.stdout
+++ b/tests/reference/cpp-expr12-fd2ea87.stdout
@@ -17,6 +17,15 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void _lpython_main_program();
+int32_t check();
+void main0();
+int32_t test(int a, int b);
+namespace {
+}
+
+// Implementations
 void _lpython_main_program()
 {
     main0();

--- a/tests/reference/cpp-expr15-1661c0d.json
+++ b/tests/reference/cpp-expr15-1661c0d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr15-1661c0d.stdout",
-    "stdout_hash": "aa739007190884b8e5b1d3711b0d0ac283777d05ad980af6ea3d7364",
+    "stdout_hash": "70cc2c6b194a476a7b67af334e96c4570e70ea404b65cf667a16aec7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr15-1661c0d.stdout
+++ b/tests/reference/cpp-expr15-1661c0d.stdout
@@ -17,6 +17,18 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void _lpython_main_program();
+double test1();
+std::complex<double> test2();
+int32_t test3();
+std::complex<double> __lpython_overloaded_9__complex(int x, int y);
+float _lfortran_caimag(std::complex<float> x);
+double _lfortran_zaimag(std::complex<double> x);
+namespace {
+}
+
+// Implementations
 void _lpython_main_program()
 {
     std::cout << test1() << std::endl;

--- a/tests/reference/cpp-expr2-09c05ad.json
+++ b/tests/reference/cpp-expr2-09c05ad.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr2-09c05ad.stdout",
-    "stdout_hash": "6c3d7cb4d07c43d82bec9407b178bed4a6f9ef599efe996fb5a0e880",
+    "stdout_hash": "8479eec5f8c040c388befa390463632b86dbb03913a4b3a3d1212b42",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr2-09c05ad.stdout
+++ b/tests/reference/cpp-expr2-09c05ad.stdout
@@ -17,6 +17,12 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void test_boolOp();
+namespace {
+}
+
+// Implementations
 void test_boolOp()
 {
     bool a;

--- a/tests/reference/cpp-expr3-9c516d4.json
+++ b/tests/reference/cpp-expr3-9c516d4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr3-9c516d4.stdout",
-    "stdout_hash": "e70b5b12dec6e5a6668e7f2500104f3b2d03cff16b376d01932aa1e5",
+    "stdout_hash": "5b2d0f5178378312fe2c1bcc8d023d5c3250248f4d414d98e645f7e6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr3-9c516d4.stdout
+++ b/tests/reference/cpp-expr3-9c516d4.stdout
@@ -17,6 +17,12 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void test_cast();
+namespace {
+}
+
+// Implementations
 void test_cast()
 {
     int a;

--- a/tests/reference/cpp-expr5-1de0e30.json
+++ b/tests/reference/cpp-expr5-1de0e30.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr5-1de0e30.stdout",
-    "stdout_hash": "c4b94ece3efeb57e537a3b5084d608c2e5974fd699370c007042803a",
+    "stdout_hash": "49e7a502b06e9092a40717c402ffb22c8e9041f2afe4a5d0210cfa4c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr5-1de0e30.stdout
+++ b/tests/reference/cpp-expr5-1de0e30.stdout
@@ -17,6 +17,12 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void test_StrOp_concat();
+namespace {
+}
+
+// Implementations
 void test_StrOp_concat()
 {
     std::string s;

--- a/tests/reference/cpp-expr6-f337f4f.json
+++ b/tests/reference/cpp-expr6-f337f4f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr6-f337f4f.stdout",
-    "stdout_hash": "8f34b920c822d50a500e646436e421cf7fcc64dd332d5316d964d480",
+    "stdout_hash": "89cf078cdb62250496f64ac5bbcd5fa308760e51af457624515ddd89",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr6-f337f4f.stdout
+++ b/tests/reference/cpp-expr6-f337f4f.stdout
@@ -17,6 +17,12 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void test_ifexp();
+namespace {
+}
+
+// Implementations
 void test_ifexp()
 {
     int a;

--- a/tests/reference/cpp-expr7-529bd53.json
+++ b/tests/reference/cpp-expr7-529bd53.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr7-529bd53.stdout",
-    "stdout_hash": "227536c5ef75ca8fd246a81458be780688da5eee1ad4548a9f0236f1",
+    "stdout_hash": "cbb3219cd63cea6bdd16b996b99616ae41b2b57dd71b05caeaf427de",
     "stderr": "cpp-expr7-529bd53.stderr",
     "stderr_hash": "28509dd59a386eebd632340a550d14299cd2a921ef6dc3ac7dbe7fe9",
     "returncode": 0

--- a/tests/reference/cpp-expr7-529bd53.stdout
+++ b/tests/reference/cpp-expr7-529bd53.stdout
@@ -17,6 +17,18 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void _lpython_main_program();
+void main0();
+void test_pow();
+int32_t test_pow_1(int a, int b);
+int32_t __lpython_overloaded_0__pow(int x, int y);
+float _lfortran_caimag(std::complex<float> x);
+double _lfortran_zaimag(std::complex<double> x);
+namespace {
+}
+
+// Implementations
 void _lpython_main_program()
 {
     main0();

--- a/tests/reference/cpp-expr8-704cece.json
+++ b/tests/reference/cpp-expr8-704cece.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr8-704cece.stdout",
-    "stdout_hash": "ec8070c7470e9a3b5cf8f32c2d8e5205615607f1d905771ecb2e9554",
+    "stdout_hash": "c92b25d717ad1695250b3f3e685f13f94b655fb4e5928d04994acc98",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr8-704cece.stdout
+++ b/tests/reference/cpp-expr8-704cece.stdout
@@ -17,6 +17,15 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void test_binop();
+int32_t __lpython_overloaded_2___lpython_floordiv(int a, int b);
+float _lfortran_caimag(std::complex<float> x);
+double _lfortran_zaimag(std::complex<double> x);
+namespace {
+}
+
+// Implementations
 void test_binop()
 {
     bool b1;

--- a/tests/reference/cpp-expr9-48868e9.json
+++ b/tests/reference/cpp-expr9-48868e9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr9-48868e9.stdout",
-    "stdout_hash": "e4d80059478260fc38f6128ed9b398d529e908e451a2d9df8071cf17",
+    "stdout_hash": "e6178dd2619299b23b5bbb49bdf1667785f00037b0dcd85c6df7383b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr9-48868e9.stdout
+++ b/tests/reference/cpp-expr9-48868e9.stdout
@@ -17,6 +17,17 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void _lpython_main_program();
+void main0();
+int32_t test_return_1(int a);
+std::string test_return_2(int a);
+int32_t test_return_3(int a);
+void test_return_4(int a);
+namespace {
+}
+
+// Implementations
 void _lpython_main_program()
 {
     main0();

--- a/tests/reference/cpp-expr_11-422c839.json
+++ b/tests/reference/cpp-expr_11-422c839.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr_11-422c839.stdout",
-    "stdout_hash": "cbe02c12fca11c20822cb21e77939cc0822e41d2fb6f88add106f453",
+    "stdout_hash": "ed5b929f3c9ee51fff1d8cc1043b3f0b47734110cd431b5039abd429",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr_11-422c839.stdout
+++ b/tests/reference/cpp-expr_11-422c839.stdout
@@ -17,6 +17,13 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void _lpython_main_program();
+void f();
+namespace {
+}
+
+// Implementations
 void _lpython_main_program()
 {
     f();

--- a/tests/reference/cpp-loop1-0a8cf3b.json
+++ b/tests/reference/cpp-loop1-0a8cf3b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-loop1-0a8cf3b.stdout",
-    "stdout_hash": "aeabc1a23670692fb997329609385b890d5a192372fbae6492c1a511",
+    "stdout_hash": "8ed38a8b917c268099a66f7a3ba0d4de4495d034dd0d311ca6e8e609",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-loop1-0a8cf3b.stdout
+++ b/tests/reference/cpp-loop1-0a8cf3b.stdout
@@ -17,6 +17,16 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void _lpython_main_program();
+void main0();
+int32_t test_factorial_1(int x);
+int32_t test_factorial_2(int x);
+int64_t test_factorial_3(int x);
+namespace {
+}
+
+// Implementations
 void _lpython_main_program()
 {
     main0();

--- a/tests/reference/cpp-loop2-0686fc4.json
+++ b/tests/reference/cpp-loop2-0686fc4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-loop2-0686fc4.stdout",
-    "stdout_hash": "5e2209259569860d088350d56ce88ddbde744de45a00acb23cd057e6",
+    "stdout_hash": "a86d4381f0752ce2e9daab0f8622bd0bb1fd8943df1e1783bdefca72",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-loop2-0686fc4.stdout
+++ b/tests/reference/cpp-loop2-0686fc4.stdout
@@ -17,6 +17,14 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void _lpython_main_program();
+void test_for();
+namespace {
+}
+void _xx_lcompilers_changed_exit_xx(int error_code);
+
+// Implementations
 void _lpython_main_program()
 {
     test_for();

--- a/tests/reference/cpp-loop3-6020091.json
+++ b/tests/reference/cpp-loop3-6020091.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-loop3-6020091.stdout",
-    "stdout_hash": "208286689360b8924599c880527ecb42188b3318cd47b0f262df5e60",
+    "stdout_hash": "139189b09e9c982b73eebc2e166bb1c2880a1baa3a927cc549b04f3f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-loop3-6020091.stdout
+++ b/tests/reference/cpp-loop3-6020091.stdout
@@ -17,6 +17,12 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void test_pass();
+namespace {
+}
+
+// Implementations
 void test_pass()
 {
     int a;

--- a/tests/reference/cpp-print_01-026ef17.json
+++ b/tests/reference/cpp-print_01-026ef17.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-print_01-026ef17.stdout",
-    "stdout_hash": "0c3010d6c2c8764d1bdf5f1684b0a27c8e6fd58b01996526ce20c029",
+    "stdout_hash": "dd676c204e4cdac681c5643a3cc25491fdfd826f1f29cea9fe5330a6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-print_01-026ef17.stdout
+++ b/tests/reference/cpp-print_01-026ef17.stdout
@@ -17,6 +17,13 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void _lpython_main_program();
+void f();
+namespace {
+}
+
+// Implementations
 void _lpython_main_program()
 {
     f();

--- a/tests/reference/cpp-test_builtin_pow-56b3f92.json
+++ b/tests/reference/cpp-test_builtin_pow-56b3f92.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-test_builtin_pow-56b3f92.stdout",
-    "stdout_hash": "a024981658a698615a7b6d8ff0b7e94aaf2822b9fadcec85a8cf11ba",
+    "stdout_hash": "21976202ba73f579d9ab991478fa99927d914ada3a6c0e2b2012ff00",
     "stderr": "cpp-test_builtin_pow-56b3f92.stderr",
     "stderr_hash": "180e1adfbb0d9c63a2fffa31951bbd629b3f1950cf0d97ca1389efe5",
     "returncode": 0

--- a/tests/reference/cpp-test_builtin_pow-56b3f92.stdout
+++ b/tests/reference/cpp-test_builtin_pow-56b3f92.stdout
@@ -17,6 +17,27 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void _lpython_main_program();
+void test_pow();
+double __lpython_overloaded_0__abs(double x);
+int32_t __lpython_overloaded_0__pow(int x, int y);
+int64_t __lpython_overloaded_1__pow(long long x, long long y);
+float __lpython_overloaded_2__pow(float x, float y);
+double __lpython_overloaded_3__pow(double x, double y);
+float __lpython_overloaded_4__pow(int x, float y);
+float __lpython_overloaded_5__pow(float x, int y);
+double __lpython_overloaded_6__pow(int x, double y);
+double __lpython_overloaded_7__pow(double x, int y);
+int32_t __lpython_overloaded_8__pow(bool x, bool y);
+std::complex<double> __lpython_overloaded_9__complex(int x, int y);
+std::complex<float> __lpython_overloaded_9__pow(std::complex<float> c, int y);
+float _lfortran_caimag(std::complex<float> x);
+double _lfortran_zaimag(std::complex<double> x);
+namespace {
+}
+
+// Implementations
 void _lpython_main_program()
 {
     test_pow();

--- a/tests/reference/cpp-test_integer_bitnot-20195fd.json
+++ b/tests/reference/cpp-test_integer_bitnot-20195fd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-test_integer_bitnot-20195fd.stdout",
-    "stdout_hash": "bf5368df4a06d35e7e31577d4094f29980be758c45cbed4fa384eee4",
+    "stdout_hash": "7f136f0afed5f480a1e56ab8c7f5300ad60557f3514f2a43d6c98027",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-test_integer_bitnot-20195fd.stdout
+++ b/tests/reference/cpp-test_integer_bitnot-20195fd.stdout
@@ -17,6 +17,13 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
     return r;
 }
 
+// Forward declarations
+void _lpython_main_program();
+void f();
+namespace {
+}
+
+// Implementations
 void _lpython_main_program()
 {
     f();


### PR DESCRIPTION
This PR syncs the current `Libasr` of `LFortran` and `LPython`.

Corresponding MR at `LFortran`: https://gitlab.com/lfortran/lfortran/-/merge_requests/1816

Corresponding PR at `Libasr`: https://github.com/lcompilers/libasr/pull/2

**Notes:**
- Reference tests for both `LFortran` and `LPython` updated.
    - For `LPython`, it seems there is change in reference tests of `cpp` backend only.
- At few places in the code (exactly `4` places, I think), there is a comment starting with `Sync:` indicating slight doubt in the respective `code`/`statement`
- For `LPython`: All tests pass.
- For `LFortran`: Few tests (5 failing tests in `tests/tests.toml` and 4 failing tests in `integration_tests/CMakeLists.txt`) are commented out. The comments are marked with `Sync:` (to ease lookup / to mark as failing due to sync).