### PR TITLE
Removing `getPointerElementType` usage in LLVM backend

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -685,14 +685,19 @@ static inline std::string get_type_code(const ASR::ttype_t *t, bool use_undersco
         }
         case ASR::ttypeType::Complex: {
             ASR::Complex_t *complx = ASR::down_cast<ASR::Complex_t>(t);
-            std::string res = "r" + std::to_string(complx->m_kind * 8);
+            std::string res = "c" + std::to_string(complx->m_kind * 8);
             if( encode_dimensions_ ) {
                 encode_dimensions(complx->n_dims, res, use_underscore_sep);
             }
             return res;
         }
         case ASR::ttypeType::Logical: {
-            return "bool";
+            ASR::Logical_t* bool_ = ASR::down_cast<ASR::Logical_t>(t);
+            std::string res = "bool";
+            if( encode_dimensions_ ) {
+                encode_dimensions(bool_->n_dims, res, use_underscore_sep);
+            }
+            return res;
         }
         case ASR::ttypeType::Character: {
             return "str";
@@ -750,7 +755,19 @@ static inline std::string get_type_code(const ASR::ttype_t *t, bool use_undersco
         }
         case ASR::ttypeType::Struct: {
             ASR::Struct_t* d = ASR::down_cast<ASR::Struct_t>(t);
-            return symbol_name(d->m_derived_type);
+            std::string res = symbol_name(d->m_derived_type);
+            if( encode_dimensions_ ) {
+                encode_dimensions(d->n_dims, res, use_underscore_sep);
+            }
+            return res;
+        }
+        case ASR::ttypeType::Union: {
+            ASR::Union_t* d = ASR::down_cast<ASR::Union_t>(t);
+            std::string res = symbol_name(d->m_union_type);
+            if( encode_dimensions_ ) {
+                encode_dimensions(d->n_dims, res, use_underscore_sep);
+            }
+            return res;
         }
         case ASR::ttypeType::Pointer: {
             ASR::Pointer_t* p = ASR::down_cast<ASR::Pointer_t>(t);
@@ -1362,11 +1379,26 @@ static inline ASR::ttype_t* duplicate_type_without_dims(Allocator& al, const ASR
             return ASRUtils::TYPE(ASR::make_Real_t(al, t->base.loc,
                         tnew->m_kind, nullptr, 0));
         }
+        case ASR::ttypeType::Complex: {
+            ASR::Complex_t* tnew = ASR::down_cast<ASR::Complex_t>(t);
+            return ASRUtils::TYPE(ASR::make_Complex_t(al, t->base.loc,
+                        tnew->m_kind, nullptr, 0));
+        }
+        case ASR::ttypeType::Logical: {
+            ASR::Logical_t* tnew = ASR::down_cast<ASR::Logical_t>(t);
+            return ASRUtils::TYPE(ASR::make_Logical_t(al, t->base.loc,
+                        tnew->m_kind, nullptr, 0));
+        }
         case ASR::ttypeType::Character: {
             ASR::Character_t* tnew = ASR::down_cast<ASR::Character_t>(t);
             return ASRUtils::TYPE(ASR::make_Character_t(al, t->base.loc,
                         tnew->m_kind, tnew->m_len, tnew->m_len_expr,
                         nullptr, 0));
+        }
+        case ASR::ttypeType::Struct: {
+            ASR::Struct_t* tstruct = ASR::down_cast<ASR::Struct_t>(t);
+            return ASRUtils::TYPE(ASR::make_Struct_t(al, t->base.loc,
+                    tstruct->m_derived_type, nullptr, 0));
         }
         case ASR::ttypeType::TypeParameter: {
             ASR::TypeParameter_t* tp = ASR::down_cast<ASR::TypeParameter_t>(t);

--- a/src/libasr/codegen/llvm_array_utils.h
+++ b/src/libasr/codegen/llvm_array_utils.h
@@ -74,12 +74,12 @@ namespace LFortran {
                     DESCR_TYPE descr_type);
 
                 /*
-                * Checks whether the given llvm::Value* is an
+                * Checks whether the given ASR::ttype_t* is an
                 * array and follows the same structure as
                 * the current descriptor.
                 */
                 virtual
-                bool is_array(llvm::Value* tmp) = 0;
+                bool is_array(ASR::ttype_t* asr_type) = 0;
 
                 /*
                 * Converts a given array llvm::Value*
@@ -87,7 +87,8 @@ namespace LFortran {
                 */
                 virtual
                 llvm::Value* convert_to_argument(llvm::Value* tmp,
-                    llvm::Type* arg_type, bool data_only=false) = 0;
+                    ASR::ttype_t* asr_arg_type, llvm::Type* arg_type,
+                    bool data_only=false) = 0;
 
                 /*
                 * Returns the type of the argument to be
@@ -139,7 +140,7 @@ namespace LFortran {
                 */
                 virtual
                 void fill_array_details(
-                    llvm::Value* arr, int n_dims,
+                    llvm::Value* arr, llvm::Type* llvm_data_type, int n_dims,
                     std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims) = 0;
 
                 /*
@@ -148,7 +149,7 @@ namespace LFortran {
                 */
                 virtual
                 void fill_malloc_array_details(
-                    llvm::Value* arr, int n_dims,
+                    llvm::Value* arr, llvm::Type* llvm_data_type, int n_dims,
                     std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims,
                     llvm::Module* module) = 0;
 
@@ -252,8 +253,9 @@ namespace LFortran {
                 void set_is_allocated_flag(llvm::Value* array, uint64_t status) = 0;
 
                 virtual
-                llvm::Value* reshape(llvm::Value* array, llvm::Value* shape,
-                                    llvm::Module* module) = 0;
+                llvm::Value* reshape(llvm::Value* array, llvm::Type* llvm_data_type,
+                                     llvm::Value* shape, ASR::ttype_t* asr_shape_type,
+                                     llvm::Module* module) = 0;
 
                 virtual
                 void copy_array(llvm::Value* src, llvm::Value* dest) = 0;
@@ -291,11 +293,12 @@ namespace LFortran {
                     LLVMUtils* _llvm_utils);
 
                 virtual
-                bool is_array(llvm::Value* tmp);
+                bool is_array(ASR::ttype_t* asr_type);
 
                 virtual
                 llvm::Value* convert_to_argument(llvm::Value* tmp,
-                    llvm::Type* arg_type, bool data_only=false);
+                    ASR::ttype_t* asr_arg_type, llvm::Type* arg_type,
+                    bool data_only=false);
 
                 virtual
                 llvm::Type* get_argument_type(llvm::Type* type,
@@ -322,12 +325,12 @@ namespace LFortran {
 
                 virtual
                 void fill_array_details(
-                    llvm::Value* arr, int n_dims,
+                    llvm::Value* arr, llvm::Type* llvm_data_type, int n_dims,
                     std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims);
 
                 virtual
                 void fill_malloc_array_details(
-                    llvm::Value* arr, int n_dims,
+                    llvm::Value* arr, llvm::Type* llvm_data_type, int n_dims,
                     std::vector<std::pair<llvm::Value*, llvm::Value*>>& llvm_dims,
                     llvm::Module* module);
 
@@ -382,8 +385,9 @@ namespace LFortran {
                 void set_is_allocated_flag(llvm::Value* array, uint64_t status);
 
                 virtual
-                llvm::Value* reshape(llvm::Value* array, llvm::Value* shape,
-                                    llvm::Module* module);
+                llvm::Value* reshape(llvm::Value* array, llvm::Type* llvm_data_type,
+                                     llvm::Value* shape, ASR::ttype_t* asr_shape_type,
+                                     llvm::Module* module);
 
                 virtual
                 void copy_array(llvm::Value* src, llvm::Value* dest);


### PR DESCRIPTION
LFortran PR - https://github.com/lfortran/lfortran/pull/908