### PR TITLE
WASM: Support building to wasm

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -108,3 +108,61 @@ jobs:
             set MACOS=0
             call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
             xonsh ci\test.xsh
+
+  build_to_wasm:
+    name: Build LPython to WASM
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: ci/environment.yml
+          extra-specs: |
+            python=3.10
+            bison=3.4
+
+      - uses: hendrikmuhs/ccache-action@main
+        with:
+          variant: sccache
+          key: ${{ github.job }}-${{ matrix.os }}
+
+      - name: Install Emscripten from Git
+        shell: bash -l {0}
+        run: |
+            mkdir $HOME/ext
+            cd $HOME/ext
+
+            git clone https://github.com/emscripten-core/emsdk.git
+            cd emsdk
+
+            # Download and install the latest SDK tools.
+            ./emsdk install latest
+
+            # Make the "latest" SDK "active" for the current user. (writes .emscripten file)
+            ./emsdk activate latest
+
+      - name: Show Emscripten Info
+        shell: bash -l {0}
+        run: |
+            set -ex
+            # Activate PATH and other environment variables in the current terminal
+            source $HOME/ext/emsdk/emsdk_env.sh
+            emcc -v
+            em++ -v
+
+      - name: Build to WASM
+        shell: bash -l {0}
+        run: |
+            set -ex
+            source $HOME/ext/emsdk/emsdk_env.sh # Activate Emscripten
+            ./build_to_wasm.sh
+
+      - name: Test built lpython.wasm
+        shell: bash -l {0}
+        run: |
+            set -ex
+            source $HOME/ext/emsdk/emsdk_env.sh # Activate Emscripten
+            node src/lpython/tests/test_lpython.js

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,6 +158,7 @@ jobs:
         run: |
             set -ex
             source $HOME/ext/emsdk/emsdk_env.sh # Activate Emscripten
+            ./build0.sh
             ./build_to_wasm.sh
 
       - name: Test built lpython.wasm

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,8 @@ output
 *.out
 *.mod
 *.smod
