### PR TITLE
CI: Fix warnings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,12 +20,12 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-2019"]
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Cache conda
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           CACHE_NUMBER: 0
         with:


### PR DESCRIPTION
Trying to fix these warnings:

`The save-state command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/`

More details: https://github.com/lcompilers/lpython/actions/runs/3718715316