### PR TITLE
 Enable Document Symbol Lookup Feature for LSP

### DIFF
--- a/src/libasr/CMakeLists.txt
+++ b/src/libasr/CMakeLists.txt
@@ -81,6 +81,7 @@ if (WITH_LSP)
   set (SRC ${SRC}
       lsp/JSONRPC2Connection.cpp
       lsp/LPythonServer.cpp
+      lsp/MessageHandler.cpp
   )
 endif()
 

--- a/src/libasr/lsp/JSONRPC2Connection.cpp
+++ b/src/libasr/lsp/JSONRPC2Connection.cpp
@@ -113,11 +113,6 @@ void JSONRPC2Connection::send_notification(std::string method, rapidjson::Docume
   body.AddMember("jsonrpc", rapidjson::Value().SetString("2.0", allocator), allocator);
   body.AddMember("method", rapidjson::Value().SetString(method.c_str(), allocator), allocator);
   body.AddMember("params", params, allocator);
-  rapidjson::StringBuffer buffer;
-  buffer.Clear();
-  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-  body.Accept(writer);
-  std::string str_body(buffer.GetString());
   this->_send(body);
 }
 

--- a/src/libasr/lsp/LPythonServer.cpp
+++ b/src/libasr/lsp/LPythonServer.cpp
@@ -109,7 +109,6 @@ struct handle_functions
     std::string path = getPath(uri);
     using LFortran::CompilerOptions;
     CompilerOptions compiler_options;
-    LCompilers::PassManager lpython_pass_manager;
     std::string runtime_library_dir = LFortran::get_runtime_library_dir();
 
     std::vector<LFortran::LPython::lsp_locations> 

--- a/src/libasr/lsp/LPythonServer.cpp
+++ b/src/libasr/lsp/LPythonServer.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <string>
 
 #include <rapidjson/document.h>

--- a/src/libasr/lsp/LPythonServer.cpp
+++ b/src/libasr/lsp/LPythonServer.cpp
@@ -1,4 +1,4 @@
-#include <map>
+#include <iostream>
 #include <string>
 
 #include <rapidjson/document.h>

--- a/src/libasr/lsp/LPythonServer.cpp
+++ b/src/libasr/lsp/LPythonServer.cpp
@@ -6,6 +6,8 @@
 
 #include "LPythonServer.hpp"
 #include "JSONRPC2Connection.hpp"
+#include "MessageHandler.hpp"
+
 struct handle_functions
 {
   JSONRPC2Connection* conn;
@@ -71,45 +73,88 @@ struct handle_functions
         );
   }
 
