### PR TITLE
Respect ``@inline`` decorator in LLVM backend

### DIFF
--- a/src/libasr/pass/inline_function_calls.cpp
+++ b/src/libasr/pass/inline_function_calls.cpp
@@ -45,6 +45,7 @@ private:
 
     bool from_inline_function_call, inlining_function;
     bool fixed_duplicated_expr_stmt;
+    bool is_fast;
 
     // Stores the local variables corresponding to the ones
     // present in function symbol table.
@@ -66,10 +67,12 @@ public:
 
     bool function_inlined;
 
-    InlineFunctionCallVisitor(Allocator &al_, const std::string& rl_path_, bool inline_external_symbol_calls_)
+    InlineFunctionCallVisitor(Allocator &al_, const std::string& rl_path_,
+                              bool inline_external_symbol_calls_, bool is_fast_)
     : PassVisitor(al_, nullptr),
     rl_path(rl_path_), function_result_var(nullptr),
     from_inline_function_call(false), inlining_function(false), fixed_duplicated_expr_stmt(false),
+    is_fast(is_fast_),
     current_routine(""), inline_external_symbol_calls(inline_external_symbol_calls_),
     node_duplicator(al_), current_routine_scope(nullptr),
     label_generator(ASRUtils::LabelGenerator::get_instance()),
@@ -208,6 +211,10 @@ public:
         ASR::Function_t* func = ASR::down_cast<ASR::Function_t>(routine);
         if( ASRUtils::is_intrinsic_function2(func) ||
             std::string(func->m_name) == current_routine ) {
+            return ;
+        }
+
+        if( !is_fast && !func->m_inline ) {
             return ;
         }
 
@@ -448,7 +455,7 @@ void pass_inline_function_calls(Allocator &al, ASR::TranslationUnit_t &unit,
                                 const LCompilers::PassOptions& pass_options) {
     std::string rl_path = pass_options.runtime_library_dir;
     bool inline_external_symbol_calls = pass_options.inline_external_symbol_calls;
-    InlineFunctionCallVisitor v(al, rl_path, inline_external_symbol_calls);
+    InlineFunctionCallVisitor v(al, rl_path, inline_external_symbol_calls, pass_options.fast);
     v.configure_node_duplicator(false);
     v.visit_TranslationUnit(unit);
     v.configure_node_duplicator(true);

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -101,6 +101,7 @@ namespace LCompilers {
                 "do_loops",
                 "forall",
                 "select_case",
+                "inline_function_calls",
                 "unused_functions"
             };
 
@@ -161,8 +162,10 @@ namespace LCompilers {
         void apply_passes(Allocator& al, LFortran::ASR::TranslationUnit_t* asr,
                           PassOptions& pass_options) {
             if( !_user_defined_passes.empty() ) {
+                pass_options.fast = true;
                 _apply_passes(al, asr, _user_defined_passes, pass_options);
             } else if( apply_default_passes ) {
+                pass_options.fast = is_fast;
                 if( is_fast ) {
                     _apply_passes(al, asr, _with_optimization_passes, pass_options);
                 } else {

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -55,9 +55,10 @@ namespace LCompilers {
         bool always_run; // for unused_functions pass
         bool inline_external_symbol_calls; // for inline_function_calls pass
         int64_t unroll_factor; // for loop_unroll pass
+        bool fast; // is fast flag enabled.
 
         PassOptions(): always_run(false), inline_external_symbol_calls(true),
-                       unroll_factor(32)
+                       unroll_factor(32), fast(false)
         {}
     };
 


### PR DESCRIPTION
https://github.com/lcompilers/lpython/pull/1057/files#r957303054

Command - **lpython --show-llvm integration_tests/expr_01.py**

```llvm
; ModuleID = 'LFortran'
source_filename = "LFortran"

@0 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
@1 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
@2 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1

define void @_lpython_main_program() {
.entry:
  call void @main0()
  br label %return

return:                                           ; preds = %.entry
  ret void
}

define void @main0() {
.entry:
  %_lpython_return_variable_add = alloca i32, align 4
  %_lpython_return_variable_and_op = alloca i32, align 4
  %x = alloca i32, align 4
  %x_add = alloca i32, align 4
  %x_and_op = alloca i32, align 4
  %y = alloca i32, align 4
  %y_add = alloca i32, align 4
  %y_and_op = alloca i32, align 4
  %z = alloca i32, align 4
  store i32 25, i32* %x, align 4
  %0 = load i32, i32* %x, align 4
  store i32 %0, i32* %x_add, align 4
  store i32 2, i32* %y_add, align 4
  %1 = load i32, i32* %x_add, align 4
  %2 = load i32, i32* %y_add, align 4
  %3 = add i32 %1, %2
  store i32 %3, i32* %_lpython_return_variable_add, align 4
  br label %goto_target

unreachable_after_goto:                           ; No predecessors!
  br label %goto_target

goto_target:                                      ; preds = %unreachable_after_goto, %.entry
  %4 = load i32, i32* %_lpython_return_variable_add, align 4
  %5 = mul i32 %4, 2
  store i32 %5, i32* %y, align 4
  %6 = load i32, i32* %x, align 4
  %7 = icmp eq i32 %6, 25
  br i1 %7, label %then, label %else

then:                                             ; preds = %goto_target
  br label %ifcont

else:                                             ; preds = %goto_target
  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @0, i32 0, i32 0))
  call void @exit(i32 1)
  br label %ifcont

ifcont:                                           ; preds = %else, %then
  %8 = load i32, i32* %y, align 4
  %9 = icmp eq i32 %8, 54
  br i1 %9, label %then1, label %else2

then1:                                            ; preds = %ifcont
  br label %ifcont3

else2:                                            ; preds = %ifcont
  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @1, i32 0, i32 0))
  call void @exit(i32 1)
  br label %ifcont3

ifcont3:                                          ; preds = %else2, %then1
  %10 = load i32, i32* %x, align 4
  store i32 %10, i32* %x_and_op, align 4
  %11 = load i32, i32* %y, align 4
  store i32 %11, i32* %y_and_op, align 4
  %12 = load i32, i32* %x_and_op, align 4
  %13 = load i32, i32* %y_and_op, align 4
  %14 = and i32 %12, %13
  store i32 %14, i32* %_lpython_return_variable_and_op, align 4
  br label %goto_target5

unreachable_after_goto4:                          ; No predecessors!
  br label %goto_target5

goto_target5:                                     ; preds = %unreachable_after_goto4, %ifcont3
  %15 = load i32, i32* %_lpython_return_variable_and_op, align 4
  store i32 %15, i32* %z, align 4
  %16 = load i32, i32* %z, align 4
  %17 = icmp eq i32 %16, 16
  br i1 %17, label %then6, label %else7

then6:                                            ; preds = %goto_target5
  br label %ifcont8

else7:                                            ; preds = %goto_target5
  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @2, i32 0, i32 0))
  call void @exit(i32 1)
  br label %ifcont8

ifcont8:                                          ; preds = %else7, %then6
  br label %return

return:                                           ; preds = %ifcont8
  ret void
}

declare void @_lfortran_printf(i8*, ...)

declare void @exit(i32)

define i32 @main() {
.entry:
  call void @_lpython_main_program()
  ret i32 0
}
```
