### PR TITLE
Improve errror message on type unsupport errors.

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -790,7 +790,7 @@ public:
                 loc);
         }
 
-        return get_type_from_var_annotation(var_annotation, loc, dims, m_args, n_args);
+        return get_type_from_var_annotation(var_annotation, annotation.base.loc, dims, m_args, n_args);
     }
 
     ASR::expr_t *index_add_one(const Location &loc, ASR::expr_t *idx) {

--- a/tests/reference/asr-test_unsupported_type-0d813dd.json
+++ b/tests/reference/asr-test_unsupported_type-0d813dd.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_unsupported_type-0d813dd.stderr",
-    "stderr_hash": "de666af5f0273dba4f002b2cf00eda1524fe16d3dba66583ba26f8fe",
+    "stderr_hash": "1675de57db132a5a4a589070d7c54ff23a57532bd967ccb416ff8c2a",
     "returncode": 2
 }

--- a/tests/reference/asr-test_unsupported_type-0d813dd.stderr
+++ b/tests/reference/asr-test_unsupported_type-0d813dd.stderr
@@ -1,5 +1,5 @@
 semantic error: Unsupported type annotation: i128
- --> tests/errors/test_unsupported_type.py:2:5
+ --> tests/errors/test_unsupported_type.py:2:8
   |
 2 |     i: i128
-  |     ^^^^^^^ 
+  |        ^^^^ 


### PR DESCRIPTION
This patch will improve error msg for [pull_749](https://github.com/lcompilers/lpython/pull/749/)
deal with unspport type 
```
2 |     i: i128
  |     ^^^^^^^
-- to -- >  
2 |     i: i128
  |        ^^^^ 
```