+  std::string getPath(std::string raw_uri)  {
+    if (raw_uri.compare(0, 7, "file://")) {
+      std::cout << "Warning";
+      return raw_uri;
+    }
+    std::string ret;
+    #ifdef _WIN32
+      // Skipping the initial "/" on Windows
+      size_t i = 8;
+    #else
+      size_t i = 7;
+    #endif
+      auto from_hex = [](unsigned char c) {
+        return c - '0' < 10 ? c - '0' : (c | 32) - 'a' + 10;
+      };
+      for (; i < raw_uri.size(); i++) {
+        if (i + 3 <= raw_uri.size() && raw_uri[i] == '%') {
+          ret.push_back(from_hex(raw_uri[i + 1]) * 16 + from_hex(raw_uri[i + 2]));
+          i += 2;
+        } else
+          ret.push_back(raw_uri[i]);
+      }
+    #ifdef _WIN32
+      std::replace(ret.begin(), ret.end(), '\\', '/');
+      if (ret.size() > 1 && ret[0] >= 'a' && ret[0] <= 'z' && ret[1] == ':') {
+        ret[0] = toupper(ret[0]);
+      }
+    #endif
+
+    return ret;
+  }
+
   void serve_document_symbol(rapidjson::Document &request, JSONRPC2Connection& obj, int rid) {
     std::string uri = request["params"]["textDocument"]["uri"].GetString();
+    std::string path = getPath(uri);
+    using LFortran::CompilerOptions;
+    CompilerOptions compiler_options;
+    LCompilers::PassManager lpython_pass_manager;
+    std::string runtime_library_dir = LFortran::get_runtime_library_dir();
 
-    int start_character = 0;
-    int start_line = 1;
-    int end_character = 10;
-    int end_line = 10;
-
-    rapidjson::Document range_object(rapidjson::kObjectType);
-    rapidjson::Document::AllocatorType &allocator = range_object.GetAllocator(); 
-    range_object.SetObject();
-
-    rapidjson::Document start_detail(rapidjson::kObjectType); 
-    start_detail.SetObject();
-    start_detail.AddMember("character", rapidjson::Value().SetInt(start_character), allocator);
-    start_detail.AddMember("line", rapidjson::Value().SetInt(start_line), allocator);
-    range_object.AddMember("start", start_detail, allocator);
-
-    rapidjson::Document end_detail(rapidjson::kObjectType); 
-    end_detail.SetObject();
-    end_detail.AddMember("character", rapidjson::Value().SetInt(end_character), allocator);
-    end_detail.AddMember("line", rapidjson::Value().SetInt(end_line), allocator);
-    range_object.AddMember("end", end_detail, allocator);
-
-    rapidjson::Document location_object(rapidjson::kObjectType);
-    location_object.SetObject();
-    location_object.AddMember("range", range_object, allocator);
-    location_object.AddMember("uri", rapidjson::Value().SetString(uri.c_str(), allocator), allocator);
+    std::vector<LFortran::LPython::lsp_locations> symbol_lists = LFortran::LPython::get_SymbolLists(path, 
+                          lpython_pass_manager, runtime_library_dir, compiler_options);
 
     rapidjson::Document test_output(rapidjson::kArrayType);
+    rapidjson::Document range_object(rapidjson::kObjectType);
+    rapidjson::Document start_detail(rapidjson::kObjectType); 
+    rapidjson::Document end_detail(rapidjson::kObjectType); 
+    rapidjson::Document location_object(rapidjson::kObjectType);
+    rapidjson::Document test_capture(rapidjson::kObjectType);
+
     test_output.SetArray();
 
-    rapidjson::Document test_capture(rapidjson::kObjectType);
-    test_capture.SetObject();
-    test_capture.AddMember("kind", rapidjson::Value().SetInt(12), allocator);
-    test_capture.AddMember("location", location_object, allocator);
-    test_capture.AddMember("name", rapidjson::Value().SetString("lsp_symbols", allocator), allocator);
-    test_output.PushBack(test_capture, test_output.GetAllocator());
+    for (auto symbol : symbol_lists) {
+      uint32_t start_character = symbol.first_column;
+      uint32_t start_line = symbol.first_line;
+      uint32_t end_character = symbol.last_column;
+      uint32_t end_line = symbol.last_line;
+      std::string name = symbol.symbol_name;
 
+      range_object.SetObject();
+      rapidjson::Document::AllocatorType &allocator = range_object.GetAllocator(); 
+
+      start_detail.SetObject();
+      start_detail.AddMember("character", rapidjson::Value().SetInt(start_character), allocator);
+      start_detail.AddMember("line", rapidjson::Value().SetInt(start_line), allocator);
+      range_object.AddMember("start", start_detail, allocator);
+
+      end_detail.SetObject();
+      end_detail.AddMember("character", rapidjson::Value().SetInt(end_character), allocator);
+      end_detail.AddMember("line", rapidjson::Value().SetInt(end_line), allocator);
+      range_object.AddMember("end", end_detail, allocator);
+
+      location_object.SetObject();
+      location_object.AddMember("range", range_object, allocator);
+      location_object.AddMember("uri", rapidjson::Value().SetString(uri.c_str(), allocator), allocator);
+
+      test_capture.SetObject();
+      test_capture.AddMember("kind", rapidjson::Value().SetInt(12), allocator);
+      test_capture.AddMember("location", location_object, allocator);
+      test_capture.AddMember("name", rapidjson::Value().SetString(name.c_str(), allocator), allocator);
+      test_output.PushBack(test_capture, test_output.GetAllocator());
+    }
     obj.write_message(rid, test_output);
   }
 };

