### PR TITLE
WASM_X64, X86: Support recursive functions

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -408,5 +408,6 @@ RUN(NAME func_dep_03    LABELS cpython llvm c)
 RUN(NAME func_dep_04    LABELS cpython llvm c)
 
 RUN(NAME float_01 LABELS cpython llvm wasm wasm_x64)
+RUN(NAME recursive_01 LABELS cpython llvm wasm wasm_x64 wasm_x86)
 
 RUN(NAME test_argv_01    LABELS llvm) # TODO: Test using CPython

--- a/integration_tests/recursive_01.py
+++ b/integration_tests/recursive_01.py
@@ -1,0 +1,24 @@
+from ltypes import i32
+
+def fib(n: i32) -> i32:
+    if n <= 1:
+        return n
+    return fib(n - 1) + fib(n - 2)
+
+def printNums(n: i32):
+    if (n == 0):
+        return
+    print(n)
+    printNums(n - 1)
+
+def main0():
+    print("===========================")
+    i: i32
+    for i in range(15):
+        print(fib(i))
+    print("===========================")
+    print(fib(20))
+    print("===========================")
+    printNums(10)
+
+main0()

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -63,7 +63,12 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         decoding_data_segment = false;
     }
 
-    void visit_Return() {}
+    void visit_Return() {
+        // Restore stack
+        m_a.asm_mov_r64_r64(X64Reg::rsp, X64Reg::rbp);
+        m_a.asm_pop_r64(X64Reg::rbp);
+        m_a.asm_ret();
+    }
 
     void visit_Unreachable() {}
 
@@ -429,11 +434,6 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
                 offset = codes[idx].insts_start_index;
                 cur_func_idx = idx;
                 decode_instructions();
-
-                // Restore stack
-                m_a.asm_mov_r64_r64(X64Reg::rsp, X64Reg::rbp);
-                m_a.asm_pop_r64(X64Reg::rbp);
-                m_a.asm_ret();
             }
 
         }

--- a/src/libasr/codegen/wasm_to_x86.cpp
+++ b/src/libasr/codegen/wasm_to_x86.cpp
@@ -52,7 +52,12 @@ class X86Visitor : public WASMDecoder<X86Visitor>,
 
     void visit_Unreachable() {}
 
-    void visit_Return() {}
+    void visit_Return() {
+        // Restore stack
+        m_a.asm_mov_r32_r32(X86Reg::esp, X86Reg::ebp);
+        m_a.asm_pop_r32(X86Reg::ebp);
+        m_a.asm_ret();
+    }
 
     void call_imported_function(uint32_t func_index) {
         switch (func_index) {
@@ -395,11 +400,6 @@ class X86Visitor : public WASMDecoder<X86Visitor>,
                 offset = codes.p[i].insts_start_index;
                 cur_func_idx = i;
                 decode_instructions();
-
-                // Restore stack
-                m_a.asm_mov_r32_r32(X86Reg::esp, X86Reg::ebp);
-                m_a.asm_pop_r32(X86Reg::ebp);
-                m_a.asm_ret();
             }
         }
 


### PR DESCRIPTION
This PR fixes the `wasm_x64` and `wasm_x86` backends for recursive functions. They now seem to work in the `wasm_x64` and `wasm_x86` backends. There is a test case `integration_tests/recursive_01.py` added.

**Example:**
```bash
(lp) ubaid@ubaid-Lenovo-ideapad-330-15ARR:~/Desktop/Open-Source/lpython$ lpython integration_tests/recursive_01.py 
===========================
0
1
1
2
3
5
8
13
21
34
55
89
144
233
377
===========================
6765
===========================
10
9
8
7
6
5
4
3
2
1
(lp) ubaid@ubaid-Lenovo-ideapad-330-15ARR:~/Desktop/Open-Source/lpython$ lpython integration_tests/recursive_01.py --backend wasm_x64 -o tmp > main.asm
(lp) ubaid@ubaid-Lenovo-ideapad-330-15ARR:~/Desktop/Open-Source/lpython$ ./tmp
===========================
0
1
1
2
3
5
8
13
21
34
55
89
144
233
377
===========================
6765
===========================
10
9
8
7
6
5
4
3
2
1
(wasm_asm) ubaid@ubaid-Lenovo-ideapad-330-15ARR:~/Desktop/Open-Source/lpython$ nasm -fbin main.asm && chmod +x main && ./main
===========================
0
1
1
2
3
5
8
13
21
34
55
89
144
233
377
===========================
6765
===========================
10
9
8
7
6
5
4
3
2
1
(wasm_asm) ubaid@ubaid-Lenovo-ideapad-330-15ARR:~/Desktop/Open-Source/lpython$ 
```