### PR TITLE
WASM_X86: Fix text format

### DIFF
--- a/src/libasr/codegen/wasm_to_x86.cpp
+++ b/src/libasr/codegen/wasm_to_x86.cpp
@@ -55,6 +55,7 @@ class X86Visitor : public WASMDecoder<X86Visitor>,
         switch (func_index) {
             case 0: {  // print_i32
                 m_a.asm_call_label("print_i32");
+                m_a.asm_pop_r32(X86Reg::eax);
                 break;
             }
             case 1: {  // print_i64

--- a/src/libasr/codegen/x86_assembler.cpp
+++ b/src/libasr/codegen/x86_assembler.cpp
@@ -51,7 +51,7 @@ void emit_elf32_header(X86Assembler &a, uint32_t p_flags) {
     a.asm_dw_imm16(2);  // e_type
     a.asm_dw_imm16(3);  // e_machine
     a.asm_dd_imm32(1);  // e_version
-    a.asm_dd_label("e_entry");  // e_entry
+    a.asm_dd_label("_start");  // e_entry
     a.asm_dd_label("e_phoff");  // e_phoff
     a.asm_dd_imm32(0);  // e_shoff
     a.asm_dd_imm32(0);  // e_flags
@@ -80,8 +80,7 @@ void emit_elf32_header(X86Assembler &a, uint32_t p_flags) {
 }
 
 void emit_elf32_footer(X86Assembler &a) {
-    a.add_var("e_entry", a.get_defined_symbol("_start").value);
-    a.add_var("filesize", a.pos()-a.origin());
+    a.add_var_size("filesize");
 }
 
 void emit_exit(X86Assembler &a, const std::string &name,

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -362,7 +362,8 @@ public:
             m_asm_code = "BITS 64\n";
             emit("    ", "org " + i2s((uint64_t)m_origin) + "\n"); // specify origin info
         } else {
-            m_asm_code = "BITS 32\n\n";
+            m_asm_code = "BITS 32\n";
+            emit("    ", "org " + i2s(m_origin) + "\n"); // specify origin info
         }
 #endif
     }

--- a/src/lpython/tests/test_asm.cpp
+++ b/src/lpython/tests/test_asm.cpp
@@ -65,6 +65,7 @@ TEST_CASE("Store and get instructions") {
     std::string asm_code = a.get_asm();
     std::string ref = S(R"""(
 BITS 32
+    org 0x08048000
 
     pop eax
     jz 0x0d
@@ -300,6 +301,7 @@ TEST_CASE("Memory operand") {
     std::string asm_code = a.get_asm();
     std::string ref = S(R"""(
 BITS 32
+    org 0x08048000
 
     inc [ebx]
     inc [ebx+3]
@@ -369,6 +371,7 @@ TEST_CASE("elf32 binary") {
     std::string asm_code = a.get_asm();
     std::string ref = S(R"""(
 BITS 32
+    org 0x08048000
 
 ehdr:
     db 0x7f
@@ -390,7 +393,7 @@ ehdr:
     dw 0x0002
     dw 0x0003
     dd 0x00000001
-    dd e_entry
+    dd _start
     dd e_phoff
     dd 0x00000000
     dd 0x00000000
@@ -444,10 +447,7 @@ exit:
     mov ebx, 0x00000000
     int 0x80
 
-e_entry equ 0x08048061
-
-
-filesize equ 0x00000088
+filesize equ $ - $$
 
 )""");
     CHECK(asm_code == ref);


### PR DESCRIPTION
**Example:**
```bash
(lp) lpython$ cat examples/expr2.py 
def main0():
    x: i32
    x = (2+3)*5
    print(x)

main0()

# Not implemented yet in LPython:
#if __name__ == "__main__":
#    main()
(lp) lpython$ lpython examples/expr2.py --backend wasm_x86 -o tmp
BITS 32
    org 0x08048000

ehdr:
    db 0x7f
    db 0x45
    db 0x4c
    db 0x46
    db 0x01
    db 0x01
    db 0x01
    db 0x00
    db 0x00
    db 0x00
    db 0x00
    db 0x00
    db 0x00
    db 0x00
    db 0x00
    db 0x00
    dw 0x0002
    dw 0x0003
    dd 0x00000001
    dd _start
    dd e_phoff
    dd 0x00000000
    dd 0x00000000
    dw ehdrsize
    dw phdrsize
    dw 0x0001
    dw 0x0000
    dw 0x0000
    dw 0x0000

ehdrsize equ 0x00000034

phdr:
    dd 0x00000001
    dd 0x00000000
    dd 0x08048000
    dd 0x08048000
    dd filesize
    dd filesize
    dd 0x00000005
    dd 0x00001000

phdrsize equ 0x00000020


e_phoff equ 0x00000034

print_i32:
    push ebp
    mov ebp, esp
    mov eax, [ebp+8]
    mov ecx, eax
    mov ebx, 0x00000000
    cmp eax, ebx
    jge .print_int_
    mov eax, 0x00000004
    mov ebx, 0x00000001
    mov ecx, string_neg
    mov edx, 0x00000001
    int 0x80
    mov ecx, [ebp+8]
    neg ecx
.print_int_:
    mov eax, ecx
    xor esi, esi
.loop:
    mov edx, 0x00000000
    mov ebx, 0x0000000a
    div ebx
    add edx, 0x00000030
    push edx
    inc esi
    cmp eax, 0x00
    je .print
    jmp .loop
.print:
    cmp esi, 0x00
    je .end
    dec esi
    mov eax, 0x00000004
    mov ecx, esp
    mov ebx, 0x00000001
    mov edx, 0x00000001
    int 0x80
    add esp, 0x00000004
    jmp .print
.end:
    mov esp, ebp
    pop ebp
    ret
string_neg:
    db 0x2d
my_exit:
    mov eax, 0x00000001
    pop ebx
    int 0x80
_lpython_main_program:
    push ebp
    mov ebp, esp
    mov eax, 0x00000000
    call main0
    mov esp, ebp
    pop ebp
    ret
main0:
    push ebp
    mov ebp, esp
    mov eax, 0x00000000
    push eax
    push 0x00000019
    pop eax
    mov [ebp-4], eax
    mov eax, [ebp-4]
    push eax
    call print_i32
    pop eax
    mov eax, 0x00000004
    mov ebx, 0x00000001
    mov ecx, string_newline
    mov edx, 0x00000001
    int 0x80
    mov esp, ebp
    pop ebp
    ret
_start:
    push ebp
    mov ebp, esp
    mov eax, 0x00000000
    call _lpython_main_program
    push 0x00000000
    jmp my_exit
    mov esp, ebp
    pop ebp
    ret
string_newline:
    db 0x0a

filesize equ $ - $$


(lp) lpython$ ./tmp
25
(wasm_asm) lpython$ nasm -fbin main.asm && chmod +x main && ./main
25
(wasm_asm) lpython$ 
```