--- a/src/libasr/lsp/LPythonServer.cpp
+++ b/src/libasr/lsp/LPythonServer.cpp
@@ -74,10 +74,8 @@ struct handle_functions
   }
 
   std::string getPath(std::string raw_uri)  {
-    if (raw_uri.compare(0, 7, "file://")) {
-      std::cout << "Warning";
+    if (raw_uri.compare(0, 7, "file://"))
       return raw_uri;
-    }
     std::string ret;
     #ifdef _WIN32
       // Skipping the initial "/" on Windows

--- a/src/libasr/lsp/LPythonServer.hpp
+++ b/src/libasr/lsp/LPythonServer.hpp
@@ -4,7 +4,14 @@
 #include <string>
 #include <rapidjson/document.h>
 
+#include <libasr/asr.h>
+#include <lpython/python_ast.h>
+#include <libasr/pass/pass_manager.h>
+#include <libasr/utils.h>
+#include <lpython/semantics/python_ast_to_asr.h>
+
 #include "JSONRPC2Connection.hpp"
+#include "MessageHandler.hpp"
 
 class LPythonServer {
     public:

--- a/src/libasr/lsp/LPythonServer.hpp
+++ b/src/libasr/lsp/LPythonServer.hpp
@@ -2,6 +2,7 @@
 #define LPYTHON_SERVER_HPP
 
 #include <string>
+#include <iostream>
 #include <rapidjson/document.h>
 
 #include <libasr/asr.h>

--- a/src/libasr/lsp/LPythonServer.hpp
+++ b/src/libasr/lsp/LPythonServer.hpp
@@ -2,7 +2,6 @@
 #define LPYTHON_SERVER_HPP
 
 #include <string>
-#include <iostream>
 #include <rapidjson/document.h>
 
 #include <libasr/asr.h>

--- a/src/libasr/lsp/LPythonServer.hpp
+++ b/src/libasr/lsp/LPythonServer.hpp
@@ -4,9 +4,6 @@
 #include <string>
 #include <rapidjson/document.h>
 
-#include <libasr/asr.h>
-#include <lpython/python_ast.h>
-#include <libasr/pass/pass_manager.h>
 #include <libasr/utils.h>
 #include <lpython/semantics/python_ast_to_asr.h>
 

--- a/src/libasr/lsp/MessageHandler.cpp
+++ b/src/libasr/lsp/MessageHandler.cpp
@@ -1,21 +1,38 @@
 #include "MessageHandler.hpp"
 
 namespace LFortran::LPython {
-       std::vector<lsp_locations> get_SymbolLists(const std::string &infile,
-           LCompilers::PassManager& pass_manager,
-           const std::string &runtime_library_dir,
-           LFortran::CompilerOptions &compiler_options) {
-               Allocator al(4*1024);
-               LFortran::diag::Diagnostics diagnostics;
-               LFortran::LocationManager lm;
-               lm.in_filename = infile;
-               std::string input = LFortran::read_file(infile);
-               lm.init_simple(input);
-               LFortran::Result<LFortran::LPython::AST::ast_t*> r1 = LFortran::parse_python_file(
-                   al, runtime_library_dir, infile, diagnostics, compiler_options.new_parser);
-               LFortran::LPython::AST::ast_t* ast = r1.result;
-               std::vector<lsp_locations> symbol_list = get_symbol_locations(al, *ast, diagnostics, true, infile, lm);
-               return symbol_list;
+    std::vector<lsp_locations> get_SymbolLists(const std::string &infile,
+        const std::string &runtime_library_dir,
+        LFortran::CompilerOptions &compiler_options) {
+            Allocator al(4*1024);
+            LFortran::diag::Diagnostics diagnostics;
+            LFortran::LocationManager lm;
+            lm.in_filename = infile;
+            std::string input = LFortran::read_file(infile);
+            lm.init_simple(input);
+            LFortran::Result<LFortran::LPython::AST::ast_t*> r1 = LFortran::parse_python_file(
+                al, runtime_library_dir, infile, diagnostics, compiler_options.new_parser);
+            LFortran::LPython::AST::ast_t* ast = r1.result;
+            LFortran::Result<LFortran::ASR::TranslationUnit_t*> x = LFortran::LPython::python_ast_to_asr(al, *ast, diagnostics, true,
+            compiler_options.disable_main, compiler_options.symtab_only, infile);
+            std::vector<lsp_locations> symbol_lists;
+            lsp_locations loc;
+            for (auto &a : x.result->m_global_scope->get_scope()) {
+                std::string symbol_name = a.first;
+                uint32_t first_line;
+                uint32_t last_line;
+                uint32_t first_column;
+                uint32_t last_column;
+                lm.pos_to_linecol(a.second->base.loc.first, first_line, first_column);
+                lm.pos_to_linecol(a.second->base.loc.last, last_line, last_column);
+                loc.first_column = first_column;
+                loc.last_column = last_column;
+                loc.first_line = first_line;
+                loc.last_line = last_line;
+                loc.symbol_name = symbol_name;
+                symbol_lists.push_back(loc);
+            }
+            return symbol_lists;
        }
 }
 

--- a/src/libasr/lsp/MessageHandler.cpp
+++ b/src/libasr/lsp/MessageHandler.cpp
@@ -1,0 +1,21 @@
+#include "MessageHandler.hpp"
+
+namespace LFortran::LPython {
+       std::vector<lsp_locations> get_SymbolLists(const std::string &infile,
+           LCompilers::PassManager& pass_manager,
+           const std::string &runtime_library_dir,
+           LFortran::CompilerOptions &compiler_options) {
+               Allocator al(4*1024);
+               LFortran::diag::Diagnostics diagnostics;
+               LFortran::LocationManager lm;
+               lm.in_filename = infile;
+               std::string input = LFortran::read_file(infile);
+               lm.init_simple(input);
+               LFortran::Result<LFortran::LPython::AST::ast_t*> r1 = LFortran::parse_python_file(
+                   al, runtime_library_dir, infile, diagnostics, compiler_options.new_parser);
+               LFortran::LPython::AST::ast_t* ast = r1.result;
+               std::vector<lsp_locations> symbol_list = get_symbol_locations(al, *ast, diagnostics, true, infile, lm);
+               return symbol_list;
+       }
+}
+

--- a/src/libasr/lsp/MessageHandler.cpp
+++ b/src/libasr/lsp/MessageHandler.cpp
@@ -28,8 +28,8 @@ namespace LFortran::LPython {
                 lm.pos_to_linecol(a.second->base.loc.last, last_line, last_column);
                 loc.first_column = first_column;
                 loc.last_column = last_column;
-                loc.first_line = first_line;
-                loc.last_line = last_line;
+                loc.first_line = first_line-1;
+                loc.last_line = last_line-1;
                 loc.symbol_name = symbol_name;
                 symbol_lists.push_back(loc);
             }

--- a/src/libasr/lsp/MessageHandler.cpp
+++ b/src/libasr/lsp/MessageHandler.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "MessageHandler.hpp"
 
 namespace LFortran::LPython {

--- a/src/libasr/lsp/MessageHandler.cpp
+++ b/src/libasr/lsp/MessageHandler.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "MessageHandler.hpp"
 
 namespace LFortran::LPython {

--- a/src/libasr/lsp/MessageHandler.cpp
+++ b/src/libasr/lsp/MessageHandler.cpp
@@ -1,6 +1,7 @@
 #include "MessageHandler.hpp"
 
 namespace LFortran::LPython {
+
     std::vector<lsp_locations> get_SymbolLists(const std::string &infile,
         const std::string &runtime_library_dir,
         LFortran::CompilerOptions &compiler_options) {
@@ -34,5 +35,6 @@ namespace LFortran::LPython {
             }
             return symbol_lists;
        }
+       
 }
 

--- a/src/libasr/lsp/MessageHandler.hpp
+++ b/src/libasr/lsp/MessageHandler.hpp
@@ -1,4 +1,3 @@
-
 #ifndef MESSAGE_HANDLER_HPP
 #define MESSAGE_HANDLER_HPP
  
@@ -9,8 +8,14 @@
 #include <lpython/python_ast.h>
  
 namespace LFortran::LPython {
+       struct lsp_locations {
+              std::string symbol_name;
+              uint32_t first_line;
+              uint32_t first_column;
+              uint32_t last_line;
+              uint32_t last_column;
+       };
        std::vector<lsp_locations> get_SymbolLists(const std::string &infile,
-       LCompilers::PassManager& pass_manager,
        const std::string &runtime_library_dir,
        LFortran::CompilerOptions &compiler_options);
 }

--- a/src/libasr/lsp/MessageHandler.hpp
+++ b/src/libasr/lsp/MessageHandler.hpp
@@ -7,6 +7,7 @@
 #include <lpython/semantics/python_ast_to_asr.h>
  
  namespace LFortran::LPython {
+       
        struct lsp_locations {
               std::string symbol_name;
               uint32_t first_line;
@@ -17,5 +18,6 @@
        std::vector<lsp_locations> get_SymbolLists(const std::string &infile,
        const std::string &runtime_library_dir,
        LFortran::CompilerOptions &compiler_options);
+       
 }
 #endif

--- a/src/libasr/lsp/MessageHandler.hpp
+++ b/src/libasr/lsp/MessageHandler.hpp
@@ -1,0 +1,17 @@
+
+#ifndef MESSAGE_HANDLER_HPP
+#define MESSAGE_HANDLER_HPP
+ 
+#include <libasr/asr.h>
+#include <lpython/semantics/python_ast_to_asr.h>
+#include <lpython/parser/parser.h>
+#include <libasr/pass/pass_manager.h>
+#include <lpython/python_ast.h>
+ 
+namespace LFortran::LPython {
+       std::vector<lsp_locations> get_SymbolLists(const std::string &infile,
+       LCompilers::PassManager& pass_manager,
+       const std::string &runtime_library_dir,
+       LFortran::CompilerOptions &compiler_options);
+}
+#endif

--- a/src/libasr/lsp/MessageHandler.hpp
+++ b/src/libasr/lsp/MessageHandler.hpp
@@ -1,13 +1,12 @@
 #ifndef MESSAGE_HANDLER_HPP
 #define MESSAGE_HANDLER_HPP
- 
-#include <libasr/asr.h>
-#include <lpython/semantics/python_ast_to_asr.h>
+
+#include <lpython/utils.h>
 #include <lpython/parser/parser.h>
-#include <libasr/pass/pass_manager.h>
-#include <lpython/python_ast.h>
+#include <libasr/string_utils.h>
+#include <lpython/semantics/python_ast_to_asr.h>
  
-namespace LFortran::LPython {
+ namespace LFortran::LPython {
        struct lsp_locations {
               std::string symbol_name;
               uint32_t first_line;

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -29,6 +29,7 @@
 
 
 namespace LFortran::LPython {
+    
 // Does a CPython style lookup for a module:
 // * First the current directory (this is incorrect, we need to do it relative to the current file)
 // * Then the LPython runtime directory

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -3843,48 +3843,6 @@ std::string get_parent_dir(const std::string &path) {
     return path.substr(0,idx);
 }
 
-std::vector<lsp_locations> symbol_information(LFortran::ASR::TranslationUnit_t *x,
-                const LFortran::LocationManager &lm) {
-    std::vector<lsp_locations> symbol_lists;
-    lsp_locations loc;
-    for (auto &a : x->m_global_scope->get_scope()) {
-        std::string symbol_name = a.first;
-        uint32_t first_line;
-        uint32_t last_line;
-        uint32_t first_column;
-        uint32_t last_column;
-        lm.pos_to_linecol(a.second->base.loc.first, first_line, first_column);
-        lm.pos_to_linecol(a.second->base.loc.last, last_line, last_column);
-        loc.first_column = first_column;
-        loc.last_column = last_column;
-        loc.first_line = first_line;
-        loc.last_line = last_line;
-        loc.symbol_name = symbol_name;
-        symbol_lists.push_back(loc);
-    }
- return symbol_lists;
-}
- 
-std::vector<lsp_locations> get_symbol_locations(Allocator &al, LFortran::LPython::AST::ast_t &ast,
-                 LFortran::diag::Diagnostics &diagnostics, bool main_module,
-                 std::string file_path, const LFortran::LocationManager &lm) {
-    std::map<int, LFortran::ASR::symbol_t *> ast_overload;
-    std::string parent_dir = get_parent_dir(file_path);
-    LFortran::LPython::AST::Module_t *ast_m =
-        LFortran::LPython::AST::down_cast2<LFortran::LPython::AST::Module_t>(
-            &ast);
-    
-    LFortran::ASR::asr_t *unit;
-    auto res = symbol_table_visitor(al, *ast_m, diagnostics, main_module,
-                                    ast_overload, parent_dir);
-    if (res.ok) {
-    unit = res.result;
-    }
-    LFortran::ASR::TranslationUnit_t *tu =
-        LFortran::ASR::down_cast2<LFortran::ASR::TranslationUnit_t>(unit);
-    return symbol_information(tu, lm);
-}
-
 Result<ASR::TranslationUnit_t*> python_ast_to_asr(Allocator &al,
     AST::ast_t &ast, diag::Diagnostics &diagnostics, bool main_module,
     bool disable_main, bool symtab_only, std::string file_path)

--- a/src/lpython/semantics/python_ast_to_asr.h
+++ b/src/lpython/semantics/python_ast_to_asr.h
@@ -5,16 +5,6 @@
 #include <libasr/asr.h>
 
 namespace LFortran::LPython {
-    struct lsp_locations {
-    std::string symbol_name;
-    uint32_t first_line;
-    uint32_t first_column;
-    uint32_t last_line;
-    uint32_t last_column;
-    };
-    std::vector<lsp_locations> get_symbol_locations(Allocator &al, LFortran::LPython::AST::ast_t &ast,
-        LFortran::diag::Diagnostics &diagnostics, bool main_module,
-        std::string file_path, const LFortran::LocationManager &lm);
     std::string pickle_python(AST::ast_t &ast, bool colors=false, bool indent=false);
     std::string pickle_tree_python(AST::ast_t &ast, bool colors=true);
     Result<ASR::TranslationUnit_t*> python_ast_to_asr(Allocator &al,

--- a/src/lpython/semantics/python_ast_to_asr.h
+++ b/src/lpython/semantics/python_ast_to_asr.h
@@ -5,6 +5,7 @@
 #include <libasr/asr.h>
 
 namespace LFortran::LPython {
+    
     std::string pickle_python(AST::ast_t &ast, bool colors=false, bool indent=false);
     std::string pickle_tree_python(AST::ast_t &ast, bool colors=true);
     Result<ASR::TranslationUnit_t*> python_ast_to_asr(Allocator &al,

--- a/src/lpython/semantics/python_ast_to_asr.h
+++ b/src/lpython/semantics/python_ast_to_asr.h
@@ -5,7 +5,16 @@
 #include <libasr/asr.h>
 
 namespace LFortran::LPython {
-
+    struct lsp_locations {
+    std::string symbol_name;
+    uint32_t first_line;
+    uint32_t first_column;
+    uint32_t last_line;
+    uint32_t last_column;
+    };
+    std::vector<lsp_locations> get_symbol_locations(Allocator &al, LFortran::LPython::AST::ast_t &ast,
+        LFortran::diag::Diagnostics &diagnostics, bool main_module,
+        std::string file_path, const LFortran::LocationManager &lm);
     std::string pickle_python(AST::ast_t &ast, bool colors=false, bool indent=false);
     std::string pickle_tree_python(AST::ast_t &ast, bool colors=true);
     Result<ASR::TranslationUnit_t*> python_ast_to_asr(Allocator &al,


### PR DESCRIPTION
This PR is a part of #441 which enables document lookup features in LSP.

In the existing codebase, the file `lpython/src/libasr/lsp/LpythonServer.cpp` has hard coded information of a symbol. This PR will get the document symbols from the ASR and send this information to the vscode extension.

**Steps to reproduce the result:** 
```bash
git clone git@github.com:ankitaS11/LPython.git && cd LPython && git checkout lsp/features/document_symbol
```

Now build the LPython binary, libraries, along with LSP binary. Refer https://github.com/lcompilers/lpython#compile-lpython for instructions. 

Compile LPython with LSP flag

```bash
cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_LLVM=yes -DWITH_STACKTRACE=yes -DWITH_LFORTRAN_BINARY_MODFILES=no -DWITH_LSP=yes .
cmake --build . -j16
```

For the extension part, clone the extension repository and build the extension: (it’s expected that nodejs and npm are installed on your system)

```bash
git@github.com:ankitaS11/custom-vscode-linter.git && cd custom-vscode-linter
# Mention the path of the binary generated for lsp (lpython/src/bin/lpython) as an executable path in the file named `client.ts`.
# ^^^ This is a must!
```

**Building Extension**

```bash
npm install && npm run compile
```

Once installation is done, enter the custom-vscode-linter folder, open VSCode and launch the extension using ctrl + shift + D for debugging mode, else open extension.ts file and press ctrl + F5 to run the extension, and select VSCode Extension Development if a dropdown appears.

Now create a new “LPython” file and save the file or try for document symbol lookup by pressing (Ctrl + Shift + O).

Thanks @certik for all the guidance with this PR. 

cc: @certik 