### PR TITLE
[Parser] Add `type-comment` support in new parser

### DIFF
--- a/src/lpython/parser/parser.yy
+++ b/src/lpython/parser/parser.yy
@@ -614,6 +614,11 @@ function_def
         $$ = FUNCTION_01($1, $3, $5, $9, @$); }
     | decorators_opt KW_DEF id "(" parameter_list_opt ")" "->" expr ":"
         sep statements { $$ = FUNCTION_02($1, $3, $5, $8, $11, @$); }
+    | decorators_opt KW_DEF id "(" parameter_list_opt ")" ":" TK_TYPE_COMMENT TK_NEWLINE
+        statements { $$ = FUNCTION_03($1, $3, $5, $10, $8, @$); }
+    | decorators_opt KW_DEF id "(" parameter_list_opt ")" "->" expr ":"
+        TK_TYPE_COMMENT TK_NEWLINE statements {
+            $$ = FUNCTION_04($1, $3, $5, $8, $12, $10, @$); }
     ;
 
 class_def
@@ -631,6 +636,16 @@ async_func_def
         statements { $$ = ASYNC_FUNCTION_03($3, $5, $9, @$); }
     | KW_ASYNC KW_DEF id "(" parameter_list_opt ")" "->" expr ":"
         sep statements { $$ = ASYNC_FUNCTION_04($3, $5, $8, $11, @$); }
+    | decorators KW_ASYNC KW_DEF id "(" parameter_list_opt ")" ":" TK_TYPE_COMMENT
+        TK_NEWLINE statements { $$ = ASYNC_FUNCTION_05($1, $4, $6, $11, $9, @$); }
+    | decorators KW_ASYNC KW_DEF id "(" parameter_list_opt ")" "->" expr ":"
+        TK_TYPE_COMMENT TK_NEWLINE statements {
+        $$ = ASYNC_FUNCTION_06($1, $4, $6, $9, $13, $11, @$); }
+    | KW_ASYNC KW_DEF id "(" parameter_list_opt ")" ":" TK_TYPE_COMMENT TK_NEWLINE
+        statements { $$ = ASYNC_FUNCTION_07($3, $5, $10, $8, @$); }
+    | KW_ASYNC KW_DEF id "(" parameter_list_opt ")" "->" expr ":"
+        TK_TYPE_COMMENT TK_NEWLINE statements {
+        $$ = ASYNC_FUNCTION_08($3, $5, $8, $12, $10, @$); }
     ;
 
 async_for_stmt

--- a/src/lpython/parser/parser.yy
+++ b/src/lpython/parser/parser.yy
@@ -534,6 +534,10 @@ with_statement
     : KW_WITH with_item_list ":" sep statements { $$ = WITH($2, $5, @$); }
     | KW_WITH "(" with_item_list "," ")" ":" sep statements {
         $$ = WITH($3, $8, @$); }
+    | KW_WITH with_item_list ":" TK_TYPE_COMMENT TK_NEWLINE
+        statements { $$ = WITH_01($2, $6, $4, @$); }
+    | KW_WITH "(" with_item_list "," ")" ":" TK_TYPE_COMMENT
+        TK_NEWLINE statements { $$ = WITH_01($3, $9, $7, @$); }
     ;
 
 decorators_opt
@@ -664,6 +668,10 @@ async_with_stmt
         $$ = ASYNC_WITH($3, $6, @$); }
     | KW_ASYNC KW_WITH "(" with_item_list "," ")" ":" sep statements {
         $$ = ASYNC_WITH($4, $9, @$); }
+    | KW_ASYNC KW_WITH with_item_list ":" TK_TYPE_COMMENT
+        TK_NEWLINE statements { $$ = ASYNC_WITH_01($3, $7, $5, @$); }
+    | KW_ASYNC KW_WITH "(" with_item_list "," ")" ":" TK_TYPE_COMMENT
+        TK_NEWLINE statements { $$ = ASYNC_WITH_01($4, $10, $8, @$); }
     ;
 
 while_statement

--- a/src/lpython/parser/parser.yy
+++ b/src/lpython/parser/parser.yy
@@ -638,6 +638,10 @@ async_for_stmt
         $$ = ASYNC_FOR_01($3, $5, $8, @$); }
     | KW_ASYNC KW_FOR tuple_item KW_IN expr ":" sep statements KW_ELSE ":" sep
         statements { $$ = ASYNC_FOR_02($3, $5, $8, $12, @$); }
