### PR TITLE
Add an option to skip pass in default pipeline

### DIFF
--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -1297,6 +1297,7 @@ int main(int argc, char *argv[])
         bool show_errors = false;
         bool with_intrinsic_modules = false;
         std::string arg_pass;
+        std::string skip_pass;
         bool arg_no_color = false;
         bool show_llvm = false;
         bool show_asm = false;
@@ -1363,6 +1364,7 @@ int main(int argc, char *argv[])
         app.add_flag("--indent", compiler_options.indent, "Indented print ASR/AST");
         app.add_flag("--tree", compiler_options.tree, "Tree structure print ASR/AST");
         app.add_option("--pass", arg_pass, "Apply the ASR pass and show ASR (implies --show-asr)");
+        app.add_option("--skip_pass", skip_pass, "Skip an ASR pass in default pipeline");
         app.add_flag("--disable-main", compiler_options.disable_main, "Do not generate any code for the `main` function");
         app.add_flag("--symtab-only", compiler_options.symtab_only, "Only create symbol tables in ASR (skip executable stmt)");
         app.add_flag("--time-report", time_report, "Show compilation time report");
@@ -1539,7 +1541,7 @@ int main(int argc, char *argv[])
         //     return emit_c_preprocessor(arg_file, compiler_options);
         // }
 
-        lpython_pass_manager.parse_pass_arg(arg_pass);
+        lpython_pass_manager.parse_pass_arg(arg_pass, skip_pass);
         if (show_tokens) {
             return emit_tokens(arg_file, true, compiler_options);
         }

--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -1364,7 +1364,7 @@ int main(int argc, char *argv[])
         app.add_flag("--indent", compiler_options.indent, "Indented print ASR/AST");
         app.add_flag("--tree", compiler_options.tree, "Tree structure print ASR/AST");
         app.add_option("--pass", arg_pass, "Apply the ASR pass and show ASR (implies --show-asr)");
-        app.add_option("--skip_pass", skip_pass, "Skip an ASR pass in default pipeline");
+        app.add_option("--skip-pass", skip_pass, "Skip an ASR pass in default pipeline");
         app.add_flag("--disable-main", compiler_options.disable_main, "Do not generate any code for the `main` function");
         app.add_flag("--symtab-only", compiler_options.symtab_only, "Only create symbol tables in ASR (skip executable stmt)");
         app.add_flag("--time-report", time_report, "Show compilation time report");

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -86,6 +86,7 @@ namespace LCompilers {
 
         bool is_fast;
         bool apply_default_passes;
+        std::string skip_pass;
 
         void _apply_passes(Allocator& al, LFortran::ASR::TranslationUnit_t* asr,
                            std::vector<std::string>& passes, PassOptions &pass_options,
@@ -159,8 +160,9 @@ namespace LCompilers {
             _user_defined_passes.clear();
         }
 
-        void parse_pass_arg(std::string& arg_pass) {
+        void parse_pass_arg(std::string& arg_pass, std::string& s_pass) {
             _user_defined_passes.clear();
+            skip_pass = s_pass;
             if (arg_pass == "") {
                 return ;
             }


### PR DESCRIPTION
Add an option to skip/ignore a pass in the default pipeline in [issue_943](https://github.com/lcompilers/lpython/issues/943)

Although there will be conflict with print asr pass [PR](https://github.com/lcompilers/lpython/pull/950) 
I think it's okay to just start.