### PR TITLE
Fix passing ``ArrayItem``, ``StructInstanceMember`` to BindC functions

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -247,6 +247,8 @@ RUN(NAME bindc_03   LABELS llvm
         EXTRAFILES bindc_03b.c)
 RUN(NAME bindc_05   LABELS llvm c
         EXTRAFILES bindc_05b.c)
+RUN(NAME bindc_06   LABELS llvm c
+        EXTRAFILES bindc_06b.c)
 RUN(NAME test_generics_01    LABELS cpython llvm)
 RUN(NAME test_cmath          LABELS cpython llvm c)
 RUN(NAME test_complex        LABELS cpython llvm c)

--- a/integration_tests/bindc_06.py
+++ b/integration_tests/bindc_06.py
@@ -1,13 +1,19 @@
-from ltypes import i32, f64, ccall
+from ltypes import i32, f64, ccall, dataclass
 from numpy import empty, int32, float64
 
+@dataclass
+class CompareOperator:
+    op_code: i32
+    op_name: str
+
 @ccall
-def compare_array_element(value1: i32, value2: f64) -> i32:
+def compare_array_element(value1: i32, value2: f64, op: i32) -> i32:
     pass
 
 def test_arrays():
     array1: i32[40] = empty(40, dtype=int32)
     array2: f64[40] = empty(40, dtype=float64)
+    compare_operator: CompareOperator = CompareOperator(0, "<")
     i: i32
 
     for i in range(40):
@@ -16,7 +22,7 @@ def test_arrays():
 
     is_small: bool = True
     for i in range(40):
-        is_small = is_small and bool(compare_array_element(array1[i], array2[i]))
+        is_small = is_small and bool(compare_array_element(array1[i], array2[i], compare_operator.op_code))
 
     print(is_small)
     assert is_small == True

--- a/integration_tests/bindc_06.py
+++ b/integration_tests/bindc_06.py
@@ -1,0 +1,24 @@
+from ltypes import i32, f64, ccall
+from numpy import empty, int32, float64
+
+@ccall
+def compare_array_element(value1: i32, value2: f64) -> i32:
+    pass
+
+def test_arrays():
+    array1: i32[40] = empty(40, dtype=int32)
+    array2: f64[40] = empty(40, dtype=float64)
+    i: i32
+
+    for i in range(40):
+        array1[i] = i + 1
+        array2[i] = float(2*i + 1)
+
+    is_small: bool = True
+    for i in range(40):
+        is_small = is_small and bool(compare_array_element(array1[i], array2[i]))
+
+    print(is_small)
+    assert is_small == True
+
+test_arrays()

--- a/integration_tests/bindc_06b.c
+++ b/integration_tests/bindc_06b.c
@@ -1,0 +1,5 @@
+#include "bindc_06b.h"
+
+int32_t compare_array_element(int32_t value1, double value2) {
+    return value1 <= value2;
+}

--- a/integration_tests/bindc_06b.c
+++ b/integration_tests/bindc_06b.c
@@ -1,5 +1,12 @@
 #include "bindc_06b.h"
 
-int32_t compare_array_element(int32_t value1, double value2) {
-    return value1 <= value2;
+int32_t compare_array_element(int32_t value1, double value2, int32_t code) {
+    switch( code ) {
+        case 0:
+            return value1 <= value2;
+        case 1:
+            return value1 >= value2;
+        default:
+            return 0;
+    }
 }

--- a/integration_tests/bindc_06b.h
+++ b/integration_tests/bindc_06b.h
@@ -1,0 +1,3 @@
+#include <inttypes.h>
+
+int32_t compare_array_element(int32_t value1, double value2);

--- a/integration_tests/bindc_06b.h
+++ b/integration_tests/bindc_06b.h
@@ -1,3 +1,3 @@
 #include <inttypes.h>
 
-int32_t compare_array_element(int32_t value1, double value2);
+int32_t compare_array_element(int32_t value1, double value2, int32_t code);

--- a/src/libasr/codegen/asr_to_c.cpp
+++ b/src/libasr/codegen/asr_to_c.cpp
@@ -489,7 +489,16 @@ public:
                     if( t->n_dims != 0 ) {
                         sub += " = " + value_var_name;
                     } else {
-                        sub += " = &" + value_var_name;
+                        sub += " = &" + value_var_name + ";\n";
+                        ASR::StructType_t* der_type_t = ASR::down_cast<ASR::StructType_t>(
+                        ASRUtils::symbol_get_past_external(t->m_derived_type));
+                        for( auto itr: der_type_t->m_symtab->get_scope() ) {
+                            if( ASRUtils::is_character(*ASRUtils::symbol_type(itr.second)) ) {
+                                sub += indent + std::string(v.m_name) + "->" + itr.first + " = (char*) malloc(40 * sizeof(char));\n";
+                            }
+                        }
+                        sub.pop_back();
+                        sub.pop_back();
                     }
                     return sub;
                 } else {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5865,10 +5865,13 @@ public:
                     uint64_t ptr_loads_copy = ptr_loads;
                     ptr_loads = !LLVM::is_llvm_struct(arg_type);
                     this->visit_expr_wrapper(x.m_args[i].m_value);
-                    if( x_abi == ASR::abiType::BindC &&
-                        ASR::is_a<ASR::CPtr_t>(*arg_type) &&
-                        ASR::is_a<ASR::StructInstanceMember_t>(*x.m_args[i].m_value) ) {
-                        tmp = LLVM::CreateLoad(*builder, tmp);
+                    if( x_abi == ASR::abiType::BindC ) {
+                        if( ASR::is_a<ASR::ArrayItem_t>(*x.m_args[i].m_value) ||
+                            ASR::is_a<ASR::StructInstanceMember_t>(*x.m_args[i].m_value) ||
+                            (ASR::is_a<ASR::CPtr_t>(*arg_type) &&
+                             ASR::is_a<ASR::StructInstanceMember_t>(*x.m_args[i].m_value)) ) {
+                            tmp = LLVM::CreateLoad(*builder, tmp);
+                        }
                     }
                     llvm::Value *value = tmp;
                     ptr_loads = ptr_loads_copy;


### PR DESCRIPTION
Other than the title initialisation of structs in C backend is fixed.