### PR TITLE
Allowing using global constants to initialise other global constants

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -156,6 +156,7 @@ RUN(NAME print_01            LABELS cpython llvm c wasm) # wasm not yet supports
 # CPython and LLVM
 RUN(NAME const_01            LABELS cpython llvm c)
 RUN(NAME const_02            LABELS cpython llvm c)
+RUN(NAME const_03            LABELS cpython llvm c)
 RUN(NAME expr_01             LABELS cpython llvm c wasm)
 RUN(NAME expr_02             LABELS cpython llvm c wasm)
 RUN(NAME expr_03             LABELS cpython llvm c wasm)

--- a/integration_tests/const_03.py
+++ b/integration_tests/const_03.py
@@ -1,0 +1,12 @@
+from ltypes import i64, f64, Const
+
+CONST_1: Const[f64] = 32.0
+CONST_2: Const[f64] = CONST_1 * 2.0
+CONST_3: Const[i64] = CONST_1 + CONST_2
+
+def test_global_consts():
+    assert CONST_1 == 32
+    assert CONST_2 == 64
+    assert abs(CONST_3 - 96.0) < 1e-12
+
+test_global_consts()

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1531,6 +1531,9 @@ public:
 
     void cast_helper(ASR::ttype_t* dest_type, ASR::expr_t*& src_expr) {
         ASR::ttype_t* src_type = ASRUtils::expr_type(src_expr);
+        if( ASR::is_a<ASR::Const_t>(*src_type) ) {
+            src_type = ASRUtils::get_contained_type(src_type);
+        }
         if( ASRUtils::check_equal_type(src_type, dest_type) ) {
             return ;
         }
@@ -2066,12 +2069,10 @@ public:
                     throw SemanticAbort();
                 }
                 init_expr = value;
-                // Set compile time to value to nullptr
-                // Once constant variables are supported
-                // in LPython set value according to the
-                // nature of the variable (nullptr if non-constant,
-                // otherwise ASRUtils::expr_value(init_expr).
                 value = nullptr;
+                if( ASR::is_a<ASR::Const_t>(*type) ) {
+                    value = ASRUtils::expr_value(init_expr);
+                }
             }
         } else {
             cast_helper(type, init_expr);


### PR DESCRIPTION
Taken from https://github.com/lcompilers/lpython/pull/1213/files