### PR TITLE
Always declare global constants in LLVM backend

### DIFF
--- a/integration_tests/const_03.py
+++ b/integration_tests/const_03.py
@@ -1,10 +1,19 @@
-from ltypes import i64, f64, Const
+from ltypes import i64, f64, i32, Const
 
 CONST_1: Const[f64] = 32.0
 CONST_2: Const[f64] = CONST_1 * 2.0
 CONST_3: Const[i64] = CONST_1 + CONST_2
 
+CONST_11: Const[i32] = 32
+CONST_12: Const[i32] = CONST_11
+
+def print_value(value: Const[f64]):
+    print(value)
+
 def test_global_consts():
+    print_value(CONST_1)
+    print_value(CONST_2)
+    print(CONST_12)
     assert CONST_1 == 32
     assert CONST_2 == 64
     assert abs(CONST_3 - 96.0) < 1e-12

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1183,6 +1183,9 @@ static inline int extract_kind_from_ttype_t(const ASR::ttype_t* type) {
         case ASR::ttypeType::Pointer: {
             return extract_kind_from_ttype_t(ASR::down_cast<ASR::Pointer_t>(type)->m_type);
         }
+        case ASR::ttypeType::Const: {
+             return extract_kind_from_ttype_t(ASR::down_cast<ASR::Const_t>(type)->m_type);
+         }
         default : {
             return -1;
         }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5668,11 +5668,24 @@ public:
                         } else {
                             auto finder = std::find(nested_globals.begin(),
                                     nested_globals.end(), h);
-                            LFORTRAN_ASSERT(finder != nested_globals.end());
-                            llvm::Value* ptr = module->getOrInsertGlobal(nested_desc_name,
-                                nested_global_struct);
-                            int idx = std::distance(nested_globals.begin(), finder);
-                            tmp = CreateLoad(llvm_utils->create_gep(ptr, idx));
+                            if (finder == nested_globals.end()) {
+                                if (arg->m_value == nullptr) {
+                                    throw CodeGenError(std::string(arg->m_name) + " isn't defined in any scope.");
+                                }
+                                this->visit_expr_wrapper(arg->m_value, true);
+                                llvm::BasicBlock &entry_block = builder->GetInsertBlock()->getParent()->getEntryBlock();
+                                llvm::IRBuilder<> builder0(context);
+                                builder0.SetInsertPoint(&entry_block, entry_block.getFirstInsertionPt());
+                                llvm::AllocaInst *target = builder0.CreateAlloca(
+                                    get_type_from_ttype_t_util(arg->m_type), nullptr, "call_arg_value");
+                                builder->CreateStore(tmp, target);
+                                tmp = target;
+                            } else {
+                                llvm::Value* ptr = module->getOrInsertGlobal(nested_desc_name,
+                                    nested_global_struct);
+                                int idx = std::distance(nested_globals.begin(), finder);
+                                tmp = CreateLoad(llvm_utils->create_gep(ptr, idx));
+                            }
                         }
                     } else if (is_a<ASR::Function_t>(*symbol_get_past_external(
                         ASR::down_cast<ASR::Var_t>(x.m_args[i].m_value)->m_v))) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4570,7 +4570,7 @@ public:
 
     void visit_IntegerConstant(const ASR::IntegerConstant_t &x) {
         int64_t val = x.m_n;
-        int a_kind = ((ASR::Integer_t*)(&(x.m_type->base)))->m_kind;
+        int a_kind = ASRUtils::extract_kind_from_ttype_t(x.m_type);
         switch( a_kind ) {
 
             case 1: {


### PR DESCRIPTION
We shouldn't directly use the values of global constants in LLVM backend. Because by doing so we skip the declaration of these global constants and in turn they become un-usable in the rest of the program (like passing them as an argument to a function). The other way is to always check whether a variable is a global constant or not and if its a global constant then use the compile time value. However IMO, that's a very bug prone path as we will almost always forget to do such checks while making use of `ASR::Variable_t` in LLVM backend. So, declaring it is a decent and robust solution. We can optimise by directly using values on a case by case basis (like if we find the need to do it in a particular then do it otherwise fallback global variable is always present).