### PR TITLE
Execute `a.out` after successful linking of the executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,17 @@ integration_tests/b1/*
 integration_tests/b2/*
 integration_tests/b3/*
 integration_tests/b4/*
+inst/bin/*
+*.tlog
+*.filters
+*.obj
+*.exe
+*.exp
+*.lib
+*.vcxproj
+*.recipe
+*.sln
+*.dll
 
 ### https://raw.github.com/github/gitignore/218a941be92679ce67d0484547e3e142b2f5f6f0/Global/macOS.gitignore
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ here to install Conda on your platform:
 
 https://github.com/conda-forge/miniforge/#download
 
-## Compile LPython
-
-Install required packages (Linux - 64 bit):
+Also, Install (Linux - 64 bit):
 
 ```bash
 sudo apt install binutils-dev
 ```
+
+## Compile LPython
 
 Clone LPython
 
@@ -95,7 +95,8 @@ You can run the following examples by hand in a terminal:
 
 ```bash
 ./src/bin/lpython examples/expr2.py
-./a.out
+./src/bin/lpython examples/expr2.py -o expr
+./expr
 ./src/bin/lpython --show-ast examples/expr2.py
 ./src/bin/lpython --show-asr examples/expr2.py
 ./src/bin/lpython --show-cpp examples/expr2.py

--- a/build1.bat
+++ b/build1.bat
@@ -1,0 +1,9 @@
+cmake ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DWITH_LLVM=yes ^
+    -DLFORTRAN_BUILD_ALL=yes ^
+    -DWITH_STACKTRACE=no ^
+    -DCMAKE_PREFIX_PATH="%CONDA_PREFIX%" ^
+    -DCMAKE_INSTALL_PREFIX=%cd%/inst ^
+    .
+cmake --build . --config Release -j8 --target install

--- a/build1_win.sh
+++ b/build1_win.sh
@@ -1,9 +1,15 @@
-#!/usr/bin/env bash
+#!/usr/bin/env xonsh
 
-bash ci/version.sh
+#bash ci/version.sh
+version=$(git describe --tags --dirty).strip()[1:]
+echo @(version) > version
+
 # Generate a Python AST from Python.asdl (Python)
 python grammar/asdl_py.py
 # Generate a Python AST from Python.asdl (C++)
 python src/libasr/asdl_cpp.py grammar/Python.asdl src/lpython/python_ast.h
 # Generate a Fortran ASR from ASR.asdl (C++)
 python src/libasr/asdl_cpp.py src/libasr/ASR.asdl src/libasr/asr.h
+
+pushd src/lpython/parser && re2c -W -b tokenizer.re -o tokenizer.cpp && popd
+pushd src/lpython/parser && bison -Wall -d -r all parser.yy && popd

--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -792,6 +792,13 @@ int link_executable(const std::vector<std::string> &infiles,
                 std::cout << "The command '" + cmd + "' failed." << std::endl;
                 return 10;
             }
+            if (outfile == "a.out") {
+                err = system("a.out");
+                if (err) {
+                    std::cout << "The command 'a.out' failed." << std::endl;
+                    return 10;
+                }
+            }
         } else {
             std::string CC = "cc";
             char *env_CC = std::getenv("LFORTRAN_CC");

--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -817,6 +817,13 @@ int link_executable(const std::vector<std::string> &infiles,
                 std::cout << "The command '" + cmd + "' failed." << std::endl;
                 return 10;
             }
+            if (outfile == "a.out") {
+                err = system("./a.out");
+                if (err) {
+                    std::cout << "The command './a.out' failed." << std::endl;
+                    return 10;
+                }
+            }
         }
         return 0;
     } else if (backend == Backend::cpp) {


### PR DESCRIPTION
Fixes: #1130 