### PR TITLE
Allow integrations tests to run with selected backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ integration_tests/b1/*
 integration_tests/b2/*
 integration_tests/b3/*
 integration_tests/b4/*
+integration_tests/_lpython-tmp-test-*
 inst/bin/*
 *.tlog
 *.filters

--- a/ci/test.xsh
+++ b/ci/test.xsh
@@ -18,4 +18,4 @@ src/bin/lpython --show-cpp tests/doconcurrentloop_01.py
 if $WIN != "1":
     python run_tests.py
     cd integration_tests
-    ./run_tests.sh -j16
+    python run_tests_new.py -j16 -b llvm cpython c wasm

--- a/integration_tests/run_tests_new.py
+++ b/integration_tests/run_tests_new.py
@@ -8,7 +8,7 @@ import os
 DEFAULT_THREADS_TO_USE = 8 # default no of threads is 8
 SUPPORTED_BACKENDS = ['llvm', 'c', 'wasm', 'cpython']
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
-LPYTHON_PATH = f"{BASE_DIR}/../src/bin:$PATH"
+LPYTHON_PATH = f"{BASE_DIR}/../src/bin"
 
 def run_cmd(cmd, cwd=None):
     print(f"+ {cmd}")
@@ -18,11 +18,12 @@ def run_cmd(cmd, cwd=None):
         exit(1)
 
 def run_test(backend):
-    run_cmd(f"mkdir {BASE_DIR}/test-{backend}")
-    cwd = f"{BASE_DIR}/test-{backend}"
+    run_cmd(f"mkdir {BASE_DIR}/_lpython-tmp-test-{backend}")
+    cwd = f"{BASE_DIR}/_lpython-tmp-test-{backend}"
     run_cmd(f"cmake -DKIND={backend} ..", cwd=cwd)
     run_cmd(f"make -j{DEFAULT_THREADS_TO_USE}", cwd=cwd)
-    run_cmd(f"ctest -j{DEFAULT_THREADS_TO_USE} --output-on-failure", cwd=cwd)
+    run_cmd(f"ctest -j{DEFAULT_THREADS_TO_USE} --output-on-failure",
+            cwd=cwd)
 
 
 def test_backend(backend):
@@ -48,7 +49,7 @@ def main():
     os.environ["PATH"] += os.pathsep + LPYTHON_PATH
     # delete previously created directories (if any)
     for backend in SUPPORTED_BACKENDS:
-        run_cmd(f"rm -rf {BASE_DIR}/test-{backend}")
+        run_cmd(f"rm -rf {BASE_DIR}/_lpython-tmp-test--{backend}")
 
     DEFAULT_THREADS_TO_USE = args.no_of_threads or DEFAULT_THREADS_TO_USE
     for backend in args.backends:

--- a/integration_tests/run_tests_new.py
+++ b/integration_tests/run_tests_new.py
@@ -10,6 +10,7 @@ SUPPORTED_BACKENDS = ['llvm', 'c', 'wasm', 'cpython']
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 LPYTHON_PATH = f"{BASE_DIR}/../src/bin"
 
+
 def run_cmd(cmd, cwd=None):
     print(f"+ {cmd}")
     process = subprocess.run(cmd, shell=True, cwd=cwd)
@@ -17,8 +18,9 @@ def run_cmd(cmd, cwd=None):
         print(f"Command failed: {cmd}")
         exit(1)
 
+
 def run_test(backend):
-    run_cmd(f"mkdir {BASE_DIR}/_lpython-tmp-test-{backend}")
+    run_cmd(f"mkdir {BASE_DIR}/_lpython-tmp-test-{backend}", cwd=BASE_DIR)
     cwd = f"{BASE_DIR}/_lpython-tmp-test-{backend}"
     run_cmd(f"cmake -DKIND={backend} ..", cwd=cwd)
     run_cmd(f"make -j{DEFAULT_THREADS_TO_USE}", cwd=cwd)
@@ -32,6 +34,7 @@ def test_backend(backend):
         return
     run_test(backend)
 
+
 def get_args():
     parser = argparse.ArgumentParser(description="LPython Integration Test Suite")
     parser.add_argument("-j", "-n", "--no_of_threads", type=int,
@@ -40,6 +43,7 @@ def get_args():
                 type=str, help="Test the requested backends (%s)" % \
                         ", ".join(SUPPORTED_BACKENDS))
     return parser.parse_args()
+
 
 def main():
     args = get_args()
@@ -54,6 +58,7 @@ def main():
     DEFAULT_THREADS_TO_USE = args.no_of_threads or DEFAULT_THREADS_TO_USE
     for backend in args.backends:
         test_backend(backend)
+
 
 if __name__ == "__main__":
     main()

--- a/integration_tests/run_tests_new.py
+++ b/integration_tests/run_tests_new.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+import argparse
+import subprocess
+import os
+
+# Initialization
+DEFAULT_THREADS_TO_USE = 8 # default no of threads is 8
+SUPPORTED_BACKENDS = ['llvm', 'c', 'wasm', 'cpython']
+BASE_DIR = os.path.dirname(os.path.realpath(__file__))
+LPYTHON_PATH = f"{BASE_DIR}/../src/bin:$PATH"
+
+def run_cmd(cmd, cwd=None):
+    print(f"+ {cmd}")
+    process = subprocess.run(cmd, shell=True, cwd=cwd)
+    if process.returncode != 0:
+        print(f"Command failed: {cmd}")
+        exit(1)
+
+def run_test(backend):
+    run_cmd(f"mkdir {BASE_DIR}/test-{backend}")
+    cwd = f"{BASE_DIR}/test-{backend}"
+    run_cmd(f"cmake -DKIND={backend} ..", cwd=cwd)
+    run_cmd(f"make -j{DEFAULT_THREADS_TO_USE}", cwd=cwd)
+    run_cmd(f"ctest -j{DEFAULT_THREADS_TO_USE} --output-on-failure", cwd=cwd)
+
+
+def test_backend(backend):
+    if backend not in SUPPORTED_BACKENDS:
+        print(f"Unsupported Backend: {backend}\n")
+        return
+    run_test(backend)
+
+def get_args():
+    parser = argparse.ArgumentParser(description="LPython Integration Test Suite")
+    parser.add_argument("-j", "-n", "--no_of_threads", type=int,
+                help="Parallel testing on given number of threads")
+    parser.add_argument("-b", "--backends", nargs="*", default=["llvm", "cpython"],
+                type=str, help="Test the requested backends (%s)" % \
+                        ", ".join(SUPPORTED_BACKENDS))
+    return parser.parse_args()
+
+def main():
+    args = get_args()
+
+    # Setup
+    global DEFAULT_THREADS_TO_USE
+    os.environ["PATH"] += os.pathsep + LPYTHON_PATH
+    # delete previously created directories (if any)
+    for backend in SUPPORTED_BACKENDS:
+        run_cmd(f"rm -rf {BASE_DIR}/test-{backend}")
+
+    DEFAULT_THREADS_TO_USE = args.no_of_threads or DEFAULT_THREADS_TO_USE
+    for backend in args.backends:
+        test_backend(backend)
+
+if __name__ == "__main__":
+    main()

--- a/integration_tests/run_tests_new.py
+++ b/integration_tests/run_tests_new.py
@@ -50,7 +50,7 @@ def main():
 
     # Setup
     global DEFAULT_THREADS_TO_USE
-    os.environ["PATH"] += os.pathsep + LPYTHON_PATH
+    os.environ["PATH"] = LPYTHON_PATH + os.pathsep + os.environ["PATH"]
     # delete previously created directories (if any)
     for backend in SUPPORTED_BACKENDS:
         run_cmd(f"rm -rf {BASE_DIR}/_lpython-tmp-test-{backend}")

--- a/integration_tests/run_tests_new.py
+++ b/integration_tests/run_tests_new.py
@@ -49,7 +49,7 @@ def main():
     os.environ["PATH"] += os.pathsep + LPYTHON_PATH
     # delete previously created directories (if any)
     for backend in SUPPORTED_BACKENDS:
-        run_cmd(f"rm -rf {BASE_DIR}/_lpython-tmp-test--{backend}")
+        run_cmd(f"rm -rf {BASE_DIR}/_lpython-tmp-test-{backend}")
 
     DEFAULT_THREADS_TO_USE = args.no_of_threads or DEFAULT_THREADS_TO_USE
     for backend in args.backends:


### PR DESCRIPTION
After merging this we won't require `integration_tests/run_tests.sh`