### PR TITLE
Replace ``sprintf`` -> ``snprintf``

### DIFF
--- a/src/libasr/containers.h
+++ b/src/libasr/containers.h
@@ -185,7 +185,7 @@ std::string string_format(const std::string& format, Args && ...args)
 {
     auto size = std::snprintf(nullptr, 0, format.c_str(), std::forward<Args>(args)...);
     std::string output(size, '\0');
-    std::sprintf(&output[0], format.c_str(), std::forward<Args>(args)...);
+    std::snprintf(&output[0], size + 1, format.c_str(), std::forward<Args>(args)...);
     return output;
 }
 


### PR DESCRIPTION
I got several of the following security warning after recent macOS update. Hence the replacement.

```bash
/Users/czgdp1807/lpython_project/lpython/src/libasr/containers.h:188:10: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
    std::sprintf(&output[0], format.c_str(), std::forward<Args>(args)...);
         ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.0.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.0.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 warning generated.
```