### PR TITLE
WASM_X64: Initial support for floats

### DIFF
--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -93,7 +93,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
                 break;
             }
             case 5: {  // flush_buf
-                emit_print_64(m_a, "string_newline", 2);
+                emit_print_64(m_a, "string_newline", 1);
                 break;
             }
             case 6: {  // set_exit_code

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -42,6 +42,15 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
     std::vector<std::pair<uint32_t, Block>> blocks;
     std::map<std::string, double> double_consts;
 
+    /*
+     A data segment in wasm uses a set of instructions/expressions to specify
+     the offset in memory where the string/data is to be stored.
+     To obtain the string offset we need to decode these set of instructions.
+     Since, we currently support compile-time strings and the string offset is
+     stored in last_vis_i32_const, the instructions are not needed for us at the moment.
+     The following variables helps us control the emitting of instructions when
+     deconding a data segment in wasm.
+    */
     bool decoding_data_segment;
 
     X64Visitor(X86Assembler &m_a, Allocator &al,

--- a/src/libasr/codegen/x86_assembler.cpp
+++ b/src/libasr/codegen/x86_assembler.cpp
@@ -117,6 +117,14 @@ void emit_float_const(X86Assembler &a, const std::string &label,
     a.asm_db_imm8(encoded_float, sizeof(z));
 }
 
+void emit_double_const(X86Assembler &a, const std::string &label,
+    const double z) {
+    uint8_t encoded_double[sizeof(z)];
+    std::memcpy(&encoded_double, &z, sizeof(z));
+    a.add_label(label);
+    a.asm_db_imm8(encoded_double, sizeof(z));
+}
+
 void emit_print(X86Assembler &a, const std::string &msg_label,
     uint32_t size)
 {

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -62,6 +62,20 @@ enum X86Reg : uint8_t {
     edi = 7,
 };
 
+static std::string r2s(X86Reg r32) {
+    switch (r32) {
+        case (X86Reg::eax) : return "eax";
+        case (X86Reg::ecx) : return "ecx";
+        case (X86Reg::edx) : return "edx";
+        case (X86Reg::ebx) : return "ebx";
+        case (X86Reg::esp) : return "esp";
+        case (X86Reg::ebp) : return "ebp";
+        case (X86Reg::esi) : return "esi";
+        case (X86Reg::edi) : return "edi";
+        default : throw AssemblerError("Unknown instruction");
+    }
+}
+
 enum X64Reg : uint8_t {
     rax =  0,
     rcx =  1,
@@ -126,20 +140,6 @@ static std::string r2s(X86FloatReg st) {
         case (X86FloatReg::st5) : return "st5";
         case (X86FloatReg::st6) : return "st6";
         case (X86FloatReg::st7) : return "st7";
-        default : throw AssemblerError("Unknown instruction");
-    }
-}
-
-static std::string r2s(X86Reg r32) {
-    switch (r32) {
-        case (X86Reg::eax) : return "eax";
-        case (X86Reg::ecx) : return "ecx";
-        case (X86Reg::edx) : return "edx";
-        case (X86Reg::ebx) : return "ebx";
-        case (X86Reg::esp) : return "esp";
-        case (X86Reg::ebp) : return "ebp";
-        case (X86Reg::esi) : return "esi";
-        case (X86Reg::edi) : return "edi";
         default : throw AssemblerError("Unknown instruction");
     }
 }

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1324,7 +1324,7 @@ public:
         m_code.push_back(m_al, 0x59);
         modrm_sib_disp(m_code, m_al,
                 r32, &s32, nullptr, 1, 0, false);
-        EMIT("addsd " + r2s(r64) + ", " + r2s(s64));
+        EMIT("mulsd " + r2s(r64) + ", " + r2s(s64));
     }
 
     // Convert Doubleword Integer to Scalar Double Precision Floating-Point Value

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -118,7 +118,7 @@ static std::string r2s(X64Reg r64) {
 }
 // Not sure if this numbering is correct. Numbering info
 // about these registers does not seem easily available.
-enum X86FloatReg : uint8_t {
+enum X86FReg : uint8_t {
     st0 = 0,
     st1 = 1,
     st2 = 2,
@@ -130,16 +130,16 @@ enum X86FloatReg : uint8_t {
 };
 
 
-static std::string r2s(X86FloatReg st) {
+static std::string r2s(X86FReg st) {
     switch (st) {
-        case (X86FloatReg::st0) : return "st0";
-        case (X86FloatReg::st1) : return "st1";
-        case (X86FloatReg::st2) : return "st2";
-        case (X86FloatReg::st3) : return "st3";
-        case (X86FloatReg::st4) : return "st4";
-        case (X86FloatReg::st5) : return "st5";
-        case (X86FloatReg::st6) : return "st6";
-        case (X86FloatReg::st7) : return "st7";
+        case (X86FReg::st0) : return "st0";
+        case (X86FReg::st1) : return "st1";
+        case (X86FReg::st2) : return "st2";
+        case (X86FReg::st3) : return "st3";
+        case (X86FReg::st4) : return "st4";
+        case (X86FReg::st5) : return "st5";
+        case (X86FReg::st6) : return "st6";
+        case (X86FReg::st7) : return "st7";
         default : throw AssemblerError("Unknown instruction");
     }
 }
@@ -1185,10 +1185,10 @@ public:
         EMIT("frndint");
     }
 
-    void asm_fsub(X86FloatReg st) {
+    void asm_fsub(X86FReg st) {
         m_code.push_back(m_al, 0xd8);
         m_code.push_back(m_al, 0xe0 + st);
-        EMIT("fsub " + r2s(X86FloatReg::st0) + ", " + r2s(st));
+        EMIT("fsub " + r2s(X86FReg::st0) + ", " + r2s(st));
     }
 
     void asm_fsubp() {

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1388,6 +1388,8 @@ void emit_exit_64(X86Assembler &a, std::string label, int exit_code);
 
 void emit_print_64(X86Assembler &a, const std::string &msg_label, uint64_t size);
 void emit_print_int_64(X86Assembler &a, const std::string &name);
+void emit_print_double(X86Assembler &a, const std::string &name);
+
 } // namespace LFortran
 
 #endif // LFORTRAN_CODEGEN_X86_ASSEMBER_H

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -831,19 +831,13 @@ public:
     void asm_mov_r64_m64(X64Reg r64, X64Reg *base, X64Reg *index,
                 uint8_t scale, int64_t disp) {
         X86Reg r32 = X86Reg(r64 & 7);
-        X86Reg* base32 = nullptr, *index32 = nullptr;
-        if (base) {
-            base32 = new X86Reg;
-            *base32 = X86Reg(*base & 7);
-        }
-        if (index) {
-            index32 = new X86Reg;
-            *index32 = X86Reg(*index & 7);
-        }
-        m_code.push_back(m_al, rex(1, r64 >> 3, (index32 ? (*index32 >> 3) : 0), (base32 ? (*base32 >> 3) : 0)));
+        m_code.push_back(m_al, rex(1, r64 >> 3, (index ? (*index >> 3) : 0), (base ? (*base >> 3) : 0)));
         m_code.push_back(m_al, 0x8b);
-        modrm_sib_disp(m_code, m_al,
-                    r32, base32, index32, scale, (int32_t)disp, true);
+        X86Reg base32, index32;
+        if (base) base32 = X86Reg(*base & 7);
+        if (index) index32 = X86Reg(*index & 7);
+        modrm_sib_disp(m_code, m_al, r32, (base ? &base32 : nullptr),
+                (index ? &index32 : nullptr),  scale, (int32_t)disp, true);
         EMIT("mov " + r2s(r64) + ", " + m2s(base, index, scale, disp));
     }
 
@@ -864,19 +858,13 @@ public:
     void asm_mov_m64_r64(X64Reg *base, X64Reg *index,
                 uint8_t scale, int64_t disp, X64Reg r64) {
         X86Reg r32 = X86Reg(r64 & 7);
-        X86Reg* base32 = nullptr, *index32 = nullptr;
-        if (base) {
-            base32 = new X86Reg;
-            *base32 = X86Reg(*base & 7);
-        }
-        if (index) {
-            index32 = new X86Reg;
-            *index32 = X86Reg(*index & 7);
-        }
-        m_code.push_back(m_al, rex(1, r64 >> 3, (index32 ? (*index32 >> 3) : 0), (base32 ? (*base32 >> 3) : 0)));
+        m_code.push_back(m_al, rex(1, r64 >> 3, (index ? (*index >> 3) : 0), (base ? (*base >> 3) : 0)));
         m_code.push_back(m_al, 0x89);
-        modrm_sib_disp(m_code, m_al,
-                    r32, base32, index32, scale, (int32_t)disp, true);
+        X86Reg base32, index32;
+        if (base) base32 = X86Reg(*base & 7);
+        if (index) index32 = X86Reg(*index & 7);
+        modrm_sib_disp(m_code, m_al, r32, (base ? &base32 : nullptr),
+                (index ? &index32 : nullptr),  scale, (int32_t)disp, true);
         EMIT("mov " + m2s(base, index, scale, disp) + ", " + r2s(r64));
     }
 
@@ -1251,21 +1239,15 @@ public:
     void asm_movsd_r64_m64(X64FReg r64, X64Reg *base, X64Reg *index,
                 uint8_t scale, int64_t disp) {
         X86Reg r32 = X86Reg(r64 & 7);
-        X86Reg* base32 = nullptr, *index32 = nullptr;
-        if (base) {
-            base32 = new X86Reg;
-            *base32 = X86Reg(*base & 7);
-        }
-        if (index) {
-            index32 = new X86Reg;
-            *index32 = X86Reg(*index & 7);
-        }
         m_code.push_back(m_al, 0xf2);
-        m_code.push_back(m_al, rex(1, r64 >> 3, (index32 ? (*index32 >> 3) : 0), (base32 ? (*base32 >> 3) : 0)));
+        m_code.push_back(m_al, rex(1, r64 >> 3, (index ? (*index >> 3) : 0), (base ? (*base >> 3) : 0)));
         m_code.push_back(m_al, 0x0f);
         m_code.push_back(m_al, 0x10);
-        modrm_sib_disp(m_code, m_al,
-                    r32, base32, index32, scale, (int32_t)disp, true);
+        X86Reg base32, index32;
+        if (base) base32 = X86Reg(*base & 7);
+        if (index) index32 = X86Reg(*index & 7);
+        modrm_sib_disp(m_code, m_al, r32, (base ? &base32 : nullptr),
+                (index ? &index32 : nullptr),  scale, (int32_t)disp, true);
         EMIT("movsd " + r2s(r64) + ", " + m2s(base, index, scale, disp));
     }
 
@@ -1273,21 +1255,15 @@ public:
     void asm_movsd_m64_r64(X64Reg *base, X64Reg *index,
                 uint8_t scale, int64_t disp, X64FReg r64) {
         X86Reg r32 = X86Reg(r64 & 7);
-        X86Reg* base32 = nullptr, *index32 = nullptr;
-        if (base) {
-            base32 = new X86Reg;
-            *base32 = X86Reg(*base & 7);
-        }
-        if (index) {
-            index32 = new X86Reg;
-            *index32 = X86Reg(*index & 7);
-        }
         m_code.push_back(m_al, 0xf2);
-        m_code.push_back(m_al, rex(1, r64 >> 3, (index32 ? (*index32 >> 3) : 0), (base32 ? (*base32 >> 3) : 0)));
+        m_code.push_back(m_al, rex(1, r64 >> 3, (index ? (*index >> 3) : 0), (base ? (*base >> 3) : 0)));
         m_code.push_back(m_al, 0x0f);
         m_code.push_back(m_al, 0x11);
-        modrm_sib_disp(m_code, m_al,
-                    r32, base32, index32, scale, (int32_t)disp, true);
+        X86Reg base32, index32;
+        if (base) base32 = X86Reg(*base & 7);
+        if (index) index32 = X86Reg(*index & 7);
+        modrm_sib_disp(m_code, m_al, r32, (base ? &base32 : nullptr),
+                (index ? &index32 : nullptr),  scale, (int32_t)disp, true);
         EMIT("movsd " + m2s(base, index, scale, disp) + ", " + r2s(r64));
     }
 

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1246,6 +1246,110 @@ public:
             X86Reg::ecx, base, index, scale, disp, true);
         EMIT("fimul dword " + m2s(base, index, scale, disp));
     }
+
+    // Move or Merge Scalar Double Precision Floating-Point Value
+    void asm_movsd_r64_m64(X64FReg r64, X64Reg *base, X64Reg *index,
+                uint8_t scale, int64_t disp) {
+        X86Reg r32 = X86Reg(r64 & 7);
+        X86Reg* base32 = nullptr, *index32 = nullptr;
+        if (base) {
+            base32 = new X86Reg;
+            *base32 = X86Reg(*base & 7);
+        }
+        if (index) {
+            index32 = new X86Reg;
+            *index32 = X86Reg(*index & 7);
+        }
+        m_code.push_back(m_al, 0xf2);
+        m_code.push_back(m_al, rex(1, r64 >> 3, (index32 ? (*index32 >> 3) : 0), (base32 ? (*base32 >> 3) : 0)));
+        m_code.push_back(m_al, 0x0f);
+        m_code.push_back(m_al, 0x10);
+        modrm_sib_disp(m_code, m_al,
+                    r32, base32, index32, scale, (int32_t)disp, true);
+        EMIT("movsd " + r2s(r64) + ", " + m2s(base, index, scale, disp));
+    }
+
+    // Move or Merge Scalar Double Precision Floating-Point Value
+    void asm_movsd_m64_r64(X64Reg *base, X64Reg *index,
+                uint8_t scale, int64_t disp, X64FReg r64) {
+        X86Reg r32 = X86Reg(r64 & 7);
+        X86Reg* base32 = nullptr, *index32 = nullptr;
+        if (base) {
+            base32 = new X86Reg;
+            *base32 = X86Reg(*base & 7);
+        }
+        if (index) {
+            index32 = new X86Reg;
+            *index32 = X86Reg(*index & 7);
+        }
+        m_code.push_back(m_al, 0xf2);
+        m_code.push_back(m_al, rex(1, r64 >> 3, (index32 ? (*index32 >> 3) : 0), (base32 ? (*base32 >> 3) : 0)));
+        m_code.push_back(m_al, 0x0f);
+        m_code.push_back(m_al, 0x11);
+        modrm_sib_disp(m_code, m_al,
+                    r32, base32, index32, scale, (int32_t)disp, true);
+        EMIT("movsd " + m2s(base, index, scale, disp) + ", " + r2s(r64));
+    }
+
+    // ADDSD—Add Scalar Double Precision Floating-Point Values
+    void asm_addsd_r64_r64(X64FReg r64, X64FReg s64) {
+        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, 0xf2);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, 0x0f);
+        m_code.push_back(m_al, 0x58);
+        modrm_sib_disp(m_code, m_al,
+                r32, &s32, nullptr, 1, 0, false);
+        EMIT("addsd " + r2s(r64) + ", " + r2s(s64));
+    }
+
+    // Subtract Scalar Double Precision Floating-Point Value
+    void asm_subsd_r64_r64(X64FReg r64, X64FReg s64) {
+        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, 0xf2);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, 0x0f);
+        m_code.push_back(m_al, 0x5c);
+        modrm_sib_disp(m_code, m_al,
+                r32, &s32, nullptr, 1, 0, false);
+        EMIT("subsd " + r2s(r64) + ", " + r2s(s64));
+    }
+
+    // Multiply Scalar Double Precision Floating-Point Value
+    void asm_mulsd_r64_r64(X64FReg r64, X64FReg s64) {
+        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, 0xf2);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, 0x0f);
+        m_code.push_back(m_al, 0x59);
+        modrm_sib_disp(m_code, m_al,
+                r32, &s32, nullptr, 1, 0, false);
+        EMIT("addsd " + r2s(r64) + ", " + r2s(s64));
+    }
+
+    // Convert Doubleword Integer to Scalar Double Precision Floating-Point Value
+    void asm_cvtsi2sd_r64_r64(X64FReg r64, X64Reg s64) {
+        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, 0xf2);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, 0x0f);
+        m_code.push_back(m_al, 0x2a);
+        modrm_sib_disp(m_code, m_al,
+                r32, &s32, nullptr, 1, 0, false);
+        EMIT("cvtsi2sd " + r2s(r64) + ", " + r2s(s64));
+    }
+
+    // Convert With Truncation Scalar Double Precision Floating-Point Value to Signed Integer
+    void asm_cvttsd2si_r64_r64(X64Reg r64, X64FReg s64) {
+        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, 0xf2);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, 0x0f);
+        m_code.push_back(m_al, 0x2c);
+        modrm_sib_disp(m_code, m_al,
+                r32, &s32, nullptr, 1, 0, false);
+        EMIT("cvttsd2si " + r2s(r64) + ", " + r2s(s64));
+    }
 };
 
 

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1373,6 +1373,8 @@ void emit_data_string(X86Assembler &a, const std::string &label,
     const std::string &s);
 void emit_float_const(X86Assembler &a, const std::string &label,
     const float z);