+    | KW_ASYNC KW_FOR tuple_item KW_IN expr ":" TK_TYPE_COMMENT TK_NEWLINE statements {
+        $$ = ASYNC_FOR_03($3, $5, $9, $7, @$); }
+    | KW_ASYNC KW_FOR tuple_item KW_IN expr ":" TK_TYPE_COMMENT TK_NEWLINE statements
+        KW_ELSE ":" sep statements { $$ = ASYNC_FOR_04($3, $5, $9, $13, $7, @$); }
     ;
 
 async_with_stmt

--- a/src/lpython/parser/parser.yy
+++ b/src/lpython/parser/parser.yy
@@ -374,6 +374,7 @@ target_list
 
 assignment_statement
     : target_list tuple_item { $$ = ASSIGNMENT($1, $2, @$); }
+    | target_list tuple_item TK_TYPE_COMMENT { $$ = ASSIGNMENT2($1, $2, $3, @$); }
     ;
 
 augassign_statement

--- a/src/lpython/parser/semantics.h
+++ b/src/lpython/parser/semantics.h
@@ -425,6 +425,14 @@ static inline Args *FUNC_ARGS(Allocator &al, Location &l,
         make_FunctionDef_t(p.m_a, l, name2char(id), args->arguments, \
         STMTS(stmts), stmts.size(), EXPRS(decorator), decorator.size(), \
         EXPR(return), nullptr)
+#define FUNCTION_03(decorator, id, args, stmts, type_comment, l) \
+        make_FunctionDef_t(p.m_a, l, name2char(id), args->arguments, \
+        STMTS(stmts), stmts.size(), EXPRS(decorator), decorator.size(), \
+        nullptr, extract_type_comment(p.m_a, type_comment))
+#define FUNCTION_04(decorator, id, args, return, stmts, type_comment, l) \
+        make_FunctionDef_t(p.m_a, l, name2char(id), args->arguments, \
+        STMTS(stmts), stmts.size(), EXPRS(decorator), decorator.size(), \
+        EXPR(return), extract_type_comment(p.m_a, type_comment))
 
 #define CLASS_01(decorator, id, stmts, l) make_ClassDef_t(p.m_a, l, \
         name2char(id), nullptr, 0, nullptr, 0, \
@@ -449,6 +457,22 @@ static inline Args *FUNC_ARGS(Allocator &al, Location &l,
 #define ASYNC_FUNCTION_04(id, args, return, stmts, l) \
         make_AsyncFunctionDef_t(p.m_a, l, name2char(id), args->arguments, \
         STMTS(stmts), stmts.size(), nullptr, 0, EXPR(return), nullptr)
+#define ASYNC_FUNCTION_05(decorator, id, args, stmts, type_comment, l) \
+        make_AsyncFunctionDef_t(p.m_a, l, name2char(id), args->arguments, \
+        STMTS(stmts), stmts.size(), EXPRS(decorator), decorator.size(), \
+        nullptr, extract_type_comment(p.m_a, type_comment))
+#define ASYNC_FUNCTION_06(decorator, id, args, return, stmts, type_comment, l) \
+        make_AsyncFunctionDef_t(p.m_a, l, name2char(id), args->arguments, \
+        STMTS(stmts), stmts.size(), EXPRS(decorator), decorator.size(), \
+        EXPR(return), extract_type_comment(p.m_a, type_comment))
+#define ASYNC_FUNCTION_07(id, args, stmts, type_comment, l) \
+        make_AsyncFunctionDef_t(p.m_a, l, name2char(id), args->arguments, \
+        STMTS(stmts), stmts.size(), nullptr, 0, nullptr,\
+        extract_type_comment(p.m_a, type_comment))
+#define ASYNC_FUNCTION_08(id, args, return, stmts, type_comment, l) \
+        make_AsyncFunctionDef_t(p.m_a, l, name2char(id), args->arguments, \
+        STMTS(stmts), stmts.size(), nullptr, 0, EXPR(return),\
+        extract_type_comment(p.m_a, type_comment))
 
 #define ASYNC_FOR_01(target, iter, stmts, l) make_AsyncFor_t(p.m_a, l, \
         EXPR(SET_EXPR_CTX_01(SET_STORE_01(target), Store)), EXPR(iter), \

--- a/src/lpython/parser/semantics.h
+++ b/src/lpython/parser/semantics.h
@@ -158,6 +158,9 @@ static inline Vec<ast_t*> SET_STORE_02(Vec<ast_t*> x) {
 #define ASSIGNMENT(targets, val, l) make_Assign_t(p.m_a, l, \
         EXPRS(SET_EXPR_CTX_02(SET_STORE_02(targets), Store)), targets.size(), \
         EXPR(val), nullptr)
+#define ASSIGNMENT2(targets, val, type_comment, l) make_Assign_t(p.m_a, l, \
+        EXPRS(SET_EXPR_CTX_02(SET_STORE_02(targets), Store)), targets.size(), \
+        EXPR(val), extract_type_comment(p.m_a, type_comment))
 
 static inline ast_t* TUPLE_02(Allocator &al, Location &l, Vec<ast_t*> elts) {
     if(is_a<expr_t>(*elts[0]) && elts.size() == 1) {

--- a/src/lpython/parser/semantics.h
+++ b/src/lpython/parser/semantics.h
@@ -310,6 +310,9 @@ static inline withitem_t *WITH_ITEM(Allocator &al, Location &l,
         EXPR(expr), EXPR(SET_EXPR_CTX_01(vars, Store)))
 #define WITH(items, body, l) make_With_t(p.m_a, l, \
         items.p, items.size(), STMTS(body), body.size(), nullptr)
+#define WITH_01(items, body, type_comment, l) make_With_t(p.m_a, l, \
+        items.p, items.size(), STMTS(body), body.size(), \
+        extract_type_comment(p.m_a, type_comment))
 
 static inline arg_t *FUNC_ARG(Allocator &al, Location &l, char *arg, expr_t* e) {
     arg_t *r = al.allocate<arg_t>();
@@ -490,6 +493,9 @@ static inline Args *FUNC_ARGS(Allocator &al, Location &l,
 
 #define ASYNC_WITH(items, body, l) make_AsyncWith_t(p.m_a, l, \
         items.p, items.size(), STMTS(body), body.size(), nullptr)
+#define ASYNC_WITH_01(items, body, type_comment, l) make_AsyncWith_t(p.m_a, l, \
+        items.p, items.size(), STMTS(body), body.size(),  \
+        extract_type_comment(p.m_a, type_comment))
 
 #define WHILE_01(e, stmts, l) make_While_t(p.m_a, l, \
         EXPR(e), STMTS(stmts), stmts.size(), nullptr, 0)

