### PR TITLE
Disallow ``f64``, ``f32``, ``c64``, ``c32`` as keys in dict

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1147,6 +1147,15 @@ public:
         return false;
     }
 
+    void raise_error_when_dict_key_is_float_or_complex(ASR::ttype_t* key_type, const Location& loc) {
+        if(ASR::is_a<ASR::Real_t>(*key_type) || ASR::is_a<ASR::Complex_t>(*key_type)) {
+            throw SemanticError("'dict' key type cannot be float/complex because resolving collisions "
+                                "by exact comparison of float/complex values will result in unexpected "
+                                "behaviours. In addition fuzzy equality checks with a certain tolerance "
+                                "does not follow transitivity with float/complex values.", loc);
+        }
+    }
+
     // Convert Python AST type annotation to an ASR type
     // Examples:
     // i32, i64, f32, f64
@@ -1213,6 +1222,7 @@ public:
                     }
                     ASR::ttype_t *key_type = ast_expr_to_asr_type(loc, *t->m_elts[0]);
                     ASR::ttype_t *value_type = ast_expr_to_asr_type(loc, *t->m_elts[1]);
+                    raise_error_when_dict_key_is_float_or_complex(key_type, loc);
                     return ASRUtils::TYPE(ASR::make_Dict_t(al, loc, key_type, value_type));
                 } else {
                     throw SemanticError("`dict` annotation must have 2 elements: types of"
@@ -3663,6 +3673,7 @@ public:
             }
             values.push_back(al, value);
         }
