### PR TITLE
Initial debugging info implementation

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -22,6 +22,7 @@ def single_test(test, verbose, no_llvm, update_reference,
     ast_new = is_included("ast_new")
     asr = is_included("asr")
     llvm = is_included("llvm")
+    llvm_dbg = is_included("llvm_dbg")
     cpp = is_included("cpp")
     c = is_included("c")
     wat = is_included("wat")
@@ -80,14 +81,22 @@ def single_test(test, verbose, no_llvm, update_reference,
         run_test(filename, "pass_{}".format(pass_), cmd,
                  filename, update_reference, extra_args)
 
-    if llvm:
-        if no_llvm:
-            log.info(f"{filename} * llvm   SKIPPED as requested")
-        else:
+    if no_llvm:
+        log.info(f"{filename} * llvm   SKIPPED as requested")
+    else:
+        if llvm:
             run_test(
                 filename,
                 "llvm",
                 "lpython --no-color --show-llvm {infile} -o {outfile}",
+                filename,
+                update_reference,
+                extra_args)
+        if llvm_dbg:
+            run_test(
+                filename,
+                "llvm_dbg",
+                "lpython --no-color --show-llvm -g {infile} -o {outfile}",
                 filename,
                 update_reference,
                 extra_args)

--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -1076,7 +1076,6 @@ int main(int argc, char *argv[])
         bool arg_c = false;
         bool arg_v = false;
         // bool arg_E = false;
-        // bool arg_g = false;
         // std::string arg_J;
         // std::vector<std::string> arg_I;
         // std::vector<std::string> arg_l;
@@ -1135,7 +1134,7 @@ int main(int argc, char *argv[])
         app.add_option("-I", compiler_options.import_path, "Specify the path"
             "to look for the module")->allow_extra_args(false);
         // app.add_option("-J", arg_J, "Where to save mod files");
-        // app.add_flag("-g", arg_g, "Compile with debugging information");
+        app.add_flag("-g", compiler_options.arg_g, "Compile with debugging information");
         // app.add_option("-D", compiler_options.c_preprocessor_defines, "Define <macro>=<value> (or 1 if <value> omitted)")->allow_extra_args(false);
         app.add_flag("--version", arg_version, "Display compiler version information");
 

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3092,6 +3092,7 @@ public:
         parent_function = nullptr;
         dict_api_lp->set_is_dict_present(is_dict_present_copy_lp);
         dict_api_sc->set_is_dict_present(is_dict_present_copy_sc);
+        DBuilder->finalize();
     }
 
     void instantiate_function(const ASR::Function_t &x){

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3131,21 +3131,14 @@ public:
                     debug_CU->getFilename(),
                     debug_CU->getDirectory());
                 llvm::DIScope *FContext = Unit;
-                unsigned LineNo = 0;
-                unsigned ScopeLine = 0;
+                uint64_t LineNo = 0;
+                uint64_t ScopeLine = 0;
                 std::string fn_debug_name = x.m_name;
-                llvm::SmallVector<llvm::Metadata *, 8> el_types;
-                llvm::DIType *DblTy = DBuilder->createBasicType("double", 64,
-                    llvm::dwarf::DW_ATE_float);
-                el_types.push_back(DblTy);
-                el_types.push_back(DblTy);
-                el_types.push_back(DblTy);
                 llvm::DISubroutineType *dtype = DBuilder->createSubroutineType(
-                    DBuilder->getOrCreateTypeArray(el_types));
+                    DBuilder->getOrCreateTypeArray(nullptr));
                 SP = DBuilder->createFunction(
-                    FContext, fn_debug_name, llvm::StringRef(), Unit, LineNo,
-                    dtype,
-                    ScopeLine,
+                    FContext, fn_debug_name, llvm::StringRef(), Unit,
+                    LineNo, dtype, ScopeLine,
                     llvm::DINode::FlagPrototyped,
                     llvm::DISubprogram::SPFlagDefinition);
                 F->setSubprogram(SP);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -345,7 +345,7 @@ public:
     void debug_emit_loc(const T &x) {
         Location loc = x.base.base.loc;
         uint64_t line = loc.first;
-        uint64_t column = loc.first;
+        uint64_t column = 0;
         builder->SetCurrentDebugLocation(
             llvm::DILocation::get(debug_current_scope->getContext(),
                 line, column, debug_current_scope));

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3150,6 +3150,7 @@ public:
                     llvm::DISubprogram::SPFlagDefinition);
                 F->setSubprogram(SP);
                 debug_current_scope = SP;
