### PR TITLE
Return path of runtime library header of development version correctly

### DIFF
--- a/src/lpython/utils.cpp
+++ b/src/lpython/utils.cpp
@@ -79,7 +79,23 @@ std::string get_runtime_library_header_dir()
     char *env_p = std::getenv("LFORTRAN_RUNTIME_LIBRARY_HEADER_DIR");
     if (env_p) return env_p;
 
-    return get_runtime_library_dir() + "/impure";
+    std::string path;
+    int dirname_length;
+    get_executable_path(path, dirname_length);
+    std::string dirname = path.substr(0, dirname_length);
+    if (   endswith(dirname, "src/bin")
+        || endswith(dirname, "src\\bin")
+        || endswith(dirname, "SRC\\BIN")) {
+        // Development version
+        return dirname + "/../libasr/runtime";
+    } else if (endswith(dirname, "src/lpython/tests") ||
+               endswith(to_lower(dirname), "src\\lpython\\tests")) {
+        // CTest Tests
+        return dirname + "/../../runtime/impure";
+    } else {
+        // Installed version
+        return dirname + "/../share/lpython/lib/impure";
+    }
 }
 
 bool is_directory(std::string path) {

--- a/src/lpython/utils.cpp
+++ b/src/lpython/utils.cpp
@@ -50,27 +50,46 @@ void get_executable_path(std::string &executable_path, int &dirname_length)
 #endif
 }
 
+enum LCompilerVersionType {
+    Installed,
+    CTest,
+    Development
+};
+
+LCompilerVersionType get_lcompiler_version_type(std::string& dirname) {
+    std::string path;
+    int dirname_length;
+    get_executable_path(path, dirname_length);
+    dirname = path.substr(0,dirname_length);
+    if (   endswith(dirname, "src/bin")
+        || endswith(dirname, "src\\bin")
+        || endswith(dirname, "SRC\\BIN")) {
+        return LCompilerVersionType::Development;
+    } else if (endswith(dirname, "src/lpython/tests") ||
+               endswith(to_lower(dirname), "src\\lpython\\tests")) {
+        return LCompilerVersionType::CTest;
+    } else {
+        return LCompilerVersionType::Installed;
+    }
+}
+
 std::string get_runtime_library_dir()
 {
     char *env_p = std::getenv("LFORTRAN_RUNTIME_LIBRARY_DIR");
     if (env_p) return env_p;
 
-    std::string path;
-    int dirname_length;
-    get_executable_path(path, dirname_length);
-    std::string dirname = path.substr(0,dirname_length);
-    if (   endswith(dirname, "src/bin")
-        || endswith(dirname, "src\\bin")
-        || endswith(dirname, "SRC\\BIN")) {
-        // Development version
-        return dirname + "/../runtime";
-    } else if (endswith(dirname, "src/lpython/tests") ||
-               endswith(to_lower(dirname), "src\\lpython\\tests")) {
-        // CTest Tests
-        return dirname + "/../../runtime";
-    } else {
-        // Installed version
-        return dirname + "/../share/lpython/lib";
+    std::string dirname = "";
+    LCompilerVersionType lcompilers_version_type = get_lcompiler_version_type(dirname);
+    switch( lcompilers_version_type ) {
+        case LCompilerVersionType::Development: {
+            return dirname + "/../runtime";
+        }
+        case LCompilerVersionType::CTest: {
+            return dirname + "/../../runtime";
+        }
+        case LCompilerVersionType::Installed: {
+            return dirname + "/../share/lpython/lib";
+        }
     }
 }
 
@@ -79,22 +98,18 @@ std::string get_runtime_library_header_dir()
     char *env_p = std::getenv("LFORTRAN_RUNTIME_LIBRARY_HEADER_DIR");
     if (env_p) return env_p;
 
-    std::string path;
-    int dirname_length;
-    get_executable_path(path, dirname_length);
-    std::string dirname = path.substr(0, dirname_length);
-    if (   endswith(dirname, "src/bin")
-        || endswith(dirname, "src\\bin")
-        || endswith(dirname, "SRC\\BIN")) {
-        // Development version
-        return dirname + "/../libasr/runtime";
-    } else if (endswith(dirname, "src/lpython/tests") ||
-               endswith(to_lower(dirname), "src\\lpython\\tests")) {
-        // CTest Tests
-        return dirname + "/../../runtime/impure";
-    } else {
-        // Installed version
-        return dirname + "/../share/lpython/lib/impure";
+    std::string dirname = "";
+    LCompilerVersionType lcompilers_version_type = get_lcompiler_version_type(dirname);
+    switch( lcompilers_version_type ) {
+        case LCompilerVersionType::Development: {
+            return dirname + "/../libasr/runtime";
+        }
+        case LCompilerVersionType::CTest: {
+            return dirname + "/../../runtime/impure";
+        }
+        case LCompilerVersionType::Installed: {
+            return dirname + "/../share/lpython/lib/impure";
+        }
     }
 }
 


### PR DESCRIPTION
With this PR,

`/Users/czgdp1807/lpython_project/lpython/src/bin/../libasr/runtime`

On `main`,

`/Users/czgdp1807/lpython_project/lpython/src/bin/../runtime/impure`

`lfortran_intrinsics.h` isn't present in `src/runtime/impure`. Its always present in `src/libasr/runtime` for development version of LPython.