### PR TITLE
CPP: Implement list

### DIFF
--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -341,6 +341,12 @@ public:
                 } else {
                     sub = format_type(dims, "struct", v.m_name, use_ref, dummy);
                 }
+            } else if (ASR::is_a<ASR::List_t>(*v.m_type)) {
+                ASR::List_t* t = ASR::down_cast<ASR::List_t>(v.m_type);
+                std::string list_element_type = get_c_type_from_ttype_t(t->m_type);
+                std::string list_type_c = list_api->get_list_type(t, list_element_type);
+                sub = format_type("", list_type_c, v.m_name,
+                                    false, false);
             } else {
                 diag.codegen_error_label("Type number '"
                     + std::to_string(v.m_type->type)
@@ -368,6 +374,9 @@ public:
         std::string unit_src = "";
         indentation_level = 0;
         indentation_spaces = 4;
+
+        list_api->set_indentation(indentation_level, indentation_spaces);
+        list_api->set_global_scope(global_scope);
 
         std::string headers =
 R"(#include <iostream>
@@ -455,7 +464,16 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
             }
         }
 
-        src = headers + array_types_decls + unit_src;
+        if (list_api->get_list_func_decls().size() > 0) {
+            array_types_decls += "\n" + list_api->get_list_func_decls() + "\n";
+        }
+
+        std::string list_funcs_defined = "";
+        if (list_api->get_generated_code().size() > 0) {
+            list_funcs_defined =  "\n" + list_api->get_generated_code() + "\n";
+        }
+
+        src = headers + array_types_decls + unit_src + list_funcs_defined;
     }
 
     void visit_Program(const ASR::Program_t &x) {


### PR DESCRIPTION
@certik @czgdp1807 

1. The current implementation uses `list_api` which is the same as in `C`. Should also add an option to use STL libraries in CPP like `vector` which might provide cleaner code just from developer's point of view. I'm not sure about the performance difference and would try the benchmarks using the current `list_api` and `std::vector`.
2. One more question is should we keep using `Kokkos`?
3. Once we figure out the above 2 solutions we can also start testing the CPP backend in integration tests?