### PR TITLE
WASM_X64: Initial support for printing string

### DIFF
--- a/src/libasr/codegen/x86_assembler.cpp
+++ b/src/libasr/codegen/x86_assembler.cpp
@@ -271,4 +271,19 @@ void emit_exit_64(X86Assembler &a, std::string name, int exit_code) {
     a.asm_syscall(); // syscall
 }
 
+void emit_print_64(X86Assembler &a, const std::string &msg_label, uint64_t size)
+{
+    // mov rax, 1        ; write(
+    // mov rdi, 1        ;   STDOUT_FILENO,
+    // mov rsi, msg      ;   "Hello, world!\n",
+    // mov rdx, msglen   ;   sizeof("Hello, world!\n")
+    // syscall           ; );
+
+    a.asm_mov_r64_imm64(X64Reg::rax, 1);
+    a.asm_mov_r64_imm64(X64Reg::rdi, 1);
+    a.asm_mov_r64_label(X64Reg::rsi, msg_label); // buf
+    a.asm_mov_r64_imm64(X64Reg::rdx, size);
+    a.asm_syscall();
+}
+
 } // namespace LFortran

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1086,6 +1086,7 @@ void emit_elf64_footer(X86Assembler &a);
 
 void emit_exit_64(X86Assembler &a, std::string label, int exit_code);
 
+void emit_print_64(X86Assembler &a, const std::string &msg_label, uint64_t size);
 } // namespace LFortran
 
 #endif // LFORTRAN_CODEGEN_X86_ASSEMBER_H

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -711,6 +711,7 @@ public:
         X86Reg r32 = X86Reg(r64 & 7);
         m_code.push_back(m_al, rex(1, 0, 0, r64 >> 3));
         m_code.push_back(m_al, 0xb8 + r32);
+        // TODO: reference_symbol().value should return 64-bit value
         uint64_t imm64 = reference_symbol(label).value;
         push_back_uint64(m_code, m_al, imm64);
         EMIT("mov " + r2s(r64) + ", " + label);


### PR DESCRIPTION
This PR adds initial support for printing strings in the `wasm_x64` backend.

**Example:**
```bash
$ cat examples/expr2.py 
def main0():
    x: i32
    a: i32 = 2
    b: i32 = 3
    c: i32 = 6
    x = (a+b)*c
    print("hello")
    print("Hi!")
    print(x)

main0()
$ lpython examples/expr2.py --backend wasm_x64 -o tmp
Call to print_i32() will be printed as exit code
$ ./tmp
hello
Hi!
$ echo $?
30
$ 
```