### PR TITLE
Generate array types correctly for derived types in LLVM backend

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -138,6 +138,7 @@ endmacro(RUN)
 # Test zero and non-zero exit code and assert statements
 RUN(NAME array_01_decl            LABELS cpython llvm c)
 RUN(NAME array_02_decl            LABELS cpython llvm c)
+RUN(NAME array_03_decl            LABELS cpython llvm c)
 RUN(NAME array_expr_01            LABELS cpython llvm)
 RUN(NAME array_expr_02            LABELS cpython llvm)
 RUN(NAME bindc_01            LABELS llvm c)

--- a/integration_tests/array_03_decl.py
+++ b/integration_tests/array_03_decl.py
@@ -1,0 +1,29 @@
+from ltypes import i32, f64, dataclass
+from numpy import empty
+
+@dataclass
+class Car:
+    price: i32
+    horsepower: f64
+
+@dataclass
+class Truck:
+    price: i32
+    wheels: i32
+
+def declare_struct_array():
+    cars: Car[1] = empty(10, dtype=Car)
+    trucks: Truck[2] = empty(20, dtype=Truck)
+    cars[0] = Car(100000, 800.0)
+    trucks[0] = Truck(1000000, 8)
+    trucks[1] = Truck(5000000, 12)
+
+    assert cars[0].price == 100000
+    assert abs(cars[0].horsepower - 800.0) <= 1e-12
+
+    assert trucks[0].price == 1000000
+    assert trucks[1].price == 5000000
+    assert trucks[0].wheels == 8
+    assert trucks[1].wheels == 12
+
+declare_struct_array()

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -1,5 +1,6 @@
 #include <libasr/codegen/llvm_array_utils.h>
 #include <libasr/codegen/llvm_utils.h>
