### PR TITLE
Saving LPython's intrinsic modules as ``pyc`` files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,9 @@ set(WITH_LFORTRAN_BINARY_MODFILES YES
 set(WITH_RUNTIME_LIBRARY YES
     CACHE BOOL "Compile and install the runtime library")
 
+set(WITH_INTRINSIC_MODULES no
+    CACHE BOOL "Compile intrinsic modules to .pyc (ASR) at build time")
+
 # Find ZLIB with our custom finder before including LLVM since the finder for LLVM
 # might search for ZLIB again and find the shared libraries instead of the static ones
 find_package(StaticZLIB REQUIRED)

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -57,3 +57,31 @@ set_target_properties(lpython PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/$<0:>
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/$<0:>
     ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/$<0:>)
+
+if (WITH_INTRINSIC_MODULES)
+    macro(LPYTHON_COMPILE_MODULE name)
+        add_custom_command(
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/../runtime/${name}.pyc
+            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/lpython
+            ARGS --disable-main -c ${CMAKE_CURRENT_SOURCE_DIR}/../runtime/${name}.py -o ${name}.o
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../runtime
+            DEPENDS lpython ${CMAKE_CURRENT_SOURCE_DIR}/../runtime/${name}.py ${ARGN}
+            COMMENT "LPython Compiling ${name}.py")
+    endmacro(LPYTHON_COMPILE_MODULE)
+
+    LPYTHON_COMPILE_MODULE(lpython_intrinsic_numpy)
+    LPYTHON_COMPILE_MODULE(lpython_builtin)
+
+    add_custom_target(lpython_intrinsics
+        ALL
+        DEPENDS
+        ${CMAKE_CURRENT_BINARY_DIR}/../runtime/lpython_intrinsic_numpy.pyc
+        ${CMAKE_CURRENT_BINARY_DIR}/../runtime/lpython_builtin.pyc
+    )
+
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/../runtime/lpython_intrinsic_numpy.pyc
+            ${CMAKE_CURRENT_BINARY_DIR}/../runtime/lpython_builtin.pyc
+        DESTINATION share/lfortran/lib
+    )
+endif()

--- a/src/libasr/modfile.cpp
+++ b/src/libasr/modfile.cpp
@@ -57,6 +57,34 @@ std::string save_modfile(const ASR::TranslationUnit_t &m) {
     return b.get_str();
 }
 
