### PR TITLE
LSP: use the new parser in there

### DIFF
--- a/src/libasr/lsp/LPythonServer.cpp
+++ b/src/libasr/lsp/LPythonServer.cpp
@@ -108,6 +108,7 @@ struct handle_functions
     std::string path = getPath(uri);
     using LFortran::CompilerOptions;
     CompilerOptions compiler_options;
+    compiler_options.new_parser = true;
     std::string runtime_library_dir = LFortran::get_runtime_library_dir();
 
     std::vector<LFortran::LPython::lsp_locations> 


### PR DESCRIPTION
This avoids issues with finding Python