### PR TITLE
Declare variables on the same line

### DIFF
--- a/integration_tests/loop_01.py
+++ b/integration_tests/loop_01.py
@@ -1,14 +1,10 @@
 def main0():
-    s: str
-    s = 'aabbcc'
-    c: str
+    s: str = 'aabbcc'; c: str
     for c in s:
         print(c)
 
 def test_issue_770():
-    i: i64
-    res: i64
-    res = 0
+    i: i64; res: i64 = 0
     for i in range(10):
         res += i
     assert res == 45


### PR DESCRIPTION
This is the most natural Python syntax to declare variables on the same
line.