+#include <libasr/asr_utils.h>
 
 namespace LFortran {
 
@@ -201,7 +202,7 @@ namespace LFortran {
         int rank, llvm::Type* el_type,
         bool get_pointer) {
             ASR::ttypeType type_ = m_type_->type;
-            std::pair<std::pair<int, int>, int> array_key = std::make_pair(std::make_pair((int)type_, a_kind), rank);
+            std::string array_key = ASRUtils::get_type_code(m_type_);
             if( tkr2array.find(array_key) != tkr2array.end() ) {
                 if( get_pointer ) {
                     return tkr2array[array_key]->getPointerTo();
@@ -230,7 +231,7 @@ namespace LFortran {
         llvm::Type* SimpleCMODescriptor::get_malloc_array_type
         (ASR::ttype_t* m_type_, int a_kind, int rank, llvm::Type* el_type, bool get_pointer) {
             ASR::ttypeType type_ = m_type_->type;
-            std::pair<std::pair<int, int>, int> array_key = std::make_pair(std::make_pair((int)type_, a_kind), rank);
+            std::string array_key = ASRUtils::get_type_code(m_type_);
             if( tkr2array.find(array_key) != tkr2array.end() ) {
                 if( get_pointer ) {
                     return tkr2array[array_key]->getPointerTo();

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -274,7 +274,7 @@ namespace LFortran {
 
                 llvm::StructType* dim_des;
 
-                std::map<std::pair<std::pair<int, int>, int>, llvm::StructType*> tkr2array;
+                std::map<std::string, llvm::StructType*> tkr2array;
 
                 llvm::Value* cmo_convertor_single_element(
                     llvm::Value* arr, std::vector<llvm::Value*>& m_args,


### PR DESCRIPTION
`integration_tests/array_03_decl.py` on `main`,

<details><summary>Click here for complete LLVM code</summary>

```llvm
; ModuleID = 'LFortran'
source_filename = "LFortran"

%array = type { %Car*, i32, %dimension_descriptor*, i1, i32 }
%Car = type { double, i32 }
%dimension_descriptor = type { i32, i32, i32 }
%complex_8 = type { double, double }

@pi_32 = global float 0x400921FB60000000
@pi_64 = global double 0x400921FB54442D18
@0 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
@1 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
@2 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
@3 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
@4 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
@5 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1

define void @_lpython_main_program() {
.entry:
  call void @declare_struct_array()
  br label %return

return:                                           ; preds = %.entry
  ret void
}

define void @declare_struct_array() {
.entry:
  %call_arg_value = alloca double, align 8
  %cars = alloca %array, align 8
  %0 = getelementptr %array, %array* %cars, i32 0, i32 1
  store i32 0, i32* %0, align 4
  %1 = getelementptr %array, %array* %cars, i32 0, i32 2
  %2 = alloca i32, align 4
  store i32 1, i32* %2, align 4
  %3 = load i32, i32* %2, align 4
  %4 = alloca %dimension_descriptor, i32 %3, align 8
  %5 = getelementptr %array, %array* %cars, i32 0, i32 4
  store i32 1, i32* %5, align 4
  store %dimension_descriptor* %4, %dimension_descriptor** %1, align 8
  %6 = load %dimension_descriptor*, %dimension_descriptor** %1, align 8
  %7 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %6, i32 0
  %8 = getelementptr %dimension_descriptor, %dimension_descriptor* %7, i32 0, i32 0
  %9 = getelementptr %dimension_descriptor, %dimension_descriptor* %7, i32 0, i32 1
  %10 = getelementptr %dimension_descriptor, %dimension_descriptor* %7, i32 0, i32 2
  store i32 1, i32* %8, align 4
  store i32 0, i32* %9, align 4
  store i32 1, i32* %10, align 4
  %11 = alloca i32, align 4
  store i32 1, i32* %11, align 4
  %12 = getelementptr %array, %array* %cars, i32 0, i32 0
  %13 = load i32, i32* %11, align 4
  %14 = alloca %Car, i32 %13, align 8
  store %Car* %14, %Car** %12, align 8
  %trucks = alloca %array, align 8
  %15 = getelementptr %array, %array* %trucks, i32 0, i32 1
  store i32 0, i32* %15, align 4
  %16 = getelementptr %array, %array* %trucks, i32 0, i32 2
  %17 = alloca i32, align 4
  store i32 1, i32* %17, align 4
  %18 = load i32, i32* %17, align 4
  %19 = alloca %dimension_descriptor, i32 %18, align 8
  %20 = getelementptr %array, %array* %trucks, i32 0, i32 4
  store i32 1, i32* %20, align 4
  store %dimension_descriptor* %19, %dimension_descriptor** %16, align 8
  %21 = load %dimension_descriptor*, %dimension_descriptor** %16, align 8
  %22 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %21, i32 0
  %23 = getelementptr %dimension_descriptor, %dimension_descriptor* %22, i32 0, i32 0
  %24 = getelementptr %dimension_descriptor, %dimension_descriptor* %22, i32 0, i32 1
  %25 = getelementptr %dimension_descriptor, %dimension_descriptor* %22, i32 0, i32 2
  store i32 1, i32* %23, align 4
  store i32 0, i32* %24, align 4
  store i32 2, i32* %25, align 4
  %26 = alloca i32, align 4
  store i32 2, i32* %26, align 4
  %27 = getelementptr %array, %array* %trucks, i32 0, i32 0
  %28 = load i32, i32* %26, align 4
  %29 = alloca %Car, i32 %28, align 8
  store %Car* %29, %Car** %27, align 8
  %30 = getelementptr %array, %array* %cars, i32 0, i32 2
  %31 = load %dimension_descriptor*, %dimension_descriptor** %30, align 8
  %32 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %31, i32 0
  %33 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 1
  %34 = load i32, i32* %33, align 4
  %35 = sub i32 0, %34
  %36 = mul i32 1, %35
  %37 = add i32 0, %36
  %38 = getelementptr %dimension_descriptor, %dimension_descriptor* %32, i32 0, i32 2
  %39 = load i32, i32* %38, align 4
  %40 = mul i32 1, %39
  %41 = getelementptr %array, %array* %cars, i32 0, i32 0
  %42 = load %Car*, %Car** %41, align 8
  %43 = getelementptr inbounds %Car, %Car* %42, i32 %37
  %44 = getelementptr %Car, %Car* %43, i32 0, i32 1
  store i32 100000, i32* %44, align 4
  %45 = getelementptr %array, %array* %cars, i32 0, i32 2
  %46 = load %dimension_descriptor*, %dimension_descriptor** %45, align 8
  %47 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %46, i32 0
  %48 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 1
  %49 = load i32, i32* %48, align 4
  %50 = sub i32 0, %49
  %51 = mul i32 1, %50
  %52 = add i32 0, %51
  %53 = getelementptr %dimension_descriptor, %dimension_descriptor* %47, i32 0, i32 2
  %54 = load i32, i32* %53, align 4
  %55 = mul i32 1, %54
  %56 = getelementptr %array, %array* %cars, i32 0, i32 0
  %57 = load %Car*, %Car** %56, align 8
  %58 = getelementptr inbounds %Car, %Car* %57, i32 %52
  %59 = getelementptr %Car, %Car* %58, i32 0, i32 0
  store double 8.000000e+02, double* %59, align 8
  %60 = getelementptr %array, %array* %trucks, i32 0, i32 2
  %61 = load %dimension_descriptor*, %dimension_descriptor** %60, align 8
  %62 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %61, i32 0
  %63 = getelementptr %dimension_descriptor, %dimension_descriptor* %62, i32 0, i32 1
  %64 = load i32, i32* %63, align 4
  %65 = sub i32 0, %64
  %66 = mul i32 1, %65
  %67 = add i32 0, %66
  %68 = getelementptr %dimension_descriptor, %dimension_descriptor* %62, i32 0, i32 2
  %69 = load i32, i32* %68, align 4
  %70 = mul i32 1, %69
  %71 = getelementptr %array, %array* %trucks, i32 0, i32 0
  %72 = load %Car*, %Car** %71, align 8
  %73 = getelementptr inbounds %Car, %Car* %72, i32 %67
  %74 = getelementptr %Car, %Car* %73, i32 0, i32 0
  store i32 1000000, double* %74, align 4
  %75 = getelementptr %array, %array* %trucks, i32 0, i32 2
  %76 = load %dimension_descriptor*, %dimension_descriptor** %75, align 8
  %77 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %76, i32 0
  %78 = getelementptr %dimension_descriptor, %dimension_descriptor* %77, i32 0, i32 1
  %79 = load i32, i32* %78, align 4
  %80 = sub i32 0, %79
  %81 = mul i32 1, %80
  %82 = add i32 0, %81
  %83 = getelementptr %dimension_descriptor, %dimension_descriptor* %77, i32 0, i32 2
  %84 = load i32, i32* %83, align 4
  %85 = mul i32 1, %84
  %86 = getelementptr %array, %array* %trucks, i32 0, i32 0
  %87 = load %Car*, %Car** %86, align 8
  %88 = getelementptr inbounds %Car, %Car* %87, i32 %82
  %89 = getelementptr %Car, %Car* %88, i32 0, i32 1
  store i32 8, i32* %89, align 4
  %90 = getelementptr %array, %array* %trucks, i32 0, i32 2
  %91 = load %dimension_descriptor*, %dimension_descriptor** %90, align 8
  %92 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %91, i32 0
  %93 = getelementptr %dimension_descriptor, %dimension_descriptor* %92, i32 0, i32 1
  %94 = load i32, i32* %93, align 4
  %95 = sub i32 1, %94
  %96 = mul i32 1, %95
  %97 = add i32 0, %96
  %98 = getelementptr %dimension_descriptor, %dimension_descriptor* %92, i32 0, i32 2
  %99 = load i32, i32* %98, align 4
  %100 = mul i32 1, %99
  %101 = getelementptr %array, %array* %trucks, i32 0, i32 0
  %102 = load %Car*, %Car** %101, align 8
  %103 = getelementptr inbounds %Car, %Car* %102, i32 %97
  %104 = getelementptr %Car, %Car* %103, i32 0, i32 0
  store i32 5000000, double* %104, align 4
  %105 = getelementptr %array, %array* %trucks, i32 0, i32 2
  %106 = load %dimension_descriptor*, %dimension_descriptor** %105, align 8
  %107 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %106, i32 0
  %108 = getelementptr %dimension_descriptor, %dimension_descriptor* %107, i32 0, i32 1
  %109 = load i32, i32* %108, align 4
  %110 = sub i32 1, %109
  %111 = mul i32 1, %110
  %112 = add i32 0, %111
  %113 = getelementptr %dimension_descriptor, %dimension_descriptor* %107, i32 0, i32 2
  %114 = load i32, i32* %113, align 4
  %115 = mul i32 1, %114
  %116 = getelementptr %array, %array* %trucks, i32 0, i32 0
  %117 = load %Car*, %Car** %116, align 8
  %118 = getelementptr inbounds %Car, %Car* %117, i32 %112
  %119 = getelementptr %Car, %Car* %118, i32 0, i32 1
  store i32 12, i32* %119, align 4
  %120 = getelementptr %array, %array* %cars, i32 0, i32 2
  %121 = load %dimension_descriptor*, %dimension_descriptor** %120, align 8
  %122 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %121, i32 0
  %123 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 1
  %124 = load i32, i32* %123, align 4
  %125 = sub i32 0, %124
  %126 = mul i32 1, %125
  %127 = add i32 0, %126
  %128 = getelementptr %dimension_descriptor, %dimension_descriptor* %122, i32 0, i32 2
  %129 = load i32, i32* %128, align 4
  %130 = mul i32 1, %129
  %131 = getelementptr %array, %array* %cars, i32 0, i32 0
  %132 = load %Car*, %Car** %131, align 8
  %133 = getelementptr inbounds %Car, %Car* %132, i32 %127
  %134 = getelementptr %Car, %Car* %133, i32 0, i32 1
  %135 = load i32, i32* %134, align 4
  %136 = icmp eq i32 %135, 100000
  br i1 %136, label %then, label %else

then:                                             ; preds = %.entry
  br label %ifcont

else:                                             ; preds = %.entry
  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @0, i32 0, i32 0))
  call void @exit(i32 1)
  br label %ifcont

ifcont:                                           ; preds = %else, %then
  %137 = getelementptr %array, %array* %cars, i32 0, i32 2
  %138 = load %dimension_descriptor*, %dimension_descriptor** %137, align 8
  %139 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %138, i32 0
  %140 = getelementptr %dimension_descriptor, %dimension_descriptor* %139, i32 0, i32 1
  %141 = load i32, i32* %140, align 4
  %142 = sub i32 0, %141
  %143 = mul i32 1, %142
  %144 = add i32 0, %143
  %145 = getelementptr %dimension_descriptor, %dimension_descriptor* %139, i32 0, i32 2
  %146 = load i32, i32* %145, align 4
  %147 = mul i32 1, %146
  %148 = getelementptr %array, %array* %cars, i32 0, i32 0
  %149 = load %Car*, %Car** %148, align 8
  %150 = getelementptr inbounds %Car, %Car* %149, i32 %144
  %151 = getelementptr %Car, %Car* %150, i32 0, i32 0
  %152 = load double, double* %151, align 8
  %153 = fsub double %152, 8.000000e+02
  store double %153, double* %call_arg_value, align 8
  %154 = call double @__module_lpython_builtin___lpython_overloaded_0__abs(double* %call_arg_value)
  %155 = fcmp ule double %154, 0x3D719799812DEA11
  br i1 %155, label %then1, label %else2

then1:                                            ; preds = %ifcont
  br label %ifcont3

else2:                                            ; preds = %ifcont
  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @1, i32 0, i32 0))
  call void @exit(i32 1)
  br label %ifcont3

ifcont3:                                          ; preds = %else2, %then1
  %156 = getelementptr %array, %array* %trucks, i32 0, i32 2
  %157 = load %dimension_descriptor*, %dimension_descriptor** %156, align 8
  %158 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %157, i32 0
  %159 = getelementptr %dimension_descriptor, %dimension_descriptor* %158, i32 0, i32 1
  %160 = load i32, i32* %159, align 4
  %161 = sub i32 0, %160
  %162 = mul i32 1, %161
  %163 = add i32 0, %162
  %164 = getelementptr %dimension_descriptor, %dimension_descriptor* %158, i32 0, i32 2
  %165 = load i32, i32* %164, align 4
  %166 = mul i32 1, %165
  %167 = getelementptr %array, %array* %trucks, i32 0, i32 0
  %168 = load %Car*, %Car** %167, align 8
  %169 = getelementptr inbounds %Car, %Car* %168, i32 %163
  %170 = getelementptr %Car, %Car* %169, i32 0, i32 0
  %171 = load double, double* %170, align 8
  %172 = icmp eq double %171, i32 1000000
  br i1 %172, label %then4, label %else5

then4:                                            ; preds = %ifcont3
  br label %ifcont6

else5:                                            ; preds = %ifcont3
  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @2, i32 0, i32 0))
  call void @exit(i32 1)
  br label %ifcont6

ifcont6:                                          ; preds = %else5, %then4
  %173 = getelementptr %array, %array* %trucks, i32 0, i32 2
  %174 = load %dimension_descriptor*, %dimension_descriptor** %173, align 8
  %175 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %174, i32 0
  %176 = getelementptr %dimension_descriptor, %dimension_descriptor* %175, i32 0, i32 1
  %177 = load i32, i32* %176, align 4
  %178 = sub i32 1, %177
  %179 = mul i32 1, %178
  %180 = add i32 0, %179
  %181 = getelementptr %dimension_descriptor, %dimension_descriptor* %175, i32 0, i32 2
  %182 = load i32, i32* %181, align 4
  %183 = mul i32 1, %182
  %184 = getelementptr %array, %array* %trucks, i32 0, i32 0
  %185 = load %Car*, %Car** %184, align 8
  %186 = getelementptr inbounds %Car, %Car* %185, i32 %180
  %187 = getelementptr %Car, %Car* %186, i32 0, i32 0
  %188 = load double, double* %187, align 8
  %189 = icmp eq double %188, i32 5000000
  br i1 %189, label %then7, label %else8

then7:                                            ; preds = %ifcont6
  br label %ifcont9

else8:                                            ; preds = %ifcont6
  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @3, i32 0, i32 0))
  call void @exit(i32 1)
  br label %ifcont9

ifcont9:                                          ; preds = %else8, %then7
  %190 = getelementptr %array, %array* %trucks, i32 0, i32 2
  %191 = load %dimension_descriptor*, %dimension_descriptor** %190, align 8
  %192 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %191, i32 0
  %193 = getelementptr %dimension_descriptor, %dimension_descriptor* %192, i32 0, i32 1
  %194 = load i32, i32* %193, align 4
  %195 = sub i32 0, %194
  %196 = mul i32 1, %195
  %197 = add i32 0, %196
  %198 = getelementptr %dimension_descriptor, %dimension_descriptor* %192, i32 0, i32 2
  %199 = load i32, i32* %198, align 4
  %200 = mul i32 1, %199
  %201 = getelementptr %array, %array* %trucks, i32 0, i32 0
  %202 = load %Car*, %Car** %201, align 8
  %203 = getelementptr inbounds %Car, %Car* %202, i32 %197
  %204 = getelementptr %Car, %Car* %203, i32 0, i32 1
  %205 = load i32, i32* %204, align 4
  %206 = icmp eq i32 %205, 8
  br i1 %206, label %then10, label %else11

then10:                                           ; preds = %ifcont9
  br label %ifcont12

else11:                                           ; preds = %ifcont9
  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @4, i32 0, i32 0))
  call void @exit(i32 1)
  br label %ifcont12

ifcont12:                                         ; preds = %else11, %then10
  %207 = getelementptr %array, %array* %trucks, i32 0, i32 2
  %208 = load %dimension_descriptor*, %dimension_descriptor** %207, align 8
  %209 = getelementptr inbounds %dimension_descriptor, %dimension_descriptor* %208, i32 0
  %210 = getelementptr %dimension_descriptor, %dimension_descriptor* %209, i32 0, i32 1
  %211 = load i32, i32* %210, align 4
  %212 = sub i32 1, %211
  %213 = mul i32 1, %212
  %214 = add i32 0, %213
  %215 = getelementptr %dimension_descriptor, %dimension_descriptor* %209, i32 0, i32 2
  %216 = load i32, i32* %215, align 4
  %217 = mul i32 1, %216
  %218 = getelementptr %array, %array* %trucks, i32 0, i32 0
  %219 = load %Car*, %Car** %218, align 8
  %220 = getelementptr inbounds %Car, %Car* %219, i32 %214
  %221 = getelementptr %Car, %Car* %220, i32 0, i32 1
  %222 = load i32, i32* %221, align 4
  %223 = icmp eq i32 %222, 12
  br i1 %223, label %then13, label %else14

then13:                                           ; preds = %ifcont12
  br label %ifcont15

else14:                                           ; preds = %ifcont12
  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @5, i32 0, i32 0))
  call void @exit(i32 1)
  br label %ifcont15

ifcont15:                                         ; preds = %else14, %then13
  br label %return

return:                                           ; preds = %ifcont15
  ret void
}

define double @__module_lpython_builtin___lpython_overloaded_0__abs(double* %x) {
.entry:
  %_lpython_return_variable = alloca double, align 8
  %result = alloca double, align 8
  %0 = load double, double* %x, align 8
  %1 = fcmp uge double %0, 0.000000e+00
  br i1 %1, label %then, label %else

then:                                             ; preds = %.entry
  %2 = load double, double* %x, align 8
  store double %2, double* %result, align 8
  br label %ifcont

else:                                             ; preds = %.entry
  %3 = load double, double* %x, align 8
  %4 = fsub double 0.000000e+00, %3
  store double %4, double* %result, align 8
  br label %ifcont

ifcont:                                           ; preds = %else, %then
  %5 = load double, double* %result, align 8
  store double %5, double* %_lpython_return_variable, align 8
  br label %return

unreachable_after_return:                         ; No predecessors!
  br label %return

return:                                           ; preds = %unreachable_after_return, %ifcont
  %6 = load double, double* %_lpython_return_variable, align 8
  ret double %6
}

declare float @_lfortran_caimag([2 x float])

declare double @_lfortran_zaimag(%complex_8)

declare double @_lfortran_dacos(double)

declare double @_lfortran_dacosh(double)

declare double @_lfortran_dasin(double)

declare double @_lfortran_dasinh(double)

declare double @_lfortran_datan(double)

declare double @_lfortran_datanh(double)

declare double @_lfortran_dcos(double)

declare double @_lfortran_dcosh(double)

declare double @_lfortran_dexp(double)

declare double @_lfortran_dlog(double)

declare double @_lfortran_dlog10(double)

declare double @_lfortran_dsin(double)

declare double @_lfortran_dsinh(double)

declare double @_lfortran_dtan(double)

declare double @_lfortran_dtanh(double)

declare float @_lfortran_sacos(float)

declare float @_lfortran_sacosh(float)

declare float @_lfortran_sasin(float)

declare float @_lfortran_sasinh(float)

declare float @_lfortran_satan(float)

declare float @_lfortran_satanh(float)

declare float @_lfortran_scos(float)

declare float @_lfortran_scosh(float)

declare float @_lfortran_sexp(float)

declare float @_lfortran_slog(float)

declare float @_lfortran_slog10(float)

declare float @_lfortran_ssin(float)

declare float @_lfortran_ssinh(float)

declare float @_lfortran_stan(float)

declare float @_lfortran_stanh(float)

declare void @_lfortran_printf(i8*, ...)

declare void @exit(i32)

define i32 @main() {
.entry:
  call void @_lpython_main_program()
  ret i32 0
}
code generation error: asr_to_llvm: module failed verification. Error:
Stored value type does not match pointer operand type!
  store i32 1000000, double* %74, align 4
 doubleStored value type does not match pointer operand type!
  store i32 5000000, double* %104, align 4
 doubleBoth operands to ICmp instruction are not of the same type!
  %172 = icmp eq double %171, i32 1000000
Both operands to ICmp instruction are not of the same type!
  %189 = icmp eq double %188, i32 5000000



Note: if any of the above error or warning messages are not clear or are lacking
context please report it to us (we consider that a bug that needs to be fixed).
```

</details>

```llvm
code generation error: asr_to_llvm: module failed verification. Error:
Stored value type does not match pointer operand type!
  store i32 1000000, double* %74, align 4
 doubleStored value type does not match pointer operand type!
  store i32 5000000, double* %104, align 4
 doubleBoth operands to ICmp instruction are not of the same type!
  %172 = icmp eq double %171, i32 1000000
Both operands to ICmp instruction are not of the same type!
  %189 = icmp eq double %188, i32 5000000
```

The reason it fails is because the current strategy for generating an array type uniquely for a given element type works only for intrinsic types (integer, float, complex). For derived types we need to use type code of element type (i.e., calling `ASRUtils::get_type_code`). Type codes are already being used to generate unique types for dict, list, etc. This PR fixes the same for arrays. 

Taken from #1164 