### PR TITLE
Fix build warning

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -732,7 +732,7 @@ LFORTRAN_API int32_t _lpython_bit_length4(int32_t num)
 LFORTRAN_API int32_t _lpython_bit_length8(int64_t num)
 {
     int32_t res = 0;
-    num = abs(num);
+    num = llabs(num);
     for(; num; num >>= 1, res++);
     return res;
 }


### PR DESCRIPTION
```
/Users/thebigbool/repos/lpython/src/libasr/runtime/lfortran_intrinsics.c:735:11: warning: absolute value function 'abs' given an argument of type 'int64_t' (aka 'long long') but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
    num = abs(num);
```

