### PR TITLE
WASM_X64: Basic support for function calls

### DIFF
--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -31,6 +31,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
                    public WASM_INSTS_VISITOR::BaseWASMVisitor<X64Visitor> {
    public:
     X86Assembler &m_a;
+    uint32_t cur_func_idx;
 
     X64Visitor(X86Assembler &m_a, Allocator &al,
                diag::Diagnostics &diagonostics, Vec<uint8_t> &code)
@@ -40,19 +41,105 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         wasm_bytes.from_pointer_n(code.data(), code.size());
     }
 
+    void visit_Return() {}
+
+    void call_imported_function(uint32_t func_idx) {
+        switch (func_idx) {
+            case 0: {  // print_i32
+                std::cerr << "Call to print_i32() will be printed as exit code\n";
+
+                // Currently, for print we are setting the value to be printed
+                // as the exit code. Later we can access/view this value from console
+                // using: echo $?
+                m_a.asm_pop_r64(X64Reg::rdi); // get exit code from stack top
+                m_a.asm_mov_r64_imm64(X64Reg::rax, 60); // sys_exit
+                m_a.asm_syscall(); // syscall
+                break;
+            }
+            case 1: {  // print_i64
+                std::cerr << "Call to print_i64() is not yet supported\n";
+                break;
+            }
+            case 2: {  // print_f32
+                std::cerr << "Call to print_f32() is not yet supported\n";
+                break;
+            }
+            case 3: {  // print_f64
+                std::cerr << "Call to print_f64() is not yet supported\n";
+                break;
+            }
+            case 4: {  // print_str
+                std::cerr << "Call to print_str() is not yet supported\n";
+                break;
+            }
+            case 5: {  // flush_buf
+                std::cerr << "Call to flush_buf() is not yet supported\n";
+                break;
+            }
+            case 6: {  // set_exit_code
+                m_a.asm_pop_r64(X64Reg::rdi); // get exit code from stack top
+                m_a.asm_mov_r64_imm64(X64Reg::rax, 60); // sys_exit
+                m_a.asm_syscall(); // syscall
+                break;
+            }
+            default: {
+                std::cerr << "Unsupported func_idx";
+            }
+        }
+    }
+
+    void visit_Call(uint32_t func_idx) {
+        if (func_idx <= 6U) {
+            call_imported_function(func_idx);
+            return;
+        }
+
+        func_idx -= 7u; // adjust function index as per imports
+        m_a.asm_call_label(exports[func_idx].name);
+    }
+
+    void visit_I32Const(int32_t value) {
+        // direct addition of imm64 to stack is not available with us yet
+        // so temporarily using a combination of instructions
+        // TODO: Update this once we have support for push_imm64()
+        m_a.asm_mov_r64_imm64(X64Reg::rax, value);
+        m_a.asm_push_r64(X64Reg::rax);
+    }
+
     void gen_x64_bytes() {
-        // update the initial value of asm text as per X64 text format
-        m_a.update_asm("BITS 64\n\n");
+        {   // Initialize/Modify values of entities for code simplicity later
+
+            m_a.update_asm("BITS 64\n\n"); // Update initial value of asm text as per X64 text format
+            exports.back().name = "_start"; // Update _lcompilers_main() to _start
+        }
 
         emit_elf64_header(m_a);
 
-        {
-            m_a.add_label("_start");
+        for (uint32_t idx = 0; idx < type_indices.size(); idx++) {
+            m_a.add_label(exports[idx].name);
+            {
+                // Initialize the stack
+                m_a.asm_push_r64(X64Reg::rbp);
+                m_a.asm_mov_r64_r64(X64Reg::rbp, X64Reg::rsp);
 
-            // exit with a fixed non-zero exit code
-            m_a.asm_mov_r64_imm64(LFortran::X64Reg::rax, 60); // sys_exit
-            m_a.asm_mov_r64_imm64(LFortran::X64Reg::rdi, 24 /* exit_code */); // exit code
-            m_a.asm_syscall(); // syscall
+                // Initialize local variables to zero and thus allocate space
+                m_a.asm_mov_r64_imm64(X64Reg::rax, 0u);
+                for (auto &local_var_info:codes[idx].locals) {
+                    for (uint32_t cnt = 0u; cnt < local_var_info.count; cnt++) {
+                        m_a.asm_push_r64(X64Reg::rax);
+                    }
+                }
+
+                offset = codes[idx].insts_start_index;
+                cur_func_idx = idx;
+                decode_instructions();
+
+                // Restore stack
+                m_a.asm_mov_r64_r64(X64Reg::rsp, X64Reg::rbp);
+                m_a.asm_pop_r64(X64Reg::rbp);
+                m_a.asm_ret();
+            }
+
         }
 
         emit_elf64_footer(m_a);

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -471,6 +471,13 @@ public:
     // Saves the generated machine code into a binary file
     void save_binary(const std::string &filename);
 
+    void asm_pop_r64(X64Reg r64) {
+        X86Reg r32 = X86Reg(r64 & 7);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, 0));
+        m_code.push_back(m_al, 0x58 + r32);
+        EMIT("pop " + r2s(r64));
+    }
+
     void asm_pop_r32(X86Reg r32) {
         m_code.push_back(m_al, 0x58 + r32);
         EMIT("pop " + r2s(r32));
@@ -480,6 +487,13 @@ public:
         m_code.push_back(m_al, 0x66);
         m_code.push_back(m_al, 0x58 + r16);
         EMIT("popl " + r2s(r16));
+    }
+
+    void asm_push_r64(X64Reg r64) {
+        X86Reg r32 = X86Reg(r64 & 7);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, 0));
+        m_code.push_back(m_al, 0x50 + r32);
+        EMIT("push " + r2s(r64));
     }
 
     void asm_push_r32(X86Reg r32) {
@@ -661,6 +675,15 @@ public:
         uint32_t imm32 = reference_symbol(label).value;
         push_back_uint32(m_code, m_al, imm32);
         EMIT("mov " + r2s(r32) + ", " + label);
+    }
+
+    void asm_mov_r64_r64(X64Reg r64, X64Reg s64) {
+        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, 0x89);
+        modrm_sib_disp(m_code, m_al,
+                s32, &r32, nullptr, 1, 0, false);
+        EMIT("mov " + r2s(r64) + ", " + r2s(s64));
     }
 
     void asm_mov_r32_r32(X86Reg r32, X86Reg s32) {

--- a/src/libasr/containers.h
+++ b/src/libasr/containers.h
@@ -95,6 +95,10 @@ struct Vec {
         return p;
     }
 
+    T& back() const {
+        return p[n - 1];
+    }
+
     const T& operator[](size_t pos) const {
         return p[pos];
     }


### PR DESCRIPTION
This `PR` adds initial support for function calls in the `WASM_X64` backend. This `PR` also adds support of generating `X64` instructions from `wasm` instructions.