+*.js
+*.wasm
 /.ccls-cache/
 .cache/
 ext/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,12 @@ set(WITH_RUNTIME_LIBRARY YES
 set(WITH_INTRINSIC_MODULES no
     CACHE BOOL "Compile intrinsic modules to .pyc (ASR) at build time")
 
+set(WITH_WHEREAMI yes
+    CACHE BOOL "Include whereami.cpp")
+
+set(WITH_ZLIB yes
+    CACHE BOOL "Compile with ZLIB Library")
+
 # Build to wasm
 set(LPYTHON_BUILD_TO_WASM no
     CACHE BOOL "Compile LPython To WASM")
@@ -281,6 +287,8 @@ message("WITH_LSP: ${WITH_LSP}")
 message("WITH_FMT: ${WITH_FMT}")
 message("WITH_LFORTRAN_BINARY_MODFILES: ${WITH_LFORTRAN_BINARY_MODFILES}")
 message("WITH_RUNTIME_LIBRARY: ${WITH_RUNTIME_LIBRARY}")
+message("WITH_WHEREAMI: ${WITH_WHEREAMI}")
+message("WITH_ZLIB: ${WITH_ZLIB}")
 message("WITH_TARGET_AARCH64: ${WITH_TARGET_AARCH64}")
 message("WITH_TARGET_X86: ${WITH_TARGET_X86}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set(LPYTHON_BUILD_TO_WASM no
 if (LPYTHON_BUILD_TO_WASM)
     set(HAVE_BUILD_TO_WASM yes)
     SET(WITH_WHEREAMI no)
+    SET(WITH_ZLIB no)
     add_definitions("-DHAVE_BUILD_TO_WASM=1")
 endif()
 
@@ -103,9 +104,13 @@ if (WITH_WHEREAMI)
     add_definitions("-DHAVE_WHEREAMI=1")
 endif()
 
-# Find ZLIB with our custom finder before including LLVM since the finder for LLVM
-# might search for ZLIB again and find the shared libraries instead of the static ones
-find_package(StaticZLIB REQUIRED)
+if (WITH_ZLIB)
+    add_definitions("-DHAVE_ZLIB=1")
+
+    # Find ZLIB with our custom finder before including LLVM since the finder for LLVM
+    # might search for ZLIB again and find the shared libraries instead of the static ones
+    find_package(StaticZLIB REQUIRED)
+endif()
 
 # LLVM
 set(WITH_LLVM no CACHE BOOL "Build with LLVM support")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,15 @@ set(WITH_RUNTIME_LIBRARY YES
 set(WITH_INTRINSIC_MODULES no
     CACHE BOOL "Compile intrinsic modules to .pyc (ASR) at build time")
 
+# Build to wasm
+set(LPYTHON_BUILD_TO_WASM no
+    CACHE BOOL "Compile LPython To WASM")
+
+if (LPYTHON_BUILD_TO_WASM)
+    set(HAVE_BUILD_TO_WASM yes)
+    add_definitions("-DHAVE_BUILD_TO_WASM=1")
+endif()
+
 # Find ZLIB with our custom finder before including LLVM since the finder for LLVM
 # might search for ZLIB again and find the shared libraries instead of the static ones
 find_package(StaticZLIB REQUIRED)
@@ -257,6 +266,7 @@ endif ()
 message("Installation prefix: ${CMAKE_INSTALL_PREFIX}")
 message("WITH_LFORTRAN_ASSERT: ${WITH_LFORTRAN_ASSERT}")
 message("LPYTHON_STATIC_BIN: ${LPYTHON_STATIC_BIN}")
+message("LPYTHON_BUILD_TO_WASM: ${LPYTHON_BUILD_TO_WASM}")
 message("WITH_STACKTRACE: ${WITH_STACKTRACE}")
 message("WITH_UNWIND: ${WITH_UNWIND}")
 message("WITH_BFD: ${WITH_BFD}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,12 @@ set(LPYTHON_BUILD_TO_WASM no
 
 if (LPYTHON_BUILD_TO_WASM)
     set(HAVE_BUILD_TO_WASM yes)
+    SET(WITH_WHEREAMI no)
     add_definitions("-DHAVE_BUILD_TO_WASM=1")
+endif()
+
+if (WITH_WHEREAMI)
+    add_definitions("-DHAVE_WHEREAMI=1")
 endif()
 
 # Find ZLIB with our custom finder before including LLVM since the finder for LLVM

--- a/build_to_wasm.sh
+++ b/build_to_wasm.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+emcmake cmake \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_CXX_FLAGS_DEBUG="-Wall -Wextra -fexceptions" \
+    -DWITH_LLVM=no \
+    -DLPYTHON_BUILD_ALL=yes \
+    -DLPYTHON_BUILD_TO_WASM=yes \
+    -DWITH_STACKTRACE=no \
+    -DWITH_LSP=no \
+    -DWITH_LFORTRAN_BINARY_MODFILES=no \
+    -DCMAKE_PREFIX_PATH="$CMAKE_PREFIX_PATH_LFORTRAN;$CONDA_PREFIX" \
+    -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
+    .
+cmake --build . -j16

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -47,6 +47,35 @@ set_target_properties(lpython PROPERTIES
     INSTALL_RPATH_USE_LINK_PATH TRUE
 )
 
+if (HAVE_BUILD_TO_WASM)
+    # set(WASM_LINK_FLAGS
+    #     "-g0" # Store no debugging information in the generated wasm file. This helps reduce generated file size
+    #     "-Oz" # Optimize for size. With this code size ~ 2.4mb. Without this code size ~49mb
+    #     "-fexceptions" # Enable Cpp exception support
+    #     "--no-entry" # No start function to execute
+    #     "-s ASSERTIONS" # Compile with Assertions which (as per docs) are helpful to debug compilation process
+    #     "-s ALLOW_MEMORY_GROWTH" # Allow dynamic memory growth upto the maximum page size limit
+    #     "-s WASM_BIGINT" # Allow use of i64 integers. ASR is needing this option to be enabled.
+    #     "-s EXPORTED_RUNTIME_METHODS=['cwrap']" # Export cwarp. cwarp helps us to call our EMSCRIPTEN_KEEPALIVE functions
+    # )
+
+    # Some extra flags below that we may need in future. But these may/might increase the code size
+    # "--preload-file ./asset_dir"
+    # "-s SAFE_HEAP=1"
+    # "-s \"EXPORTED_RUNTIME_METHODS=['ccall']\""
+    # "-s EXPORTED_FUNCTIONS=\"['_free', '_malloc']\""
+
+    # Notes:
+    # STANDALONE_WASM is disabling support for exceptions, so it is currently omitted
+    # In build_to_wasm.sh, we need CMAKE_CXX_FLAGS_DEBUG="-Wall -Wextra -fexceptions" flags for exception support
+    set(WASM_COMPILE_FLAGS "-g0 -fexceptions")
+    set(WASM_LINK_FLAGS
+      "-g0 -Oz -fexceptions -Wall -Wextra --no-entry -s ASSERTIONS -s ALLOW_MEMORY_GROWTH=1 -s WASM_BIGINT -s \"EXPORTED_RUNTIME_METHODS=['cwrap']\""
+    )
+    set_target_properties(lpython PROPERTIES COMPILE_FLAGS ${WASM_COMPILE_FLAGS})
+    set_target_properties(lpython PROPERTIES LINK_FLAGS ${WASM_LINK_FLAGS})
+endif()
+
 install(TARGETS lpython
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     ARCHIVE DESTINATION share/lpython/lib

--- a/src/lpython/CMakeLists.txt
+++ b/src/lpython/CMakeLists.txt
@@ -22,7 +22,12 @@ if (WITH_XEUS)
     )
 endif()
 add_library(lpython_lib ${SRC})
-target_link_libraries(lpython_lib asr lpython_runtime_static ZLIB::ZLIB)
+target_link_libraries(lpython_lib asr lpython_runtime_static)
+
+if (WITH_ZLIB)
+    target_link_libraries(lpython_lib ZLIB::ZLIB)
+endif()
+
 target_include_directories(lpython_lib BEFORE PUBLIC ${lpython_SOURCE_DIR}/src)
 target_include_directories(lpython_lib BEFORE PUBLIC ${lpython_BINARY_DIR}/src)
 if (WITH_XEUS)

--- a/src/lpython/CMakeLists.txt
+++ b/src/lpython/CMakeLists.txt
@@ -10,9 +10,12 @@ set(SRC
     python_serialization.cpp
 
     utils.cpp
-
-    ../bin/tpl/whereami/whereami.cpp
 )
+
+if (WITH_WHEREAMI)
+    set(SRC ${SRC} ../bin/tpl/whereami/whereami.cpp)
+endif()
+
 if (WITH_XEUS)
     set(SRC ${SRC}
 #        fortran_kernel.cpp

--- a/src/lpython/utils.cpp
+++ b/src/lpython/utils.cpp
@@ -17,6 +17,7 @@ namespace LFortran {
 
 void get_executable_path(std::string &executable_path, int &dirname_length)
 {
+#ifdef HAVE_WHEREAMI
     int length;
 
     length = wai_getExecutablePath(NULL, 0, &dirname_length);
@@ -30,6 +31,10 @@ void get_executable_path(std::string &executable_path, int &dirname_length)
     } else {
         throw LCompilersException("Cannot determine executable path.");
     }
+#else
+    executable_path = "src/bin/lpython.js";
+    dirname_length = 7;
+#endif
 }
 
 std::string get_runtime_library_dir()


### PR DESCRIPTION
This `PR` adds support of compiling/building `LPython` to `wasm`. 

It also adds support for building `LPython` to `wasm` at the `CI`.