### PR TITLE
Shell script to write out Clojure format to known location

### DIFF
--- a/generate-clojure.sh
+++ b/generate-clojure.sh
@@ -1,0 +1,14 @@
+I=./integration_tests
+O=~/tmp/lpython-clojure
+FILES="${I}/*.py"
+rm -rf $O 2> /dev/null || true
+mkdir -p $O
+for F in ${FILES}
+do
+    X=${F%.py}
+    Y=${X##*/}.clj
+    Z=${O}/${Y}
+    # echo "${X}, ${Y}, ${Z}"
+    echo "processing ${F} into ${Z} ..."
+    ./src/bin/lpython --show-asr --no-color ${F} > ${Z}
+done

--- a/src/libasr/asdl_cpp.py
+++ b/src/libasr/asdl_cpp.py
@@ -1409,7 +1409,7 @@ class PickleVisitorVisitor(ASDLVisitor):
                     self.emit('{', level)
                     self.emit('    size_t i = 0;', level)
                     self.emit('    for (auto &a : x.m_%s->get_scope()) {' % field.name, level)
-                    self.emit('        s.append(a.first + ":");', level)
+                    self.emit('        s.append(":" + a.first + " ");', level)
                     self.emit('        if(indent) {', level)
                     self.emit('            inc_indent();', level+1)
                     self.emit('            s.append("\\n" + indtd);', level+1)


### PR DESCRIPTION
wrote a small shell file to run over all integration_tests and write out ASR trees in Clojure format to ~/tmp/lpython-clojure

includes small fix to PickleVisitorVisitor to write Clojure format