### PR TITLE
Implement separate chaining implicitly via linear probing

### DIFF
--- a/integration_tests/test_dict_01.py
+++ b/integration_tests/test_dict_01.py
@@ -12,5 +12,6 @@ def test_dict():
         assert abs(rollnumber2cpi[i] - i/100.0 - 5.0) <= 1e-12
 
     assert abs(rollnumber2cpi[0] - 1.1) <= 1e-12
+    assert len(rollnumber2cpi) == 1001
 
 test_dict()

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -238,7 +238,7 @@ public:
     llvm_utils(std::make_unique<LLVMUtils>(context, builder.get())),
     list_api(std::make_unique<LLVMList>(context, llvm_utils.get(), builder.get())),
     tuple_api(std::make_unique<LLVMTuple>(context, llvm_utils.get(), builder.get())),
-    dict_api(std::make_unique<LLVMDict>(context, llvm_utils.get(), builder.get())),
+    dict_api(std::make_unique<LLVMDictOptimizedLinearProbing>(context, llvm_utils.get(), builder.get())),
     arr_descr(LLVMArrUtils::Descriptor::get_descriptor(context,
               builder.get(),
               llvm_utils.get(),

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -286,6 +286,13 @@ namespace LFortran {
         is_dict_present(false) {
     }
 
+    LLVMDictOptimizedLinearProbing::LLVMDictOptimizedLinearProbing(
+        llvm::LLVMContext& context_,
+        LLVMUtils* llvm_utils_,
+        llvm::IRBuilder<>* builder_):
+        LLVMDict(context_, llvm_utils_, builder_) {
+        }
+
     llvm::Type* LLVMList::get_list_type(llvm::Type* el_type, std::string& type_code,
                                         int32_t type_size) {
         if( typecode2listtype.find(type_code) != typecode2listtype.end() ) {
@@ -577,10 +584,86 @@ namespace LFortran {
         are_iterators_set = false;
     }
 
-    void LLVMDict::linear_probing(llvm::Value* capacity, llvm::Value* key_hash,
-                                  llvm::Value* key, llvm::Value* key_list,
-                                  llvm::Value* key_mask, llvm::Module& module,
-                                  ASR::ttype_t* key_asr_type, bool for_read) {
+    void LLVMDict::resolve_collision(
+        llvm::Value* capacity, llvm::Value* key_hash,
+        llvm::Value* key, llvm::Value* key_list,
+        llvm::Value* key_mask, llvm::Module& module,
+        ASR::ttype_t* key_asr_type, bool /*for_read*/) {
+        if( !are_iterators_set ) {
+            pos_ptr = builder->CreateAlloca(llvm::Type::getInt32Ty(context), nullptr);
+            is_key_matching_var = builder->CreateAlloca(llvm::Type::getInt1Ty(context), nullptr);
+        }
+        LLVM::CreateStore(*builder, key_hash, pos_ptr);
+
+
+        llvm::BasicBlock *loophead = llvm::BasicBlock::Create(context, "loop.head");
+        llvm::BasicBlock *loopbody = llvm::BasicBlock::Create(context, "loop.body");
+        llvm::BasicBlock *loopend = llvm::BasicBlock::Create(context, "loop.end");
+
+
+        // head
+        llvm_utils->start_new_block(loophead);
+        {
+            llvm::Value* pos = LLVM::CreateLoad(*builder, pos_ptr);
+            llvm::Value* is_key_set = LLVM::CreateLoad(*builder,
+                                        llvm_utils->create_ptr_gep(key_mask, pos));
+            is_key_set = builder->CreateICmpNE(is_key_set,
+                llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 0)));
+            llvm::Value* is_key_matching = llvm::ConstantInt::get(llvm::Type::getInt1Ty(context),
+                                                                  llvm::APInt(1, 0));
+            LLVM::CreateStore(*builder, is_key_matching, is_key_matching_var);
+            llvm::Function *fn = builder->GetInsertBlock()->getParent();
+            llvm::BasicBlock *thenBB = llvm::BasicBlock::Create(context, "then", fn);
+            llvm::BasicBlock *elseBB = llvm::BasicBlock::Create(context, "else");
+            llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont");
+            builder->CreateCondBr(is_key_set, thenBB, elseBB);
+            builder->SetInsertPoint(thenBB);
+            {
+                llvm::Value* original_key = llvm_utils->list_api->read_item(key_list, pos,
+                                                LLVM::is_llvm_struct(key_asr_type), false);
+                is_key_matching = llvm_utils->is_equal_by_value(key, original_key, module,
+                                                                key_asr_type);
+                LLVM::CreateStore(*builder, is_key_matching, is_key_matching_var);
+            }
+            builder->CreateBr(mergeBB);
+
+
+            llvm_utils->start_new_block(elseBB);
+            llvm_utils->start_new_block(mergeBB);
+            // TODO: Allow safe exit if pos becomes key_hash again.
+            // Ideally should not happen as dict will be resized once
+            // load factor touches a threshold (which will always be less than 1)
+            // so there will be some key which will not be set. However for safety
+            // we can add an exit from the loop with a error message.
+            llvm::Value *cond = builder->CreateAnd(is_key_set, builder->CreateNot(
+                                    LLVM::CreateLoad(*builder, is_key_matching_var)));
+            builder->CreateCondBr(cond, loopbody, loopend);
+        }
+
+
+        // body
+        llvm_utils->start_new_block(loopbody);
+        {
+            llvm::Value* pos = LLVM::CreateLoad(*builder, pos_ptr);
+            pos = builder->CreateAdd(pos, llvm::ConstantInt::get(llvm::Type::getInt32Ty(context),
+                                                                 llvm::APInt(32, 1)));
+            pos = builder->CreateSRem(pos, capacity);
+            LLVM::CreateStore(*builder, pos, pos_ptr);
+        }
+
+
+        builder->CreateBr(loophead);
+
+
+        // end
+        llvm_utils->start_new_block(loopend);
+    }
+
+    void LLVMDictOptimizedLinearProbing::resolve_collision(
+        llvm::Value* capacity, llvm::Value* key_hash,
+        llvm::Value* key, llvm::Value* key_list,
+        llvm::Value* key_mask, llvm::Module& module,
+        ASR::ttype_t* key_asr_type, bool for_read) {
         if( !are_iterators_set ) {
             if( !for_read ) {
                 pos_ptr = builder->CreateAlloca(llvm::Type::getInt32Ty(context), nullptr);
@@ -648,15 +731,45 @@ namespace LFortran {
         llvm_utils->start_new_block(loopend);
     }
 
-    void LLVMDict::linear_probing_for_write(llvm::Value* dict, llvm::Value* key_hash,
-                                            llvm::Value* key, llvm::Value* value,
-                                            llvm::Module& module, ASR::ttype_t* key_asr_type,
-                                            ASR::ttype_t* value_asr_type) {
+    void LLVMDict::resolve_collision_for_write(
+        llvm::Value* dict, llvm::Value* key_hash,
+        llvm::Value* key, llvm::Value* value,
+        llvm::Module& module, ASR::ttype_t* key_asr_type,
+        ASR::ttype_t* value_asr_type) {
         llvm::Value* key_list = get_key_list(dict);
         llvm::Value* value_list = get_value_list(dict);
         llvm::Value* key_mask = LLVM::CreateLoad(*builder, get_pointer_to_keymask(dict));
         llvm::Value* capacity = LLVM::CreateLoad(*builder, get_pointer_to_capacity(dict));
-        linear_probing(capacity, key_hash, key, key_list, key_mask, module, key_asr_type);
+        this->resolve_collision(capacity, key_hash, key, key_list, key_mask, module, key_asr_type);
+        llvm::Value* pos = LLVM::CreateLoad(*builder, pos_ptr);
+        llvm_utils->list_api->write_item(key_list, pos, key,
+                                         key_asr_type, module, false);
+        llvm_utils->list_api->write_item(value_list, pos, value,
+                                         value_asr_type, module, false);
+        llvm::Value* key_mask_value = LLVM::CreateLoad(*builder,
+            llvm_utils->create_ptr_gep(key_mask, pos));
+        llvm::Value* is_slot_empty = builder->CreateICmpEQ(key_mask_value,
+            llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 0)));
+        llvm::Value* occupancy_ptr = get_pointer_to_occupancy(dict);
+        is_slot_empty = builder->CreateZExt(is_slot_empty, llvm::Type::getInt32Ty(context));
+        llvm::Value* occupancy = LLVM::CreateLoad(*builder, occupancy_ptr);
+        LLVM::CreateStore(*builder, builder->CreateAdd(occupancy, is_slot_empty),
+                          occupancy_ptr);
+        LLVM::CreateStore(*builder,
+                          llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), llvm::APInt(8, 1)),
+                          llvm_utils->create_ptr_gep(key_mask, pos));
+    }
+
+    void LLVMDictOptimizedLinearProbing::resolve_collision_for_write(
+        llvm::Value* dict, llvm::Value* key_hash,
+        llvm::Value* key, llvm::Value* value,
+        llvm::Module& module, ASR::ttype_t* key_asr_type,
+        ASR::ttype_t* value_asr_type) {
+        llvm::Value* key_list = get_key_list(dict);
+        llvm::Value* value_list = get_value_list(dict);
+        llvm::Value* key_mask = LLVM::CreateLoad(*builder, get_pointer_to_keymask(dict));
+        llvm::Value* capacity = LLVM::CreateLoad(*builder, get_pointer_to_capacity(dict));
+        this->resolve_collision(capacity, key_hash, key, key_list, key_mask, module, key_asr_type);
         llvm::Value* pos = LLVM::CreateLoad(*builder, pos_ptr);
         llvm_utils->list_api->write_item(key_list, pos, key,
                                          key_asr_type, module, false);
@@ -681,9 +794,24 @@ namespace LFortran {
         LLVM::CreateStore(*builder, set_max_2, llvm_utils->create_ptr_gep(key_mask, pos));
     }
 
-    llvm::Value* LLVMDict::linear_probing_for_read(llvm::Value* dict, llvm::Value* key_hash,
-                                                   llvm::Value* key, llvm::Module& module,
-                                                   ASR::ttype_t* key_asr_type) {
+    llvm::Value* LLVMDict::resolve_collision_for_read(
+        llvm::Value* dict, llvm::Value* key_hash,
+        llvm::Value* key, llvm::Module& module,
+        ASR::ttype_t* key_asr_type) {
+        llvm::Value* key_list = get_key_list(dict);
+        llvm::Value* value_list = get_value_list(dict);
+        llvm::Value* key_mask = LLVM::CreateLoad(*builder, get_pointer_to_keymask(dict));
+        llvm::Value* capacity = LLVM::CreateLoad(*builder, get_pointer_to_capacity(dict));
+        this->resolve_collision(capacity, key_hash, key, key_list, key_mask, module, key_asr_type);
+        llvm::Value* pos = LLVM::CreateLoad(*builder, pos_ptr);
+        llvm::Value* item = llvm_utils->list_api->read_item(value_list, pos, true, false);
+        return item;
+    }
+
+    llvm::Value* LLVMDictOptimizedLinearProbing::resolve_collision_for_read(
+        llvm::Value* dict, llvm::Value* key_hash,
+        llvm::Value* key, llvm::Module& module,
+        ASR::ttype_t* key_asr_type) {
         llvm::Value* key_list = get_key_list(dict);
         llvm::Value* value_list = get_value_list(dict);
         llvm::Value* key_mask = LLVM::CreateLoad(*builder, get_pointer_to_keymask(dict));
@@ -707,7 +835,7 @@ namespace LFortran {
         builder->CreateBr(mergeBB);
         llvm_utils->start_new_block(elseBB);
         {
-            linear_probing(capacity, key_hash, key, key_list, key_mask,
+            this->resolve_collision(capacity, key_hash, key, key_list, key_mask,
                            module, key_asr_type, true);
         }
         llvm_utils->start_new_block(mergeBB);
@@ -809,7 +937,7 @@ namespace LFortran {
                 llvm::Value* value = llvm_utils->list_api->read_item(value_list, idx,
                                         LLVM::is_llvm_struct(value_asr_type), false);
                 llvm::Value* key_hash = get_key_hash(current_capacity, key, key_asr_type, *module);
-                linear_probing(current_capacity, key_hash, key, new_key_list,
+                this->resolve_collision(current_capacity, key_hash, key, new_key_list,
                                new_key_mask, *module, key_asr_type);
                 llvm::Value* pos = LLVM::CreateLoad(*builder, pos_ptr);
                 llvm::Value* key_dest = llvm_utils->list_api->read_item(new_key_list, pos,
@@ -883,8 +1011,8 @@ namespace LFortran {
         rehash_all_at_once_if_needed(dict, module, key_asr_type, value_asr_type);
         llvm::Value* current_capacity = LLVM::CreateLoad(*builder, get_pointer_to_capacity(dict));
         llvm::Value* key_hash = get_key_hash(current_capacity, key, key_asr_type, *module);
-        linear_probing_for_write(dict, key_hash, key, value, *module,
-                                 key_asr_type, value_asr_type);
+        this->resolve_collision_for_write(dict, key_hash, key, value, *module,
+                                          key_asr_type, value_asr_type);
     }
 
     llvm::Value* LLVMDict::read_item(llvm::Value* dict, llvm::Value* key,
@@ -892,8 +1020,8 @@ namespace LFortran {
                              bool get_pointer) {
         llvm::Value* current_capacity = LLVM::CreateLoad(*builder, get_pointer_to_capacity(dict));
         llvm::Value* key_hash = get_key_hash(current_capacity, key, key_asr_type, module);
-        llvm::Value* value_ptr = linear_probing_for_read(dict, key_hash, key, module,
-                                                         key_asr_type);
+        llvm::Value* value_ptr = this->resolve_collision_for_read(dict, key_hash, key, module,
+                                                                  key_asr_type);
         if( get_pointer ) {
             return value_ptr;
         }
@@ -920,6 +1048,10 @@ namespace LFortran {
     llvm::Value* LLVMDict::len(llvm::Value* dict) {
         return LLVM::CreateLoad(*builder, get_pointer_to_occupancy(dict));
     }
+
+    LLVMDict::~LLVMDict() {}
+
+    LLVMDictOptimizedLinearProbing::~LLVMDictOptimizedLinearProbing() {}
 
     void LLVMList::resize_if_needed(llvm::Value* list, llvm::Value* n,
                                     llvm::Value* capacity, int32_t type_size,

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -1049,7 +1049,9 @@ namespace LFortran {
         return LLVM::CreateLoad(*builder, get_pointer_to_occupancy(dict));
     }
 
-    LLVMDict::~LLVMDict() {}
+    LLVMDict::~LLVMDict() {
+        typecode2dicttype.clear();
+    }
 
     LLVMDictOptimizedLinearProbing::~LLVMDictOptimizedLinearProbing() {}
 

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -217,7 +217,7 @@ namespace LFortran {
     };
 
     class LLVMDict {
-        private:
+        protected:
 
             llvm::LLVMContext& context;
             LLVMUtils* llvm_utils;
@@ -256,17 +256,20 @@ namespace LFortran {
             llvm::Value* get_key_hash(llvm::Value* capacity, llvm::Value* key,
                                       ASR::ttype_t* key_asr_type, llvm::Module& module);
 
-            void linear_probing(llvm::Value* capacity, llvm::Value* key_hash,
+            virtual
+            void resolve_collision(llvm::Value* capacity, llvm::Value* key_hash,
                                 llvm::Value* key, llvm::Value* key_list,
                                 llvm::Value* key_mask, llvm::Module& module,
                                 ASR::ttype_t* key_asr_type, bool for_read=false);
 
-            void linear_probing_for_write(llvm::Value* dict, llvm::Value* key_hash,
+            virtual
+            void resolve_collision_for_write(llvm::Value* dict, llvm::Value* key_hash,
                                           llvm::Value* key, llvm::Value* value,
                                           llvm::Module& module, ASR::ttype_t* key_asr_type,
                                           ASR::ttype_t* value_asr_type);
 
-            llvm::Value* linear_probing_for_read(llvm::Value* dict, llvm::Value* key_hash,
+            virtual
+            llvm::Value* resolve_collision_for_read(llvm::Value* dict, llvm::Value* key_hash,
                                                  llvm::Value* key, llvm::Module& module,
                                                  ASR::ttype_t* key_asr_type);
 
@@ -297,6 +300,37 @@ namespace LFortran {
                                ASR::Dict_t* dict_type, llvm::Module* module);
 
             llvm::Value* len(llvm::Value* dict);
+
+            virtual ~LLVMDict();
+    };
+
+    class LLVMDictOptimizedLinearProbing: public LLVMDict {
+
+        public:
+
+            LLVMDictOptimizedLinearProbing(llvm::LLVMContext& context_,
+                                    LLVMUtils* llvm_utils,
+                                    llvm::IRBuilder<>* builder);
+
+            virtual
+            void resolve_collision(llvm::Value* capacity, llvm::Value* key_hash,
+                                llvm::Value* key, llvm::Value* key_list,
+                                llvm::Value* key_mask, llvm::Module& module,
+                                ASR::ttype_t* key_asr_type, bool for_read=false);
+
+            virtual
+            void resolve_collision_for_write(llvm::Value* dict, llvm::Value* key_hash,
+                                            llvm::Value* key, llvm::Value* value,
+                                            llvm::Module& module, ASR::ttype_t* key_asr_type,
+                                            ASR::ttype_t* value_asr_type);
+
+            virtual
+            llvm::Value* resolve_collision_for_read(llvm::Value* dict, llvm::Value* key_hash,
+                                                    llvm::Value* key, llvm::Module& module,
+                                                    ASR::ttype_t* key_asr_type);
+
+            virtual ~LLVMDictOptimizedLinearProbing();
+
     };
 
 } // LFortran

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -259,7 +259,7 @@ namespace LFortran {
             void linear_probing(llvm::Value* capacity, llvm::Value* key_hash,
                                 llvm::Value* key, llvm::Value* key_list,
                                 llvm::Value* key_mask, llvm::Module& module,
-                                ASR::ttype_t* key_asr_type);
+                                ASR::ttype_t* key_asr_type, bool for_read=false);
 
             void linear_probing_for_write(llvm::Value* dict, llvm::Value* key_hash,
                                           llvm::Value* key, llvm::Value* value,


### PR DESCRIPTION
Separate chaining in its raw form requires creating linked list for each insertion in the `dict`. This implies expensive `malloc` calls for each insertion. This becomes a major overhead when we scale the number of insertions as can be seen with C++ benchmarks [here](https://gist.github.com/czgdp1807/e7f7b6ca52c57b16b27ec8d0259c6d4a). However the advantage of separate chaining is that when the length of linked list at a given index is 1 then we know for sure that we don't need to compare keys by value as no collision has happened yet.

So, instead of creating LinkedList for each new insertion, I have updated `key_mask` to provide the signal whether linear probing is to be done or not. This way we can have the benefit separate chaining (avoiding comparison of keys by value while reading) and linear probing (cache efficiency, low overhead as `malloc` calls are made only when rehashing the table) both at one time.

~I am yet to decouple the logic into a separate child class of `LLVMDict` so that we can switch between the two collision resolution strategies easily.~

**Note** - The benefit of this should be visible when we will be using derived data structures as keys (such as tuple, or very long strings). For now the [benchmarks](https://gist.github.com/czgdp1807/e7f7b6ca52c57b16b27ec8d0259c6d4a) don't show any slowdowns.