### PR TITLE
Ignore forward declarations of ``ccall`` functions in C backend

### DIFF
--- a/integration_tests/bindc_03.py
+++ b/integration_tests/bindc_03.py
@@ -5,11 +5,11 @@ def g(a: CPtr, value: i32) -> None:
     pass
 
 @ccall
-def get_array(size: i32) -> CPtr:
+def get_array(size: i32) -> CPtr: # this function can be called from Python but is defined in C code
     pass
 
 @ccallable
-def f(q_void: CPtr) -> None:
+def f(q_void: CPtr) -> None: # this function can be called from C code
     i: i32
     el: i32
     q: Pointer[i32[:]]

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -336,10 +336,29 @@ R"(#include <stdio.h>
 
     std::string declare_all_functions(const SymbolTable &scope) {
         std::string code;
+        bool is_ccall_present = false;
+        code += "#ifndef IGNORE_DECLARATIONS\n";
         for (auto &item : scope.get_scope()) {
             if (ASR::is_a<ASR::Function_t>(*item.second)) {
                 ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(item.second);
-                code += get_function_declaration(*s) + ";\n";
+                if( s->m_abi == ASR::abiType::BindC &&
+                    s->m_deftype == ASR::deftypeType::Interface ) {
+                    is_ccall_present = true;
+                    code += get_function_declaration(*s) + ";\n";
+                }
+            }
+        }
+        code += "#endif\n";
+        if( !is_ccall_present ) {
+            code.clear();
+        }
+        for (auto &item : scope.get_scope()) {
+            if (ASR::is_a<ASR::Function_t>(*item.second)) {
+                ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(item.second);
+                if( !(s->m_abi == ASR::abiType::BindC &&
+                      s->m_deftype == ASR::deftypeType::Interface) ) {
+                    code += get_function_declaration(*s) + ";\n";
+                }
             }
         }
         return code;

--- a/tests/reference/c-c_interop1-e215531.json
+++ b/tests/reference/c-c_interop1-e215531.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-c_interop1-e215531.stdout",
-    "stdout_hash": "23a942be9dc8ba7d8a2c52cc1796b7ab9a5e36b46d7243a90b8a2982",
+    "stdout_hash": "2b1a31cfadcf4608a3f0a08e83371dc23908e6907899ce6c6b6d9c8c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-c_interop1-e215531.stdout
+++ b/tests/reference/c-c_interop1-e215531.stdout
@@ -35,8 +35,10 @@ struct dimension_descriptor
     int32_t lower_bound, length;
 };
 // Forward declarations
+#ifndef IGNORE_DECLARATIONS
 double f(double x);
 void g(double a, float b, int64_t c, int32_t d);
+#endif
 double h(double x);
 void l(double a, float b, int64_t c, int32_t d);
 void main0();

--- a/tests/reference/c-expr7-bb2692a.json
+++ b/tests/reference/c-expr7-bb2692a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-expr7-bb2692a.stdout",
-    "stdout_hash": "eb171aa2ddb886cd94cdf609133e1358f918dfac7387dee4bb37cd75",
+    "stdout_hash": "a015c5fec9daa1557b1bf01c0e46272f0e7553999306157f535d3714",
     "stderr": "c-expr7-bb2692a.stderr",
     "stderr_hash": "28509dd59a386eebd632340a550d14299cd2a921ef6dc3ac7dbe7fe9",
     "returncode": 0

--- a/tests/reference/c-expr7-bb2692a.stdout
+++ b/tests/reference/c-expr7-bb2692a.stdout
@@ -41,9 +41,11 @@ void _lpython_main_program();
 void main0();
 void test_pow();
 int32_t test_pow_1(int32_t a, int32_t b);
-int32_t __lpython_overloaded_0__pow(int32_t x, int32_t y);
+#ifndef IGNORE_DECLARATIONS
 float _lfortran_caimag(float complex x);
 double _lfortran_zaimag(double complex x);
+#endif
+int32_t __lpython_overloaded_0__pow(int32_t x, int32_t y);
 
 // Implementations
 void _lpython_main_program()

--- a/tests/reference/cpp-expr15-1661c0d.json
+++ b/tests/reference/cpp-expr15-1661c0d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr15-1661c0d.stdout",
-    "stdout_hash": "20951d251ebc5ce94f1b8456cc344bb85022b23d0a724c96de9cf2ad",
+    "stdout_hash": "0cf004e982e0f9c9ebd2b10a46927ff626739240db98ee89fdfbed74",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr15-1661c0d.stdout
+++ b/tests/reference/cpp-expr15-1661c0d.stdout
@@ -27,9 +27,11 @@ void _lpython_main_program();
 double test1();
 std::complex<double> test2();
 int32_t test3();