--- a/src/lpython/parser/semantics.h
+++ b/src/lpython/parser/semantics.h
@@ -456,6 +456,13 @@ static inline Args *FUNC_ARGS(Allocator &al, Location &l,
 #define ASYNC_FOR_02(target, iter, stmts, orelse, l) make_AsyncFor_t(p.m_a, l, \
         EXPR(SET_EXPR_CTX_01(SET_STORE_01(target), Store)), EXPR(iter), \
         STMTS(stmts), stmts.size(), STMTS(orelse), orelse.size(), nullptr)
+#define ASYNC_FOR_03(target, iter, stmts, type_comment, l) make_AsyncFor_t(p.m_a, l, \
+        EXPR(SET_EXPR_CTX_01(SET_STORE_01(target), Store)), EXPR(iter), \
+        STMTS(stmts), stmts.size(), nullptr, 0, extract_type_comment(p.m_a, type_comment))
+#define ASYNC_FOR_04(target, iter, stmts, orelse, type_comment, l) make_AsyncFor_t(p.m_a, l, \
+        EXPR(SET_EXPR_CTX_01(SET_STORE_01(target), Store)), EXPR(iter), \
+        STMTS(stmts), stmts.size(), STMTS(orelse), orelse.size(), \
+        extract_type_comment(p.m_a, type_comment))
 
 #define ASYNC_WITH(items, body, l) make_AsyncWith_t(p.m_a, l, \
         items.p, items.size(), STMTS(body), body.size(), nullptr)


### PR DESCRIPTION
I have tried to add support for parsing `type-comments` for almost every case
- [x] `For` (Already completed in #724)
- [x] `AsyncFor`
- [x] `FunctionDef`
- [x] `AsyncFunctionDef`
- [x] `With`
- [x] `AsyncWith`
- [x] `Assignment`
- [ ] `Function Agrs` (TODO)