+                debug_emit_loc(x);
             } else {
                 uint32_t old_h = llvm_symtab_fn_names[fn_name];
                 F = llvm_symtab_fn[old_h];
@@ -3358,6 +3359,7 @@ public:
         llvm::BasicBlock *BB = llvm::BasicBlock::Create(context,
                 ".entry", F);
         builder->SetInsertPoint(BB);
+        debug_emit_loc(x);
         declare_args(x, *F);
         declare_local_vars(x);
     }
@@ -5922,7 +5924,7 @@ public:
     }
 
     void visit_SubroutineCall(const ASR::SubroutineCall_t &x) {
-        //debug_emit_loc(x);
+        debug_emit_loc(x);
         if( ASRUtils::is_intrinsic_optimization(x.m_name) ) {
             ASR::Function_t* routine = ASR::down_cast<ASR::Function_t>(
                         ASRUtils::symbol_get_past_external(x.m_name));

--- a/src/libasr/codegen/asr_to_llvm.h
+++ b/src/libasr/codegen/asr_to_llvm.h
@@ -11,7 +11,7 @@ namespace LFortran {
             diag::Diagnostics &diagnostics,
             llvm::LLVMContext &context, Allocator &al,
             LCompilers::PassManager& pass_manager,
-            Platform platform,
+            CompilerOptions &co,
             const std::string &run_fn);
 
 } // namespace LFortran

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -38,6 +38,7 @@ struct CompilerOptions {
     bool implicit_interface = false;
     std::string target = "";
     std::string arg_o = "";
+    bool arg_g = false;
     std::string import_path = "";
     Platform platform;
 

--- a/src/lpython/python_evaluator.cpp
+++ b/src/lpython/python_evaluator.cpp
@@ -54,7 +54,7 @@ Result<std::unique_ptr<LLVMModule>> PythonCompiler::get_llvm3(
     std::unique_ptr<LFortran::LLVMModule> m;
     Result<std::unique_ptr<LFortran::LLVMModule>> res
         = asr_to_llvm(asr, diagnostics,
-            e->get_context(), al, lpm, compiler_options.platform,
+            e->get_context(), al, lpm, compiler_options,
             run_fn);
     if (res.ok) {
         m = std::move(res.result);

--- a/tests/reference/llvm_dbg-expr_01-bc258d6.json
+++ b/tests/reference/llvm_dbg-expr_01-bc258d6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm_dbg-expr_01-bc258d6.stdout",
-    "stdout_hash": "61d43851fd28f9d5eaa81cbe3ab5d73b1ecfba96ab2a71099cd9a300",
+    "stdout_hash": "81125732049c71a6e7061cb752e3d50b5ab879c8ee939a454b326ac7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm_dbg-expr_01-bc258d6.json
+++ b/tests/reference/llvm_dbg-expr_01-bc258d6.json
@@ -1,0 +1,13 @@
+{
+    "basename": "llvm_dbg-expr_01-bc258d6",
+    "cmd": "lpython --no-color --show-llvm -g {infile} -o {outfile}",
+    "infile": "tests/expr_01.py",
+    "infile_hash": "4284fe3a1b4dd3e5d1de1357a79e9a25b426ca245b4cc91cf99e8547",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "llvm_dbg-expr_01-bc258d6.stdout",
+    "stdout_hash": "c154701c9d118a952d9c6640361115fce74b0e52093ab0b68532f094",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/llvm_dbg-expr_01-bc258d6.json
+++ b/tests/reference/llvm_dbg-expr_01-bc258d6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm_dbg-expr_01-bc258d6.stdout",
-    "stdout_hash": "c154701c9d118a952d9c6640361115fce74b0e52093ab0b68532f094",
+    "stdout_hash": "61d43851fd28f9d5eaa81cbe3ab5d73b1ecfba96ab2a71099cd9a300",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm_dbg-expr_01-bc258d6.stdout
+++ b/tests/reference/llvm_dbg-expr_01-bc258d6.stdout
@@ -1,0 +1,53 @@
+; ModuleID = 'LFortran'
+source_filename = "LFortran"
+
+@0 = private unnamed_addr constant [2 x i8] c" \00", align 1
+@1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@2 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1
+
+define void @_lpython_main_program() !dbg !3 {
+.entry:
+  call void @main0(), !dbg !6
+  br label %return, !dbg !6
+
+return:                                           ; preds = %.entry
+  ret void, !dbg !6
+}
+
+define void @main0() !dbg !7 {
+.entry:
+  %x = alloca i32, align 4, !dbg !8
+  %x2 = alloca i64, align 8, !dbg !8
+  %y = alloca float, align 4, !dbg !8
+  %y2 = alloca double, align 8, !dbg !8
+  store i32 25, i32* %x, align 4, !dbg !9
+  %0 = load i32, i32* %x, align 4, !dbg !9
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0)), !dbg !9
+  br label %return, !dbg !9
+
+return:                                           ; preds = %.entry
+  ret void, !dbg !9
+}
+
+declare void @_lfortran_printf(i8*, ...)
+
+define i32 @main() !dbg !10 {
+.entry:
+  call void @_lpython_main_program(), !dbg !11
+  ret i32 0, !dbg !11
+}
+
+!llvm.dbg.cu = !{!0}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "LPython Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
+!1 = !DIFile(filename: "xxexpr.py", directory: "/yy/")
+!2 = !{}
+!3 = distinct !DISubprogram(name: "_lpython_main_program", scope: !1, file: !1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!4 = !DISubroutineType(types: !5)
+!5 = !{null}
+!6 = !DILocation(line: 89, column: 89, scope: !3)
+!7 = distinct !DISubprogram(name: "main0", scope: !1, file: !1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!8 = !DILocation(line: 0, scope: !7)
+!9 = !DILocation(line: 63, column: 63, scope: !7)
+!10 = distinct !DISubprogram(name: "main_program", scope: !1, file: !1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!11 = !DILocation(line: 0, scope: !10)

--- a/tests/reference/llvm_dbg-expr_01-bc258d6.stdout
+++ b/tests/reference/llvm_dbg-expr_01-bc258d6.stdout
@@ -17,25 +17,34 @@ return:                                           ; preds = %.entry
 define void @main0() !dbg !7 {
 .entry:
   %x = alloca i32, align 4, !dbg !8
+  call void @llvm.dbg.declare(metadata i32* %x, metadata !9, metadata !DIExpression()), !dbg !11
   %x2 = alloca i64, align 8, !dbg !8
+  call void @llvm.dbg.declare(metadata i64* %x2, metadata !12, metadata !DIExpression()), !dbg !14
   %y = alloca float, align 4, !dbg !8
+  call void @llvm.dbg.declare(metadata float* %y, metadata !15, metadata !DIExpression()), !dbg !17
   %y2 = alloca double, align 8, !dbg !8
-  store i32 25, i32* %x, align 4, !dbg !9
-  %0 = load i32, i32* %x, align 4, !dbg !9
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0)), !dbg !9
-  br label %return, !dbg !9
+  call void @llvm.dbg.declare(metadata double* %y2, metadata !18, metadata !DIExpression()), !dbg !20
+  store i32 25, i32* %x, align 4, !dbg !21
+  %0 = load i32, i32* %x, align 4, !dbg !21
+  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0)), !dbg !21
+  br label %return, !dbg !21
 
 return:                                           ; preds = %.entry
-  ret void, !dbg !9
+  ret void, !dbg !21
 }
+
+; Function Attrs: nounwind readnone speculatable willreturn
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
 
 declare void @_lfortran_printf(i8*, ...)
 
-define i32 @main() !dbg !10 {
+define i32 @main() !dbg !22 {
 .entry:
-  call void @_lpython_main_program(), !dbg !11
-  ret i32 0, !dbg !11
+  call void @_lpython_main_program(), !dbg !23
+  ret i32 0, !dbg !23
 }
+
+attributes #0 = { nounwind readnone speculatable willreturn }
 
 !llvm.dbg.cu = !{!0}
 
@@ -48,6 +57,18 @@ define i32 @main() !dbg !10 {
 !6 = !DILocation(line: 89, column: 89, scope: !3)
 !7 = distinct !DISubprogram(name: "main0", scope: !1, file: !1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !8 = !DILocation(line: 0, scope: !7)
-!9 = !DILocation(line: 63, column: 63, scope: !7)
-!10 = distinct !DISubprogram(name: "main_program", scope: !1, file: !1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
-!11 = !DILocation(line: 0, scope: !10)
+!9 = !DILocalVariable(name: "x", arg: 1, scope: !7, file: !1, line: 17, type: !10)
+!10 = !DIBasicType(name: "integer", size: 32, encoding: DW_ATE_signed)
+!11 = !DILocation(line: 17, scope: !7)
+!12 = !DILocalVariable(name: "x2", arg: 2, scope: !7, file: !1, line: 28, type: !13)
+!13 = !DIBasicType(name: "integer", size: 64, encoding: DW_ATE_signed)
+!14 = !DILocation(line: 28, scope: !7)
+!15 = !DILocalVariable(name: "y", arg: 3, scope: !7, file: !1, line: 40, type: !16)
+!16 = !DIBasicType(name: "float", size: 32, encoding: DW_ATE_float)
+!17 = !DILocation(line: 40, scope: !7)
+!18 = !DILocalVariable(name: "y2", arg: 4, scope: !7, file: !1, line: 51, type: !19)
+!19 = !DIBasicType(name: "double", size: 64, encoding: DW_ATE_float)
+!20 = !DILocation(line: 51, scope: !7)
+!21 = !DILocation(line: 63, column: 63, scope: !7)
+!22 = distinct !DISubprogram(name: "main_program", scope: !1, file: !1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!23 = !DILocation(line: 0, scope: !22)

--- a/tests/reference/llvm_dbg-expr_01-bc258d6.stdout
+++ b/tests/reference/llvm_dbg-expr_01-bc258d6.stdout
@@ -18,11 +18,11 @@ define void @main0() !dbg !7 {
 .entry:
   %x = alloca i32, align 4, !dbg !8
   call void @llvm.dbg.declare(metadata i32* %x, metadata !9, metadata !DIExpression()), !dbg !11
-  %x2 = alloca i64, align 8, !dbg !8
+  %x2 = alloca i64, align 8
   call void @llvm.dbg.declare(metadata i64* %x2, metadata !12, metadata !DIExpression()), !dbg !14
-  %y = alloca float, align 4, !dbg !8
+  %y = alloca float, align 4
   call void @llvm.dbg.declare(metadata float* %y, metadata !15, metadata !DIExpression()), !dbg !17
-  %y2 = alloca double, align 8, !dbg !8
+  %y2 = alloca double, align 8
   call void @llvm.dbg.declare(metadata double* %y2, metadata !18, metadata !DIExpression()), !dbg !20
   store i32 25, i32* %x, align 4, !dbg !21
   %0 = load i32, i32* %x, align 4, !dbg !21
@@ -40,8 +40,8 @@ declare void @_lfortran_printf(i8*, ...)
 
 define i32 @main() !dbg !22 {
 .entry:
-  call void @_lpython_main_program(), !dbg !23
-  ret i32 0, !dbg !23
+  call void @_lpython_main_program(), !dbg !25
+  ret i32 0, !dbg !25
 }
 
 attributes #0 = { nounwind readnone speculatable willreturn }
@@ -54,7 +54,7 @@ attributes #0 = { nounwind readnone speculatable willreturn }
 !3 = distinct !DISubprogram(name: "_lpython_main_program", scope: !1, file: !1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !4 = !DISubroutineType(types: !5)
 !5 = !{null}
-!6 = !DILocation(line: 89, column: 89, scope: !3)
+!6 = !DILocation(line: 89, scope: !3)
 !7 = distinct !DISubprogram(name: "main0", scope: !1, file: !1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !8 = !DILocation(line: 0, scope: !7)
 !9 = !DILocalVariable(name: "x", arg: 1, scope: !7, file: !1, line: 17, type: !10)
@@ -69,6 +69,8 @@ attributes #0 = { nounwind readnone speculatable willreturn }
 !18 = !DILocalVariable(name: "y2", arg: 4, scope: !7, file: !1, line: 51, type: !19)
 !19 = !DIBasicType(name: "double", size: 64, encoding: DW_ATE_float)
 !20 = !DILocation(line: 51, scope: !7)
-!21 = !DILocation(line: 63, column: 63, scope: !7)
-!22 = distinct !DISubprogram(name: "main_program", scope: !1, file: !1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
-!23 = !DILocation(line: 0, scope: !22)
+!21 = !DILocation(line: 63, scope: !7)
+!22 = distinct !DISubprogram(name: "main_program", scope: !1, file: !1, type: !23, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!23 = !DISubroutineType(types: !24)
+!24 = !{!10}
+!25 = !DILocation(line: 0, scope: !22)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -144,6 +144,7 @@ filename = "expr_01.py"
 ast = true
 asr = true
 llvm = true
+llvm_dbg = true
 
 [[test]]
 filename = "../integration_tests/array_01_decl.py"

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3,6 +3,7 @@
 # ast_new ... run the New Parser and output AST, compare against reference version
 # asr ... run the Semantics and output ASR, compare against reference version
 # llvm ... run the Semantics and output LLVM, compare against reference version
+# llvm_dbg ... run the Semantics and output LLVM with debug information
 # tokens ... output Tokens, compare against reference version
 # run ... compiles and executes the specified file;
 #         checks both runtime errors and successful runs


### PR DESCRIPTION
Currently it shows:
```llvm
$ lpython --show-llvm examples/expr2.py 
; ModuleID = 'LFortran'
source_filename = "LFortran"

@0 = private unnamed_addr constant [2 x i8] c" \00", align 1
@1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
@2 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1

define void @_lpython_main_program() !dbg !2 {
.entry:
  call void @main0()
  br label %return

return:                                           ; preds = %.entry
  ret void
}

define void @main0() !dbg !7 {
.entry:
  %x = alloca i32, align 4
  store i32 25, i32* %x, align 4, !dbg !9
  %0 = load i32, i32* %x, align 4, !dbg !9
  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @2, i32 0, i32 0), i32 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0)), !dbg !9
  br label %return, !dbg !9

return:                                           ; preds = %.entry
  ret void, !dbg !9
}

declare void @_lfortran_printf(i8*, ...)

define i32 @main() {
.entry:
  call void @_lpython_main_program(), !dbg !9
  ret i32 0, !dbg !9
}

!llvm.dbg.cu = !{!0}

!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "Kaleidoscope Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
!1 = !DIFile(filename: "xxexpr.py", directory: "/yy/")
!2 = distinct !DISubprogram(name: "_lpython_main_program", scope: !1, file: !1, type: !3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !6)
!3 = !DISubroutineType(types: !4)
!4 = !{!5, !5, !5}
!5 = !DIBasicType(name: "double", size: 64, encoding: DW_ATE_float)
!6 = <temporary!> !{}
!7 = distinct !DISubprogram(name: "main0", scope: !1, file: !1, type: !3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !8)
!8 = <temporary!> !{}
!9 = !DILocation(line: 28, column: 28, scope: !7)
code generation error: asr_to_llvm: module failed verification. Error:
Expected no forward declarations!
!6 = <temporary!> !{}
inlinable function call in a function with debug info must have a !dbg location
  call void @main0()
Expected no forward declarations!
!8 = <temporary!> !{}



Note: if any of the above error or warning messages are not clear or are lacking
context please report it to us (we consider that a bug that needs to be fixed).
```