+void emit_double_const(X86Assembler &a, const std::string &label,
+    const double z);
 void emit_print(X86Assembler &a, const std::string &msg_label,
     uint32_t size);
 void emit_print_int(X86Assembler &a, const std::string &name);

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -144,6 +144,48 @@ static std::string r2s(X86FReg st) {
     }
 }
 
+enum X64FReg : uint8_t {
+    xmm0 = 0,
+    xmm1 = 1,
+    xmm2 = 2,
+    xmm3 = 3,
+    xmm4 = 4,
+    xmm5 = 5,
+    xmm6 = 6,
+    xmm7 = 7,
+    xmm8 = 8,
+    xmm9 = 9,
+    xmm10 = 10,
+    xmm11 = 11,
+    xmm12 = 12,
+    xmm13 = 13,
+    xmm14 = 14,
+    xmm15 = 15,
+};
+
+
+static std::string r2s(X64FReg xmm) {
+    switch (xmm) {
+        case (X64FReg::xmm0) : return "xmm0";
+        case (X64FReg::xmm1) : return "xmm1";
+        case (X64FReg::xmm2) : return "xmm2";
+        case (X64FReg::xmm3) : return "xmm3";
+        case (X64FReg::xmm4) : return "xmm4";
+        case (X64FReg::xmm5) : return "xmm5";
+        case (X64FReg::xmm6) : return "xmm6";
+        case (X64FReg::xmm7) : return "xmm7";
+        case (X64FReg::xmm8) : return "xmm8";
+        case (X64FReg::xmm9) : return "xmm9";
+        case (X64FReg::xmm10) : return "xmm10";
+        case (X64FReg::xmm11) : return "xmm11";
+        case (X64FReg::xmm12) : return "xmm12";
+        case (X64FReg::xmm13) : return "xmm13";
+        case (X64FReg::xmm14) : return "xmm14";
+        case (X64FReg::xmm15) : return "xmm15";
+        default : throw AssemblerError("Unknown instruction");
+    }
+}
+
 static std::string m2s(X64Reg *base, X64Reg *index, uint8_t scale, int64_t disp) {
     std::string r;
     r = "[";


### PR DESCRIPTION
This PR adds initial support for floats in the `wasm_x64` backend.

**Example:**
```bash
(lp) lpython$ cat examples/expr2.py 
def main0():
    print(52)
    print("hi")
    print(123.456)
    print("hi")
    print(52)
    print(23.414)
    print("hi")
    print(79)
main0()
(lp) lpython$ lpython examples/expr2.py --backend wasm_x64 -o tmp > main.asm
(lp) lpython$ ./tmp
52
hi
123.45600000
hi
52
23.41400000
hi
79
(lp) lpython$ 
```