### PR TITLE
WASM_X64: Support local variables

### DIFF
--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -106,6 +106,31 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         m_a.asm_push_r64(X64Reg::rax);
     }
 
+    void visit_I32Add() {
+        m_a.asm_pop_r64(X64Reg::rbx);
+        m_a.asm_pop_r64(X64Reg::rax);
+        m_a.asm_add_r64_r64(X64Reg::rax, X64Reg::rbx);
+        m_a.asm_push_r64(X64Reg::rax);
+    }
+    void visit_I32Sub() {
+        m_a.asm_pop_r64(X64Reg::rbx);
+        m_a.asm_pop_r64(X64Reg::rax);
+        m_a.asm_sub_r64_r64(X64Reg::rax, X64Reg::rbx);
+        m_a.asm_push_r64(X64Reg::rax);
+    }
+    void visit_I32Mul() {
+        m_a.asm_pop_r64(X64Reg::rbx);
+        m_a.asm_pop_r64(X64Reg::rax);
+        m_a.asm_mul_r64(X64Reg::rbx);
+        m_a.asm_push_r64(X64Reg::rax);
+    }
+    void visit_I32DivS() {
+        m_a.asm_pop_r64(X64Reg::rbx);
+        m_a.asm_pop_r64(X64Reg::rax);
+        m_a.asm_div_r64(X64Reg::rbx);
+        m_a.asm_push_r64(X64Reg::rax);
+    }
+
     void gen_x64_bytes() {
         {   // Initialize/Modify values of entities for code simplicity later
 

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -716,10 +716,19 @@ public:
 
     void asm_mov_r64_m64(X64Reg r64, X64Reg *base, X64Reg *index,
                 uint8_t scale, int64_t disp) {
-        X86Reg r32 = X86Reg(r64 & 7), base32 = X86Reg(base & 7), index32 = X86Reg(index & 7);
-        m_code.push_back(m_al, rex(1, r64 >> 3, index32 >> 3, base32 >> 3));
+        X86Reg r32 = X86Reg(r64 & 7);
+        X86Reg* base32 = nullptr, *index32 = nullptr;
+        if (base) {
+            base32 = new X86Reg;
+            *base32 = X86Reg(*base & 7);
+        }
+        if (index) {
+            index32 = new X86Reg;
+            *index32 = X86Reg(*index & 7);
+        }
+        m_code.push_back(m_al, rex(1, r64 >> 3, (index32 ? (*index32 >> 3) : 0), (base32 ? (*base32 >> 3) : 0)));
         m_code.push_back(m_al, 0x8b);
-            modrm_sib_disp(m_code, m_al,
+        modrm_sib_disp(m_code, m_al,
                     r32, base32, index32, scale, (int32_t)disp, true);
         EMIT("mov " + r2s(r64) + ", " + m2s(base, index, scale, disp));
     }
@@ -740,8 +749,17 @@ public:
 
     void asm_mov_m64_r64(X64Reg *base, X64Reg *index,
                 uint8_t scale, int64_t disp, X64Reg r64) {
-        X86Reg r32 = X86Reg(r64 & 7), base32 = X86Reg(base & 7), index32 = X86Reg(index & 7);
-        m_code.push_back(m_al, rex(1, r64 >> 3, index32 >> 3, base32 >> 3));
+        X86Reg r32 = X86Reg(r64 & 7);
+        X86Reg* base32 = nullptr, *index32 = nullptr;
+        if (base) {
+            base32 = new X86Reg;
+            *base32 = X86Reg(*base & 7);
+        }
+        if (index) {
+            index32 = new X86Reg;
+            *index32 = X86Reg(*index & 7);
+        }
+        m_code.push_back(m_al, rex(1, r64 >> 3, (index32 ? (*index32 >> 3) : 0), (base32 ? (*base32 >> 3) : 0)));
         m_code.push_back(m_al, 0x89);
         modrm_sib_disp(m_code, m_al,
                     r32, base32, index32, scale, (int32_t)disp, true);

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -493,7 +493,7 @@ public:
 
     void asm_pop_r64(X64Reg r64) {
         X86Reg r32 = X86Reg(r64 & 7);
-        m_code.push_back(m_al, rex(1, r64 >> 3, 0, 0));
+        m_code.push_back(m_al, rex(1, 0, 0, r64 >> 3));
         m_code.push_back(m_al, 0x58 + r32);
         EMIT("pop " + r2s(r64));
     }
@@ -511,7 +511,7 @@ public:
 
     void asm_push_r64(X64Reg r64) {
         X86Reg r32 = X86Reg(r64 & 7);
-        m_code.push_back(m_al, rex(1, r64 >> 3, 0, 0));
+        m_code.push_back(m_al, rex(1, 0, 0, r64 >> 3));
         m_code.push_back(m_al, 0x50 + r32);
         EMIT("push " + r2s(r64));
     }
@@ -684,8 +684,9 @@ public:
     }
 
     void asm_mov_r64_imm64(X64Reg r64, uint64_t imm64) {
-        m_code.push_back(m_al, rex(1, 0, 0, 0));
-        m_code.push_back(m_al, 0xb8 + r64);
+        X86Reg r32 = X86Reg(r64 & 7);
+        m_code.push_back(m_al, rex(1, 0, 0, r64 >> 3));
+        m_code.push_back(m_al, 0xb8 + r32);
         push_back_uint64(m_code, m_al, imm64);
         EMIT("mov " + r2s(r64) + ", " + i2s(imm64));
     }
@@ -699,7 +700,7 @@ public:
 
     void asm_mov_r64_r64(X64Reg r64, X64Reg s64) {
         X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
-        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, rex(1, s64 >> 3, 0, r64 >> 3));
         m_code.push_back(m_al, 0x89);
         modrm_sib_disp(m_code, m_al,
                 s32, &r32, nullptr, 1, 0, false);

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -736,6 +736,15 @@ public:
         EMIT("sub " + r2s(r32) + ", " + i2s(imm8));
     }
 
+    void asm_sub_r64_r64(X64Reg r64, X64Reg s64) {
+        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, 0x29);
+        modrm_sib_disp(m_code, m_al,
+                s32, &r32, nullptr, 1, 0, false);
+        EMIT("sub " + r2s(r64) + ", " + r2s(s64));
+    }
+
     void asm_sub_r32_r32(X86Reg r32, X86Reg s32) {
         m_code.push_back(m_al, 0x29);
         modrm_sib_disp(m_code, m_al,
@@ -865,6 +874,15 @@ public:
         EMIT("add " + m2s(base, index, scale, disp) + ", " + r2s(r32));
     }
 
+    void asm_add_r64_r64(X64Reg s64, X64Reg r64) {
+        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, rex(1, s64 >> 3, 0, r64 >> 3));
+        m_code.push_back(m_al, 0x01);
+        modrm_sib_disp(m_code, m_al,
+                r32, &s32, nullptr, 1, 0, false);
+        EMIT("add " + r2s(s64) + ", " + r2s(r64));
+    }
+
     void asm_add_r32_r32(X86Reg s32, X86Reg r32) {
         m_code.push_back(m_al, 0x01);
         modrm_sib_disp(m_code, m_al,
@@ -888,11 +906,29 @@ public:
         EMIT("add " + r2s(r32) + ", " + i2s(imm32));
     }
 
+    void asm_mul_r64(X64Reg r64) {
+        X86Reg r32 = X86Reg(r64 & 7);
+        m_code.push_back(m_al, rex(1, 0, 0, r64 >> 3));
+        m_code.push_back(m_al, 0xF7);
+        modrm_sib_disp(m_code, m_al,
+                X86Reg::esp, &r32, nullptr, 1, 0, false);
+        EMIT("mul " + r2s(r64));
+    }
+
     void asm_mul_r32(X86Reg r32) {
         m_code.push_back(m_al, 0xF7);
         modrm_sib_disp(m_code, m_al,
                 X86Reg::esp, &r32, nullptr, 1, 0, false);
         EMIT("mul " + r2s(r32));
+    }
+
+    void asm_div_r64(X64Reg r64) {
+        X86Reg r32 = X86Reg(r64 & 7);
+        m_code.push_back(m_al, rex(1, 0, 0, r64 >> 3));
+        m_code.push_back(m_al, 0xF7);
+        modrm_sib_disp(m_code, m_al,
+                X86Reg::esi, &r32, nullptr, 1, 0, false);
+        EMIT("div " + r2s(r64));
     }
 
     void asm_div_r32(X86Reg r32) {

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -115,6 +115,26 @@ static std::string r2s(X86Reg r32) {
     }
 }
 
+static std::string m2s(X64Reg *base, X64Reg *index, uint8_t scale, int64_t disp) {
+    std::string r;
+    r = "[";
+    if (base) r += r2s(*base);
+    if (index) {
+        if (base) r += "+";
+        if (scale == 1) {
+            r += r2s(*index);
+        } else {
+            r += std::to_string(scale) + "*" + r2s(*index);
+        }
+    }
+    if (disp) {
+        if ((base || index) && (disp > 0)) r += "+";
+        r += std::to_string(disp);
+    }
+    r += "]";
+    return r;
+}
+
 static std::string m2s(X86Reg *base, X86Reg *index, uint8_t scale, int32_t disp) {
     std::string r;
     r = "[";
@@ -693,6 +713,16 @@ public:
         EMIT("mov " + r2s(r32) + ", " + r2s(s32));
     }
 
+    void asm_mov_r64_m64(X64Reg r64, X64Reg *base, X64Reg *index,
+                uint8_t scale, int64_t disp) {
+        X86Reg r32 = X86Reg(r64 & 7), base32 = X86Reg(base & 7), index32 = X86Reg(index & 7);
+        m_code.push_back(m_al, rex(1, r64 >> 3, index32 >> 3, base32 >> 3));
+        m_code.push_back(m_al, 0x8b);
+            modrm_sib_disp(m_code, m_al,
+                    r32, base32, index32, scale, (int32_t)disp, true);
+        EMIT("mov " + r2s(r64) + ", " + m2s(base, index, scale, disp));
+    }
+
     void asm_mov_r32_m32(X86Reg r32, X86Reg *base, X86Reg *index,
                 uint8_t scale, int32_t disp) {
         if (r32 == X86Reg::eax && !base && !index) {
@@ -705,6 +735,16 @@ public:
                     r32, base, index, scale, disp, true);
         }
         EMIT("mov " + r2s(r32) + ", " + m2s(base, index, scale, disp));
+    }
+
+    void asm_mov_m64_r64(X64Reg *base, X64Reg *index,
+                uint8_t scale, int64_t disp, X64Reg r64) {
+        X86Reg r32 = X86Reg(r64 & 7), base32 = X86Reg(base & 7), index32 = X86Reg(index & 7);
+        m_code.push_back(m_al, rex(1, r64 >> 3, index32 >> 3, base32 >> 3));
+        m_code.push_back(m_al, 0x89);
+        modrm_sib_disp(m_code, m_al,
+                    r32, base32, index32, scale, (int32_t)disp, true);
+        EMIT("mov " + m2s(base, index, scale, disp) + ", " + r2s(r64));
     }
 
     void asm_mov_m32_r32(X86Reg *base, X86Reg *index,


### PR DESCRIPTION
This `PR` adds support for local variables in the `wasm_x64` backend. 

Examples:
```bash
$ cat examples/expr2.py 
def main0():
    x: i32
    x = (2+3)*5
    y: i32
    z: i32
    y = 14
    z = 2
    print(x + y * z)

main0()
$ lpython examples/expr2.py --backend wasm_x64 -o tmp
Call to print_i32() will be printed as exit code
Call to flush_buf() is not yet supported
$ ./tmp
$ echo $?
53
$ cat examples/expr2.py 
def sqr(x: i32) -> i32:
    return x * x

def main0():
    pi: i32 = 3
    r: i32 = 5
    area: i32
    area = pi * sqr(r)
    print(area)

main0()
$ lpython examples/expr2.py --backend wasm_x64 -o tmp
Call to print_i32() will be printed as exit code
Call to flush_buf() is not yet supported
$ ./tmp
$ echo $?
75
```