-std::complex<double> __lpython_overloaded_9__complex(int32_t x, int32_t y);
+#ifndef IGNORE_DECLARATIONS
 float _lfortran_caimag(std::complex<float> x);
 double _lfortran_zaimag(std::complex<double> x);
+#endif
+std::complex<double> __lpython_overloaded_9__complex(int32_t x, int32_t y);
 namespace {
 }
 

--- a/tests/reference/cpp-expr7-529bd53.json
+++ b/tests/reference/cpp-expr7-529bd53.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr7-529bd53.stdout",
-    "stdout_hash": "f455c0d2fb2503c5cddcc6c0bb844d1655ad37ce2dae27143eaf06cf",
+    "stdout_hash": "11a93835c5854760f7bcb25818e84df5d2e923317fa154758d4e9a71",
     "stderr": "cpp-expr7-529bd53.stderr",
     "stderr_hash": "28509dd59a386eebd632340a550d14299cd2a921ef6dc3ac7dbe7fe9",
     "returncode": 0

--- a/tests/reference/cpp-expr7-529bd53.stdout
+++ b/tests/reference/cpp-expr7-529bd53.stdout
@@ -27,9 +27,11 @@ void _lpython_main_program();
 void main0();
 void test_pow();
 int32_t test_pow_1(int32_t a, int32_t b);
-int32_t __lpython_overloaded_0__pow(int32_t x, int32_t y);
+#ifndef IGNORE_DECLARATIONS
 float _lfortran_caimag(std::complex<float> x);
 double _lfortran_zaimag(std::complex<double> x);
+#endif
+int32_t __lpython_overloaded_0__pow(int32_t x, int32_t y);
 namespace {
 }
 

--- a/tests/reference/cpp-expr8-704cece.json
+++ b/tests/reference/cpp-expr8-704cece.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr8-704cece.stdout",
-    "stdout_hash": "9975e17559daac6c3fadd390b2f0713cdba1e952003ffcacff245f76",
+    "stdout_hash": "b1408f6dd75bca1326593029fe0bfd90d3c8d27b2f56bb7de4506570",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr8-704cece.stdout
+++ b/tests/reference/cpp-expr8-704cece.stdout
@@ -24,9 +24,11 @@ struct dimension_descriptor
 };
 // Forward declarations
 void test_binop();
-int32_t __lpython_overloaded_2___lpython_floordiv(int32_t a, int32_t b);
+#ifndef IGNORE_DECLARATIONS
 float _lfortran_caimag(std::complex<float> x);
 double _lfortran_zaimag(std::complex<double> x);
+#endif
+int32_t __lpython_overloaded_2___lpython_floordiv(int32_t a, int32_t b);
 namespace {
 }
 

--- a/tests/reference/cpp-test_builtin_pow-56b3f92.json
+++ b/tests/reference/cpp-test_builtin_pow-56b3f92.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-test_builtin_pow-56b3f92.stdout",
-    "stdout_hash": "b12957fdc9bfb4c05bda981e62e6ddefdd78d3fc6436bcf94c7a3f6d",
+    "stdout_hash": "7b0a1e6433492ab46e230e00bb0881f86ba4d38b49a959ed34decd18",
     "stderr": "cpp-test_builtin_pow-56b3f92.stderr",
     "stderr_hash": "180e1adfbb0d9c63a2fffa31951bbd629b3f1950cf0d97ca1389efe5",
     "returncode": 0

--- a/tests/reference/cpp-test_builtin_pow-56b3f92.stdout
+++ b/tests/reference/cpp-test_builtin_pow-56b3f92.stdout
@@ -25,6 +25,10 @@ struct dimension_descriptor
 // Forward declarations
 void _lpython_main_program();
 void test_pow();
+#ifndef IGNORE_DECLARATIONS
+float _lfortran_caimag(std::complex<float> x);
+double _lfortran_zaimag(std::complex<double> x);
+#endif
 int32_t __lpython_overloaded_0___mod(int32_t a, int32_t b);
 double __lpython_overloaded_0__abs(double x);
 int32_t __lpython_overloaded_0__pow(int32_t x, int32_t y);
@@ -43,8 +47,6 @@ double __lpython_overloaded_7__pow(double x, int32_t y);
 int32_t __lpython_overloaded_8__pow(bool x, bool y);
 std::complex<double> __lpython_overloaded_9__complex(int32_t x, int32_t y);
 std::complex<float> __lpython_overloaded_9__pow(std::complex<float> c, int32_t y);
-float _lfortran_caimag(std::complex<float> x);
-double _lfortran_zaimag(std::complex<double> x);
 namespace {
 }
 


### PR DESCRIPTION
Closes https://github.com/lcompilers/lpython/issues/1094