### PR TITLE
WASM_X64: Support if else

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -241,7 +241,7 @@ RUN(NAME expr_13             LABELS llvm c
 RUN(NAME expr_14             LABELS cpython llvm c)
 RUN(NAME loop_01             LABELS cpython llvm c)
 RUN(NAME loop_02             LABELS cpython llvm c wasm wasm_x86)
-RUN(NAME if_01               LABELS cpython llvm c wasm wasm_x86)
+RUN(NAME if_01               LABELS cpython llvm c wasm wasm_x86 wasm_x64)
 RUN(NAME if_02               LABELS cpython llvm c wasm wasm_x86)
 RUN(NAME print_02            LABELS cpython llvm)
 RUN(NAME test_types_01       LABELS cpython llvm c)

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -2102,9 +2102,9 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
 
     void visit_Assert(const ASR::Assert_t &x) {
         this->visit_expr(*x.m_test);
-        wasm::emit_i32_eqz(m_code_section, m_al);
         wasm::emit_b8(m_code_section, m_al, 0x04);  // emit if start
         wasm::emit_b8(m_code_section, m_al, 0x40);  // empty block type
+        wasm::emit_b8(m_code_section, m_al, 0x05);  // starting of else
         if (x.m_msg) {
             std::string msg =
                 ASR::down_cast<ASR::StringConstant_t>(x.m_msg)->m_s;
@@ -2114,7 +2114,6 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         }
         wasm::emit_i32_const(m_code_section, m_al, 1);  // non-zero exit code
         exit();
-        wasm::emit_b8(m_code_section, m_al, 0x05);  // starting of else
         wasm::emit_expr_end(m_code_section, m_al);  // emit if end
     }
 };


### PR DESCRIPTION
This PR adds support for `if-else` statements in the `wasm_x64` backend.