### PR TITLE
Revert "Correct the build instructions in README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ call build0.bat  # Windows
 Compile LPython:
 
 ```bash
-./build1.sh
+cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_LLVM=yes -DWITH_STACKTRACE=yes -DWITH_LFORTRAN_BINARY_MODFILES=no .
+cmake --build . -j16
 ```
 
 ## Tests:


### PR DESCRIPTION
Reverts lcompilers/lpython#755

We have to revert it, because currently for the CPython based parser, we need to specify `-DWITH_LFORTRAN_BINARY_MODFILES=no`.