### PR TITLE
WASM_X86: Support float types

### DIFF
--- a/src/libasr/codegen/wasm_to_x86.cpp
+++ b/src/libasr/codegen/wasm_to_x86.cpp
@@ -350,6 +350,7 @@ class X86Visitor : public WASMDecoder<X86Visitor>,
         X86Reg label_reg = X86Reg::eax;
         m_a.asm_fld_m32(&label_reg, nullptr, 1, 0); // loads into floating register stack
         X86Reg stack_top = X86Reg::esp;
+        m_a.asm_push_imm32(0); // decrement stack and create space
         m_a.asm_fstp_m32(&stack_top, nullptr, 1, 0); // store float on integer stack top;
     }
 

--- a/src/libasr/codegen/wasm_to_x86.cpp
+++ b/src/libasr/codegen/wasm_to_x86.cpp
@@ -343,7 +343,7 @@ class X86Visitor : public WASMDecoder<X86Visitor>,
 
     void visit_F64Const(double Z) {
         float z = Z; // down cast 64-bit double to 32-bit float
-        std::string label = "float-" + std::to_string(z);
+        std::string label = "float_" + std::to_string(z);
         float_consts[label] = z;
         m_a.asm_mov_r32_label(X86Reg::eax, label);
         X86Reg label_reg = X86Reg::eax;

--- a/src/libasr/codegen/wasm_to_x86.cpp
+++ b/src/libasr/codegen/wasm_to_x86.cpp
@@ -321,6 +321,17 @@ class X86Visitor : public WASMDecoder<X86Visitor>,
     void visit_I32LeS() { handle_I32Compare("LtE"); }
     void visit_I32Ne() { handle_I32Compare("NotEq"); }
 
+    void visit_F64Const(double Z) {
+        float z = Z; // down cast 64-bit double to 32-bit float
+        std::string label = "float-" + std::to_string(z);
+        float_consts[label] = z;
+        m_a.asm_mov_r32_label(X86Reg::eax, label);
+        X86Reg label_reg = X86Reg::eax;
+        m_a.asm_fld_m32(&label_reg, nullptr, 1, 0); // loads into floating register stack
+        X86Reg stack_top = X86Reg::esp;
+        m_a.asm_fstp_m32(&stack_top, nullptr, 1, 0); // store float on integer stack top;
+    }
+
     void gen_x86_bytes() {
         emit_elf32_header(m_a);
 

--- a/src/libasr/codegen/wasm_to_x86.cpp
+++ b/src/libasr/codegen/wasm_to_x86.cpp
@@ -68,7 +68,8 @@ class X86Visitor : public WASMDecoder<X86Visitor>,
                 break;
             }
             case 3: {  // print_f64
-                std::cerr << "Call to print_f64() is not yet supported";
+                m_a.asm_call_label("print_f64");
+                m_a.asm_add_r32_imm32(X86Reg::esp, 4);  // increment stack top and thus pop the value passed as argument
                 break;
             }
             case 4: {  // print_str
@@ -357,6 +358,7 @@ class X86Visitor : public WASMDecoder<X86Visitor>,
 
         // Add runtime library functions
         emit_print_int(m_a, "print_i32");
+        emit_print_float(m_a, "print_f64");
         emit_exit2(m_a, "my_exit");
 
         // declare compile-time strings

--- a/src/libasr/codegen/x86_assembler.cpp
+++ b/src/libasr/codegen/x86_assembler.cpp
@@ -109,6 +109,14 @@ void emit_data_string(X86Assembler &a, const std::string &label,
     a.asm_db_imm8(s.c_str(), s.size());
 }
 
+void emit_float_const(X86Assembler &a, const std::string &label,
+    const float z) {
+    uint8_t encoded_float[sizeof(z)];
+    std::memcpy(&encoded_float, &z, sizeof(z));
+    a.add_label(label);
+    a.asm_db_imm8(encoded_float, sizeof(z));
+}
+
 void emit_print(X86Assembler &a, const std::string &msg_label,
     uint32_t size)
 {

--- a/src/libasr/codegen/x86_assembler.cpp
+++ b/src/libasr/codegen/x86_assembler.cpp
@@ -209,6 +209,55 @@ void emit_print_int(X86Assembler &a, const std::string &name)
     emit_data_string(a, "string_neg", "-"); // - symbol for printing negative ints
 }
 
+void emit_print_float(X86Assembler &a, const std::string &name) {
+    // void print_float(float z);
+    a.add_label(name);
+
+    // Initialize stack
+    a.asm_push_r32(X86Reg::ebp);
+    a.asm_mov_r32_r32(X86Reg::ebp, X86Reg::esp);
+
+    X86Reg base = X86Reg::ebp;
+    a.asm_fld_m32(&base, nullptr, 1, 8); // load argument into floating register stack
+    a.asm_push_imm32(0); // decrement stack pointer and create space
+    X86Reg stack_top = X86Reg::esp;
+    a.asm_fistp_m32(&stack_top, nullptr, 1, 0);
+
+    // print the integral part
+    {
+        a.asm_call_label("print_i32");
+        a.asm_pop_r32(X86Reg::eax); // increament the stack pointer and thus remove space
+    }
+
+    // print dot
+    emit_print(a, "string_dot", 1U);
+
+    // print fractional part
+    {
+        a.asm_fld_m32(&base, nullptr, 1, 8); // load argument into floating register stack
+        a.asm_fld_m32(&base, nullptr, 1, 8); // load another copy of argument into floating register stack
+        a.asm_frndint(); // round st(0) to integral part
+        a.asm_fsubp();
+
+        // st(0) now contains only the fractional part
+
+        a.asm_push_imm32(100000000);
+        a.asm_fimul_m32int(&stack_top, nullptr, 1, 0);
+        a.asm_fistp_m32(&stack_top, nullptr, 1, 0);
+        // print the fractional part
+        {
+            a.asm_call_label("print_i32");
+            a.asm_pop_r32(X86Reg::eax); // increament the stack pointer and thus remove space
+        }
+    }
+
+    // Restore stack
+    a.asm_mov_r32_r32(X86Reg::esp, X86Reg::ebp);
+    a.asm_pop_r32(X86Reg::ebp);
+    a.asm_ret();
+
+    emit_data_string(a, "string_dot", "."); // - symbol for printing floats
+}
 
 /************************* 64-bit functions **************************/
 

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1166,6 +1166,7 @@ void emit_float_const(X86Assembler &a, const std::string &label,
 void emit_print(X86Assembler &a, const std::string &msg_label,
     uint32_t size);
 void emit_print_int(X86Assembler &a, const std::string &name);
+void emit_print_float(X86Assembler &a, const std::string &name);
 
 // Generate an ELF 64 bit header and footer
 // With these two functions, one only has to generate a `_start` assembly

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1158,6 +1158,8 @@ void emit_exit2(X86Assembler &a, const std::string &name);
 
 void emit_data_string(X86Assembler &a, const std::string &label,
     const std::string &s);
+void emit_float_const(X86Assembler &a, const std::string &label,
+    const float z);
 void emit_print(X86Assembler &a, const std::string &msg_label,
     uint32_t size);
 void emit_print_int(X86Assembler &a, const std::string &name);

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -102,6 +102,19 @@ static std::string r2s(X64Reg r64) {
         default : throw AssemblerError("Unknown instruction");
     }
 }
+// Not sure if this numbering is correct. Numbering info
+// about these registers does not seem easily available.
+enum X86FloatReg : uint8_t {
+    st0 = 0,
+    st1 = 1,
+    st2 = 2,
+    st3 = 3,
+    st4 = 4,
+    st5 = 5,
+    st6 = 6,
+    st7 = 7,
+};
+
 
 static std::string r2s(X86Reg r32) {
     switch (r32) {
@@ -1101,6 +1114,27 @@ public:
         m_code.push_back(m_al, 0x0F);
         m_code.push_back(m_al, 0x05);
         EMIT("syscall");
+    }
+
+    void asm_fld_m32(X86Reg *base, X86Reg *index,
+                uint8_t scale, int32_t disp) {
+        m_code.push_back(m_al, 0xd9);
+        m_code.push_back(m_al, ModRM_byte(0b00, 0, *base));
+        EMIT("fld dword " + m2s(base, index, scale, disp));
+    }
+
+    void asm_fst_m32(X86Reg *base, X86Reg *index,
+                uint8_t scale, int32_t disp) {
+        m_code.push_back(m_al, 0xd9);
+        m_code.push_back(m_al, ModRM_byte(0b00, 2, *base));
+        EMIT("fst dword " + m2s(base, index, scale, disp));
+    }
+
+    void asm_fstp_m32(X86Reg *base, X86Reg *index,
+                uint8_t scale, int32_t disp) {
+        m_code.push_back(m_al, 0xd9);
+        m_code.push_back(m_al, ModRM_byte(0b00, 3, *base));
+        EMIT("fstp dword " + m2s(base, index, scale, disp));
     }
 
 };

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1119,21 +1119,24 @@ public:
     void asm_fld_m32(X86Reg *base, X86Reg *index,
                 uint8_t scale, int32_t disp) {
         m_code.push_back(m_al, 0xd9);
-        m_code.push_back(m_al, ModRM_byte(0b00, 0, *base));
+        modrm_sib_disp(m_code, m_al,
+            X86Reg::eax, base, index, scale, disp, true);
         EMIT("fld dword " + m2s(base, index, scale, disp));
     }
 
     void asm_fst_m32(X86Reg *base, X86Reg *index,
                 uint8_t scale, int32_t disp) {
         m_code.push_back(m_al, 0xd9);
-        m_code.push_back(m_al, ModRM_byte(0b00, 2, *base));
+        modrm_sib_disp(m_code, m_al,
+            X86Reg::edx, base, index, scale, disp, true);
         EMIT("fst dword " + m2s(base, index, scale, disp));
     }
 
     void asm_fstp_m32(X86Reg *base, X86Reg *index,
                 uint8_t scale, int32_t disp) {
         m_code.push_back(m_al, 0xd9);
-        m_code.push_back(m_al, ModRM_byte(0b00, 3, *base));
+        modrm_sib_disp(m_code, m_al,
+            X86Reg::ebx, base, index, scale, disp, true);
         EMIT("fstp dword " + m2s(base, index, scale, disp));
     }
 

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -116,6 +116,20 @@ enum X86FloatReg : uint8_t {
 };
 
 
+static std::string r2s(X86FloatReg st) {
+    switch (st) {
+        case (X86FloatReg::st0) : return "st0";
+        case (X86FloatReg::st1) : return "st1";
+        case (X86FloatReg::st2) : return "st2";
+        case (X86FloatReg::st3) : return "st3";
+        case (X86FloatReg::st4) : return "st4";
+        case (X86FloatReg::st5) : return "st5";
+        case (X86FloatReg::st6) : return "st6";
+        case (X86FloatReg::st7) : return "st7";
+        default : throw AssemblerError("Unknown instruction");
+    }
+}
+
 static std::string r2s(X86Reg r32) {
     switch (r32) {
         case (X86Reg::eax) : return "eax";
@@ -1140,6 +1154,47 @@ public:
         EMIT("fstp dword " + m2s(base, index, scale, disp));
     }
 
+    void asm_fist_m32(X86Reg *base, X86Reg *index,
+                uint8_t scale, int32_t disp) {
+        m_code.push_back(m_al, 0xdb);
+        modrm_sib_disp(m_code, m_al,
+            X86Reg::edx, base, index, scale, disp, true);
+        EMIT("fist dword " + m2s(base, index, scale, disp));
+    }
+
+    void asm_fistp_m32(X86Reg *base, X86Reg *index,
+                uint8_t scale, int32_t disp) {
+        m_code.push_back(m_al, 0xdb);
+        modrm_sib_disp(m_code, m_al,
+            X86Reg::ebx, base, index, scale, disp, true);
+        EMIT("fistp dword " + m2s(base, index, scale, disp));
+    }
+
+    void asm_frndint() {
+        m_code.push_back(m_al, 0xd9);
+        m_code.push_back(m_al, 0xfc);
+        EMIT("frndint");
+    }
+
+    void asm_fsub(X86FloatReg st) {
+        m_code.push_back(m_al, 0xd8);
+        m_code.push_back(m_al, 0xe0 + st);
+        EMIT("fsub " + r2s(X86FloatReg::st0) + ", " + r2s(st));
+    }
+
+    void asm_fsubp() {
+        m_code.push_back(m_al, 0xde);
+        m_code.push_back(m_al, 0xe9);
+        EMIT("fsubp");
+    }
+
+    void asm_fimul_m32int(X86Reg *base, X86Reg *index,
+                uint8_t scale, int32_t disp) {
+        m_code.push_back(m_al, 0xda);
+        modrm_sib_disp(m_code, m_al,
+            X86Reg::ecx, base, index, scale, disp, true);
+        EMIT("fimul dword " + m2s(base, index, scale, disp));
+    }
 };
 
 


### PR DESCRIPTION
This PR adds initial support for float data type in `wasm_x86` backend.