### PR TITLE
Add builtins

### DIFF
--- a/examples/example1.py
+++ b/examples/example1.py
@@ -1,7 +1,7 @@
 def main0():	
 	x: i32
 	x = 100
-	print((1023).to_bytes())
-	print(x.to_bytes())
+	print((7).to_bytes(5,'big'))
+	#print(x.to_bytes())
 	
 main0()

--- a/examples/example1.py
+++ b/examples/example1.py
@@ -1,0 +1,7 @@
+def main0():	
+	x: i32
+	x = 100
+	print((1023).to_bytes())
+	print(x.to_bytes())
+	
+main0()

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -304,6 +304,7 @@ expr
     | DictPop(expr a, expr key, ttype type, expr? value)
     | SetPop(expr a, ttype type, expr? value)
     | IntegerBitLen(expr a, ttype type, expr? value)
+    | IntegerToBytes(expr a, ttype type, expr? value)
 
 
 -- `len` in Character:

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -1250,6 +1250,22 @@ R"(#include <stdio.h>
         }
     }
 
+    void visit_IntegerToBytes(const ASR::IntegerToBytes_t& x) {
+        self().visit_expr(*x.m_a);
+        //int arg_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
+        src = "_lpython_to_bytes(" + src + ")";
+        // switch (arg_kind) {
+        //     case 1: src = "_lpython_bit_length1(" + src + ")"; break;
+        //     case 2: src = "_lpython_bit_length2(" + src + ")"; break;
+        //     case 4: src = "_lpython_bit_length4(" + src + ")"; break;
+        //     case 8: src = "_lpython_bit_length8(" + src + ")"; break;
+        //     default: throw CodeGenError("Unsupported Integer Kind: " + \
+        //                     std::to_string(arg_kind));
+        // }
+    }
+
+
+
     void visit_IntegerCompare(const ASR::IntegerCompare_t &x) {
         handle_Compare(x);
     }

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -737,6 +737,11 @@ LFORTRAN_API int32_t _lpython_bit_length8(int64_t num)
     return res;
 }
 
+LFORTRAN_API int32_t _lpython_to_bytes(int32_t num)
+{
+    return num;
+}
+
 //repeat str for n time
 LFORTRAN_API void _lfortran_strrepeat(char** s, int32_t n, char** dest)
 {

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -153,6 +153,7 @@ LFORTRAN_API int32_t _lpython_bit_length1(int8_t num);
 LFORTRAN_API int32_t _lpython_bit_length2(int16_t num);
 LFORTRAN_API int32_t _lpython_bit_length4(int32_t num);
 LFORTRAN_API int32_t _lpython_bit_length8(int64_t num);
+LFORTRAN_API int32_t _lpython_to_bytes(int32_t num);
 LFORTRAN_API void _lfortran_strrepeat(char** s, int32_t n, char** dest);
 LFORTRAN_API char* _lfortran_strrepeat_c(char* s, int32_t n);
 LFORTRAN_API void _lfortran_strcat(char** s1, char** s2, char** dest);

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -4856,6 +4856,13 @@ public:
                         4, nullptr, 0));
                     tmp = ASR::make_IntegerConstant_t(al, x.base.base.loc, res, int_type);
                     return;
+                } else if (std::string(at->m_attr) == std::string("to_bytes")) {
+                    AST::ConstantInt_t *n = AST::down_cast<AST::ConstantInt_t>(at->m_value);
+                    int64_t int_val = std::abs(n->m_value);
+                    ASR::ttype_t *int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc,
+                        4, nullptr, 0));
+                    tmp = ASR::make_IntegerConstant_t(al, x.base.base.loc, int_val, int_type);
+                    return;
                 } else {
                     throw SemanticError("'int' object has no attribute '" + std::string(at->m_attr) + "'",
                         x.base.base.loc);

--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -18,6 +18,7 @@ struct AttributeHandler {
 
     AttributeHandler() {
         attribute_map = {
+            {"int@to_bytes", &eval_int_to_bytes},
             {"int@bit_length", &eval_int_bit_length},
             {"list@append", &eval_list_append},
             {"list@remove", &eval_list_remove},
@@ -72,6 +73,17 @@ struct AttributeHandler {
         ASR::ttype_t *int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc,
                                         int_kind, nullptr, 0));
         return ASR::make_IntegerBitLen_t(al, loc, s, int_type, nullptr);
+    }
+
+    static ASR::asr_t* eval_int_to_bytes(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &/*diag*/) {
+        if (args.size() != 0) {
+            throw SemanticError("int.bit_length() takes no arguments", loc);
+        }
+        int int_kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(s));
+        ASR::ttype_t *int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc,
+                                        int_kind, nullptr, 0));
+        return ASR::make_IntegerToBytes_t(al, loc, s, int_type, nullptr);
     }
 
     static ASR::asr_t* eval_list_append(ASR::expr_t *s, Allocator &al, const Location &loc,


### PR DESCRIPTION
I have implemented the compile time function (mostly by monkey-ing the changes made in #875) that will be called when the `int.to_bytes()` method will be called.

As per discussion (#281) the implementation currently returns a string only and NOT an instance of the `class bytes` which is yet to be implemented.

Creating a draft PR so that maintainers can keep an eye on the progress.

Please feel free to leave comments because this is my first PR on any open source project so it will be very helpful! Thanks!

Related to #281 