+        raise_error_when_dict_key_is_float_or_complex(key_type, x.base.base.loc);
         ASR::ttype_t* type = ASRUtils::TYPE(ASR::make_Dict_t(al, x.base.base.loc,
                                              key_type, value_type));
         tmp = ASR::make_DictConstant_t(al, x.base.base.loc, keys.p, keys.size(),

--- a/tests/errors/test_dict10.py
+++ b/tests/errors/test_dict10.py
@@ -1,0 +1,6 @@
+from ltypes import c32, f64
+
+def test_dict():
+    d: dict[c32, f64] = {}
+    r: c32 = complex(0.1, 0.1)
+    d[r] = 1.1

--- a/tests/errors/test_dict11.py
+++ b/tests/errors/test_dict11.py
@@ -1,0 +1,6 @@
+from ltypes import c64, f32
+
+def test_dict():
+    d: dict[c64, f32] = {}
+    r: c64 = complex(0.1, 0.1)
+    d[r] = 1.1

--- a/tests/errors/test_dict12.py
+++ b/tests/errors/test_dict12.py
@@ -1,0 +1,4 @@
+def test_dict():
+    print({0.0: 1.1}) # constant dict with floating point value as key
+
+test_dict()

--- a/tests/errors/test_dict13.py
+++ b/tests/errors/test_dict13.py
@@ -1,0 +1,4 @@
+def test_dict():
+    print({complex(0.0, 1.0): 1.1}) # constant dict with complex value as key
+
+test_dict()

--- a/tests/errors/test_dict8.py
+++ b/tests/errors/test_dict8.py
@@ -1,0 +1,5 @@
+from ltypes import f64
+
+def test_dict():
+    d: dict[f64, f64] = {}
+    d[0.1] = 1.1

--- a/tests/errors/test_dict9.py
+++ b/tests/errors/test_dict9.py
@@ -1,0 +1,6 @@
+from ltypes import f32, f64
+
+def test_dict():
+    d: dict[f32, f64] = {}
+    r: f32 = 0.1
+    d[r] = 1.1

--- a/tests/reference/asr-test_dict10-8c0beff.json
+++ b/tests/reference/asr-test_dict10-8c0beff.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_dict10-8c0beff",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_dict10.py",
+    "infile_hash": "6e7e12d241f428b975744850c68f7b4a401a6ba035922e37e66f07d1",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_dict10-8c0beff.stderr",
+    "stderr_hash": "95d5b555fbf664cf7bc7735845c89acc77393a00ad44b42fcf7c8fe8",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_dict10-8c0beff.stderr
+++ b/tests/reference/asr-test_dict10-8c0beff.stderr
@@ -1,0 +1,5 @@
+semantic error: 'dict' key type cannot be float/complex because resolving collisions by exact comparison of float/complex values will result in unexpected behaviours. In addition fuzzy equality checks with a certain tolerance does not follow transitivity with float/complex values.
+ --> tests/errors/test_dict10.py:4:5
+  |
+4 |     d: dict[c32, f64] = {}
+  |     ^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-test_dict11-2ab4e6c.json
+++ b/tests/reference/asr-test_dict11-2ab4e6c.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_dict11-2ab4e6c",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_dict11.py",
+    "infile_hash": "c1ffba7ea161c60aa89578a819f9c1ff89863c0e71118a40ce67a702",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_dict11-2ab4e6c.stderr",
+    "stderr_hash": "4944c96752dfe5fcfc190831966428e9568e9d4b8b03a553524df84b",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_dict11-2ab4e6c.stderr
+++ b/tests/reference/asr-test_dict11-2ab4e6c.stderr
@@ -1,0 +1,5 @@
+semantic error: 'dict' key type cannot be float/complex because resolving collisions by exact comparison of float/complex values will result in unexpected behaviours. In addition fuzzy equality checks with a certain tolerance does not follow transitivity with float/complex values.
+ --> tests/errors/test_dict11.py:4:5
+  |
+4 |     d: dict[c64, f32] = {}
+  |     ^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-test_dict12-7c74d08.json
+++ b/tests/reference/asr-test_dict12-7c74d08.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_dict12-7c74d08",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_dict12.py",
+    "infile_hash": "4a8a3f88d0c29a68083bc142a792c35b6f13d7bdf1a635f91920baeb",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_dict12-7c74d08.stderr",
+    "stderr_hash": "9243262b97e5e6a555eafbbfd93440e86e66a3536cc0fb9902a7e0d2",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_dict12-7c74d08.stderr
+++ b/tests/reference/asr-test_dict12-7c74d08.stderr
@@ -1,0 +1,5 @@
+semantic error: 'dict' key type cannot be float/complex because resolving collisions by exact comparison of float/complex values will result in unexpected behaviours. In addition fuzzy equality checks with a certain tolerance does not follow transitivity with float/complex values.
+ --> tests/errors/test_dict12.py:2:11
+  |
+2 |     print({0.0: 1.1}) # constant dict with floating point value as key
+  |           ^^^^^^^^^^ 

--- a/tests/reference/asr-test_dict13-683b290.json
+++ b/tests/reference/asr-test_dict13-683b290.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_dict13-683b290",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_dict13.py",
+    "infile_hash": "ee757d46a81447cf45321822e379e83acbecd32578e300f27fc93d1b",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_dict13-683b290.stderr",
+    "stderr_hash": "60bc3be332a1b638ade1cf40068ee4381ba4a79942a76c104c9cdebd",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_dict13-683b290.stderr
+++ b/tests/reference/asr-test_dict13-683b290.stderr
@@ -1,0 +1,5 @@
+semantic error: 'dict' key type cannot be float/complex because resolving collisions by exact comparison of float/complex values will result in unexpected behaviours. In addition fuzzy equality checks with a certain tolerance does not follow transitivity with float/complex values.
+ --> tests/errors/test_dict13.py:2:11
+  |
+2 |     print({complex(0.0, 1.0): 1.1}) # constant dict with complex value as key
+  |           ^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-test_dict8-d960ce0.json
+++ b/tests/reference/asr-test_dict8-d960ce0.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_dict8-d960ce0",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_dict8.py",
+    "infile_hash": "a0e29d11cde61d2c83b67392048930efb34f8ded6e42a4101f0b248d",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_dict8-d960ce0.stderr",
+    "stderr_hash": "86744c3a768772a885a4cafef8973f69689fb2522aae6dfe486f7dcd",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_dict8-d960ce0.stderr
+++ b/tests/reference/asr-test_dict8-d960ce0.stderr
@@ -1,0 +1,5 @@
+semantic error: 'dict' key type cannot be float/complex because resolving collisions by exact comparison of float/complex values will result in unexpected behaviours. In addition fuzzy equality checks with a certain tolerance does not follow transitivity with float/complex values.
+ --> tests/errors/test_dict8.py:4:5
+  |
+4 |     d: dict[f64, f64] = {}
+  |     ^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-test_dict9-907bda7.json
+++ b/tests/reference/asr-test_dict9-907bda7.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_dict9-907bda7",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_dict9.py",
+    "infile_hash": "90e01bb400b78fa0a8fb11fc90924aacbb7f53677e42ceecc743215d",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_dict9-907bda7.stderr",
+    "stderr_hash": "14a0981e18ecf1948417be8e93c7956f82c76fcc5e84b1d428d525c0",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_dict9-907bda7.stderr
+++ b/tests/reference/asr-test_dict9-907bda7.stderr
@@ -1,0 +1,5 @@
+semantic error: 'dict' key type cannot be float/complex because resolving collisions by exact comparison of float/complex values will result in unexpected behaviours. In addition fuzzy equality checks with a certain tolerance does not follow transitivity with float/complex values.
+ --> tests/errors/test_dict9.py:4:5
+  |
+4 |     d: dict[f32, f64] = {}
+  |     ^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -708,6 +708,30 @@ filename = "errors/test_dict1.py"
 asr = true
 
 [[test]]
+filename = "errors/test_dict8.py"
+asr = true
+
+[[test]]
+filename = "errors/test_dict9.py"
+asr = true
+
+[[test]]
+filename = "errors/test_dict10.py"
+asr = true
+
+[[test]]
+filename = "errors/test_dict11.py"
+asr = true
+
+[[test]]
+filename = "errors/test_dict12.py"
+asr = true
+
+[[test]]
+filename = "errors/test_dict13.py"
+asr = true
+
+[[test]]
 filename = "errors/test_zero_division.py"
 asr = true
 


### PR DESCRIPTION
Signed-off-by: Ron Nuriel <rnuriel@gsitechnology.com>

Closes #1074 