### PR TITLE
Wasm_x86: support functions return value

### DIFF
--- a/src/libasr/codegen/wasm_to_x86.cpp
+++ b/src/libasr/codegen/wasm_to_x86.cpp
@@ -35,7 +35,7 @@ class X86Generator : public WASMDecoder<X86Generator> {
                 m_a.asm_push_r32(X86Reg::ebp);
                 m_a.asm_mov_r32_r32(X86Reg::ebp, X86Reg::esp);
 
-                // Initialze space for local variables to zero
+                // Initialze local variables to zero and thus allocate space
                 m_a.asm_mov_r32_imm32(X86Reg::eax, 0U);
                 for (uint32_t j = 0; j < codes.p[i].locals.size(); j++) {
                     for (uint32_t k = 0; k < codes.p[i].locals.p[j].count;
@@ -106,7 +106,9 @@ Result<int> wasm_to_x86(Vec<uint8_t> &wasm_bytes, Allocator &al,
         auto t1 = std::chrono::high_resolution_clock::now();
         m_a.verify();
         auto t2 = std::chrono::high_resolution_clock::now();
-        time_verify = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+        time_verify =
+            std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)
+                .count();
     }
 
     {
@@ -124,9 +126,11 @@ Result<int> wasm_to_x86(Vec<uint8_t> &wasm_bytes, Allocator &al,
                   << std::endl;
         std::cout << "Generate asm: " << std::setw(5) << time_gen_x86_bytes
                   << std::endl;
-        std::cout << "Verify:       " << std::setw(5) << time_verify << std::endl;
+        std::cout << "Verify:       " << std::setw(5) << time_verify
+                  << std::endl;
         std::cout << "Save:       " << std::setw(5) << time_save << std::endl;
-        int total = time_decode_wasm + time_gen_x86_bytes + time_verify + time_save;
+        int total =
+            time_decode_wasm + time_gen_x86_bytes + time_verify + time_save;
         std::cout << "Total:      " << std::setw(5) << total << std::endl;
     }
     return 0;

--- a/src/libasr/codegen/wasm_to_x86.h
+++ b/src/libasr/codegen/wasm_to_x86.h
@@ -43,7 +43,7 @@ class X86Visitor : public BaseWASMVisitor<X86Visitor> {
             if (func_index == 0) {
                 m_a.asm_call_label("print_i32");
             } else if (func_index == 5) {
-                // currently ignoring print_buf
+                // currently ignoring flush_buf
             } else if (func_index == 6) {
                 m_a.asm_call_label("exit");
             } else {

--- a/src/libasr/codegen/wasm_to_x86.h
+++ b/src/libasr/codegen/wasm_to_x86.h
@@ -51,12 +51,15 @@ class X86Visitor : public BaseWASMVisitor<X86Visitor> {
                                  std::to_string(func_index) +
                                  " not yet supported";
             }
-        } else {
-            m_a.asm_call_label(exports[func_index - 7].name);
+            return;
         }
 
+        uint32_t imports_adjusted_func_index = func_index - 7U;
+        m_a.asm_call_label(exports[imports_adjusted_func_index].name);
+
+
         // Pop the passed function arguments
-        wasm::FuncType func_type = func_types[type_indices[func_index]];
+        wasm::FuncType func_type = func_types[type_indices[imports_adjusted_func_index]];
         for (uint32_t i = 0; i < func_type.param_types.size(); i++) {
             m_a.asm_pop_r32(X86Reg::eax);
         }
@@ -68,7 +71,7 @@ class X86Visitor : public BaseWASMVisitor<X86Visitor> {
             m_a.asm_mov_r32_m32(
                 X86Reg::eax, &base, nullptr, 1,
                 -(4 * (func_type.param_types.size() + 2 +
-                       func_codes[func_index].locals.size() + 1)));
+                       func_codes[imports_adjusted_func_index].locals.size() + 1)));
 
             // push eax value onto stack
             m_a.asm_push_r32(X86Reg::eax);


### PR DESCRIPTION
This PR adds support for return values of function calls.

Example:
```python
def A_Sqr(x: i32) -> i32:
    return x * x

def ComputeCircleArea(radius: i32) -> i32:
    pi: i32
    pi = 3
    return pi * A_Sqr(radius)

def Main0():
    print(ComputeCircleArea(5))

Main0()
```
Output:
```bash
(lp) ubaid@ubaid-Lenovo-ideapad-330-15ARR:~/OpenSource/lpython$ lpython examples/expr2.py --backend x86
(lp) ubaid@ubaid-Lenovo-ideapad-330-15ARR:~/OpenSource/lpython$ ./a.out 
75
(lp) ubaid@ubaid-Lenovo-ideapad-330-15ARR:~/OpenSource/lpython$ lpython examples/expr2.py --backend wasm_x86
(lp) ubaid@ubaid-Lenovo-ideapad-330-15ARR:~/OpenSource/lpython$ ./a.out 
75(lp) ubaid@ubaid-Lenovo-ideapad-330-15ARR:~/OpenSource/lpython$ 
```


Only the latest/recent two commits are part of this `PR`. The rest of the commits are part of https://github.com/lcompilers/lpython/pull/1223. I will rebase this `PR` once https://github.com/lcompilers/lpython/pull/1223 is merged.