+std::string save_pycfile(const ASR::TranslationUnit_t &m) {
+#ifdef WITH_LFORTRAN_BINARY_MODFILES
+    BinaryWriter b;
+#else
+    TextWriter b;
+#endif
+    // Header
+    b.write_string(lfortran_modfile_type_string);
+    b.write_string(LFORTRAN_VERSION);
+
+    // AST section: Original module source code:
+    // Currently empty.
+    // Note: in the future we can save here:
+    // * A path to the original source code
+    // * Hash of the orig source code
+    // * AST binary export of it (this AST only changes if the hash changes)
+
+    // ASR section:
+
+    // Export ASR:
+    // Currently empty.
+
+    // Full ASR:
+    b.write_string(serialize(m));
+
+    return b.get_str();
+}
+
 ASR::TranslationUnit_t* load_modfile(Allocator &al, const std::string &s,
         bool load_symtab_id, SymbolTable &symtab) {
 #ifdef WITH_LFORTRAN_BINARY_MODFILES
@@ -74,6 +102,29 @@ ASR::TranslationUnit_t* load_modfile(Allocator &al, const std::string &s,
     }
     std::string asr_binary = b.read_string();
     ASR::asr_t *asr = deserialize_asr(al, asr_binary, load_symtab_id, symtab);
+
+    ASR::TranslationUnit_t *tu = ASR::down_cast2<ASR::TranslationUnit_t>(asr);
+    return tu;
+}
+
+ASR::TranslationUnit_t* load_pycfile(Allocator &al, const std::string &s,
+        bool load_symtab_id) {
+#ifdef WITH_LFORTRAN_BINARY_MODFILES
+    BinaryReader b(s);
+#else
+    TextReader b(s);
+#endif
+
+    std::string file_type = b.read_string();
+    if (file_type != lfortran_modfile_type_string) {
+        throw LCompilersException("LFortran Modfile format not recognized");
+    }
+    std::string version = b.read_string();
+    if (version != LFORTRAN_VERSION) {
+        throw LCompilersException("Incompatible format: LFortran Modfile was generated using version '" + version + "', but current LFortran version is '" + LFORTRAN_VERSION + "'");
+    }
+    std::string asr_binary = b.read_string();
+    ASR::asr_t *asr = deserialize_asr(al, asr_binary, load_symtab_id);
 
     ASR::TranslationUnit_t *tu = ASR::down_cast2<ASR::TranslationUnit_t>(asr);
     return tu;

--- a/src/libasr/modfile.cpp
+++ b/src/libasr/modfile.cpp
@@ -12,6 +12,34 @@ namespace LFortran {
 
 const std::string lfortran_modfile_type_string = "LFortran Modfile";
 
+inline void save_asr(const ASR::TranslationUnit_t &m, std::string& asr_string) {
+    #ifdef WITH_LFORTRAN_BINARY_MODFILES
+    BinaryWriter b;
+#else
+    TextWriter b;
+#endif
+    // Header
+    b.write_string(lfortran_modfile_type_string);
+    b.write_string(LFORTRAN_VERSION);
+
+    // AST section: Original module source code:
+    // Currently empty.
+    // Note: in the future we can save here:
+    // * A path to the original source code
+    // * Hash of the orig source code
+    // * AST binary export of it (this AST only changes if the hash changes)
+
+    // ASR section:
+
+    // Export ASR:
+    // Currently empty.
+
+    // Full ASR:
+    b.write_string(serialize(m));
+
+    asr_string = b.get_str();
+}
+
 // The save_modfile() and load_modfile() must stay consistent. What is saved
 // must be loaded in exactly the same order.
 
@@ -30,63 +58,19 @@ std::string save_modfile(const ASR::TranslationUnit_t &m) {
         LFORTRAN_ASSERT(ASR::is_a<ASR::Module_t>(*a.second));
         if ((bool&)a) { } // Suppress unused warning in Release mode
     }
-#ifdef WITH_LFORTRAN_BINARY_MODFILES
-    BinaryWriter b;
-#else
-    TextWriter b;
-#endif
-    // Header
-    b.write_string(lfortran_modfile_type_string);
-    b.write_string(LFORTRAN_VERSION);
 
-    // AST section: Original module source code:
-    // Currently empty.
-    // Note: in the future we can save here:
-    // * A path to the original source code
-    // * Hash of the orig source code
-    // * AST binary export of it (this AST only changes if the hash changes)
-
-    // ASR section:
-
-    // Export ASR:
-    // Currently empty.
-
-    // Full ASR:
-    b.write_string(serialize(m));
-
-    return b.get_str();
+    std::string asr_string;
+    save_asr(m, asr_string);
+    return asr_string;
 }
 
 std::string save_pycfile(const ASR::TranslationUnit_t &m) {
-#ifdef WITH_LFORTRAN_BINARY_MODFILES
-    BinaryWriter b;
-#else
-    TextWriter b;
-#endif
-    // Header
-    b.write_string(lfortran_modfile_type_string);
-    b.write_string(LFORTRAN_VERSION);
-
-    // AST section: Original module source code:
-    // Currently empty.
-    // Note: in the future we can save here:
-    // * A path to the original source code
-    // * Hash of the orig source code
-    // * AST binary export of it (this AST only changes if the hash changes)
-
-    // ASR section:
-
-    // Export ASR:
-    // Currently empty.
-
-    // Full ASR:
-    b.write_string(serialize(m));
-
-    return b.get_str();
+    std::string asr_string;
+    save_asr(m, asr_string);
+    return asr_string;
 }
 
-ASR::TranslationUnit_t* load_modfile(Allocator &al, const std::string &s,
-        bool load_symtab_id, SymbolTable &symtab) {
+inline void load_serialised_asr(const std::string &s, std::string& asr_binary) {
 #ifdef WITH_LFORTRAN_BINARY_MODFILES
     BinaryReader b(s);
 #else
@@ -100,7 +84,13 @@ ASR::TranslationUnit_t* load_modfile(Allocator &al, const std::string &s,
     if (version != LFORTRAN_VERSION) {
         throw LCompilersException("Incompatible format: LFortran Modfile was generated using version '" + version + "', but current LFortran version is '" + LFORTRAN_VERSION + "'");
     }
-    std::string asr_binary = b.read_string();
+    asr_binary = b.read_string();
+}
+
+ASR::TranslationUnit_t* load_modfile(Allocator &al, const std::string &s,
+        bool load_symtab_id, SymbolTable &symtab) {
+    std::string asr_binary;
+    load_serialised_asr(s, asr_binary);
     ASR::asr_t *asr = deserialize_asr(al, asr_binary, load_symtab_id, symtab);
 
     ASR::TranslationUnit_t *tu = ASR::down_cast2<ASR::TranslationUnit_t>(asr);
@@ -109,21 +99,8 @@ ASR::TranslationUnit_t* load_modfile(Allocator &al, const std::string &s,
 
 ASR::TranslationUnit_t* load_pycfile(Allocator &al, const std::string &s,
         bool load_symtab_id) {
-#ifdef WITH_LFORTRAN_BINARY_MODFILES
-    BinaryReader b(s);
-#else
-    TextReader b(s);
-#endif
-
-    std::string file_type = b.read_string();
-    if (file_type != lfortran_modfile_type_string) {
-        throw LCompilersException("LFortran Modfile format not recognized");
-    }
-    std::string version = b.read_string();
-    if (version != LFORTRAN_VERSION) {
-        throw LCompilersException("Incompatible format: LFortran Modfile was generated using version '" + version + "', but current LFortran version is '" + LFORTRAN_VERSION + "'");
-    }
-    std::string asr_binary = b.read_string();
+    std::string asr_binary;
+    load_serialised_asr(s, asr_binary);
     ASR::asr_t *asr = deserialize_asr(al, asr_binary, load_symtab_id);
 
     ASR::TranslationUnit_t *tu = ASR::down_cast2<ASR::TranslationUnit_t>(asr);

--- a/src/libasr/modfile.h
+++ b/src/libasr/modfile.h
@@ -8,9 +8,14 @@ namespace LFortran {
     // Save a module to a modfile
     std::string save_modfile(const ASR::TranslationUnit_t &m);
 
+    std::string save_pycfile(const ASR::TranslationUnit_t &m);
+
     // Load a module from a modfile
     ASR::TranslationUnit_t* load_modfile(Allocator &al, const std::string &s,
         bool load_symtab_id, SymbolTable &symtab);
+
+    ASR::TranslationUnit_t* load_pycfile(Allocator &al, const std::string &s,
+        bool load_symtab_id);
 
 }
 

--- a/src/libasr/serialization.cpp
+++ b/src/libasr/serialization.cpp
@@ -307,7 +307,12 @@ void fix_external_symbols(ASR::TranslationUnit_t &unit,
 }
 
 ASR::asr_t* deserialize_asr(Allocator &al, const std::string &s,
-        bool load_symtab_id, SymbolTable &external_symtab) {
+        bool load_symtab_id, SymbolTable & /*external_symtab*/) {
+    return deserialize_asr(al, s, load_symtab_id);
+}
+
+ASR::asr_t* deserialize_asr(Allocator &al, const std::string &s,
+        bool load_symtab_id) {
     ASRDeserializationVisitor v(al, s, load_symtab_id);
     ASR::asr_t *node = v.deserialize_node();
     ASR::TranslationUnit_t *tu = ASR::down_cast2<ASR::TranslationUnit_t>(node);
@@ -318,9 +323,6 @@ ASR::asr_t* deserialize_asr(Allocator &al, const std::string &s,
     p.visit_TranslationUnit(*tu);
 
     LFORTRAN_ASSERT(asr_verify(*tu, false));
-
-    // Suppress a warning for now
-    if ((bool&)external_symtab) {}
 
     return node;
 }

--- a/src/libasr/serialization.h
+++ b/src/libasr/serialization.h
@@ -9,6 +9,8 @@ namespace LFortran {
     std::string serialize(const ASR::TranslationUnit_t &unit);
     ASR::asr_t* deserialize_asr(Allocator &al, const std::string &s,
             bool load_symtab_id, SymbolTable &symtab);
+    ASR::asr_t* deserialize_asr(Allocator &al, const std::string &s,
+            bool load_symtab_id);
 
     void fix_external_symbols(ASR::TranslationUnit_t &unit,
             SymbolTable &external_symtab);

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1307,7 +1307,7 @@ public:
                         al, left->base.loc, left, ASR::cast_kindType::IntegerToReal, dest_type));
                 } else if (ASR::is_a<ASR::TypeParameter_t>(*left_type)) {
                     left = ASR::down_cast<ASR::expr_t>(ASRUtils::make_Cast_t_value(
-                        al, left->base.loc, left, ASR::cast_kindType::TemplateToReal, dest_type));                    
+                        al, left->base.loc, left, ASR::cast_kindType::TemplateToReal, dest_type));
                 }
                 if (ASRUtils::is_integer(*right_type)) {
                     if (ASRUtils::expr_value(right) != nullptr) {
@@ -1428,7 +1428,7 @@ public:
                 } else {
                     throw SemanticError("Both type variables must support addition operation", loc);
                 }
-            } 
+            }
             if (op == ASR::binopType::Div) {
                 if (ASRUtils::has_trait(left_param, ASR::traitType::Divisible)) {
                     dest_type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, 8, nullptr, 0));
@@ -2673,7 +2673,7 @@ public:
                         std::string tvar_name = AST::down_cast<AST::Name_t>(x.m_targets[0])->m_id;
                         // Check if the type variable name is a reserved type keyword
                         const char* type_list[14]
-                            = { "list", "set", "dict", "tuple", 
+                            = { "list", "set", "dict", "tuple",
                                 "i8", "i16", "i32", "i64", "f32",
                                 "f64", "c32", "c64", "str", "bool"};
                         for (int i = 0; i < 14; i++) {
@@ -3064,7 +3064,7 @@ public:
                                             target_type->base.loc);
                     }
                     tmp = ASR::make_Assignment_t(al, x.base.base.loc, target, assign_value, nullptr);
-                    return ;    
+                    return ;
                 }
             }
             if( ASR::is_a<ASR::Pointer_t>(*target_type) &&

--- a/src/lpython/semantics/python_ast_to_asr.h
+++ b/src/lpython/semantics/python_ast_to_asr.h
@@ -5,12 +5,15 @@
 #include <libasr/asr.h>
 
 namespace LFortran::LPython {
-    
+
     std::string pickle_python(AST::ast_t &ast, bool colors=false, bool indent=false);
     std::string pickle_tree_python(AST::ast_t &ast, bool colors=true);
     Result<ASR::TranslationUnit_t*> python_ast_to_asr(Allocator &al,
         LPython::AST::ast_t &ast, diag::Diagnostics &diagnostics,
         bool main_module, bool disable_main, bool symtab_only, std::string file_path);
+
+    int save_pyc_files(const LFortran::ASR::TranslationUnit_t &u,
+                       std::string infile);
 
 } // namespace LFortran
 


### PR DESCRIPTION
https://github.com/lcompilers/lpython/issues/992#issuecomment-1221244033

For now I just save the ASR of a Python file compiled with `-c` option in `.pyc` files. Next steps,

1. Add the possibility first try loading the module from `.pyc` file generated earlier. If not found then compile and re-save in `.pyc` file.
2. Update CMake build files to compile intrinsic modules and save their ASR during LPython's build time. 
3. Test the update end to end.