### PR TITLE
WASM_X64,X86: Manipulate stack pointer using sub/add instructions

### DIFF
--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -482,7 +482,7 @@ Result<int> wasm_to_x64(Vec<uint8_t> &wasm_bytes, Allocator &al,
     }
 
     //! Helpful for debugging
-    std::cout << x64_visitor.m_a.get_asm() << std::endl;
+    // std::cout << x64_visitor.m_a.get_asm() << std::endl;
 
     if (time_report) {
         std::cout << "Codegen Time report:" << std::endl;

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -91,7 +91,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
             }
             case 3: {  // print_f64
                 m_a.asm_call_label("print_f64");
-                m_a.asm_pop_r64(X64Reg::r15); // pop the passed argument
+                m_a.asm_add_r64_imm32(X64Reg::rsp, 8); // pop the passed argument
                 break;
             }
             case 4: {  // print_str
@@ -133,9 +133,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
 
         // Pop the passed function arguments
         wasm::FuncType func_type = func_types[type_indices[func_idx]];
-        for (uint32_t i = 0; i < func_type.param_types.size(); i++) {
-            m_a.asm_pop_r64(X64Reg::rax);
-        }
+        m_a.asm_add_r64_imm32(X64Reg::rsp, 8 * func_type.param_types.size()); // pop the passed argument
 
         // Adjust the return values of the called function
         X64Reg base = X64Reg::rsp;
@@ -224,7 +222,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
                 m_a.asm_mov_r64_m64(X64Reg::rax, &base, nullptr, 1, 8 * (2 + localidx));
                 m_a.asm_push_r64(X64Reg::rax);
             } else if (var_type == "f64") {
-                m_a.asm_push_r64(X64Reg::rax); // temporary push to create space for value to be fetched
+                m_a.asm_sub_r64_imm32(X64Reg::rsp,  8); // create space for value to be fetched
                 m_a.asm_movsd_r64_m64(X64FReg::xmm0, &base, nullptr, 1, 8 * (2 + localidx));
                 X64Reg stack_top = X64Reg::rsp;
                 m_a.asm_movsd_m64_r64(&stack_top, nullptr, 1, 0, X64FReg::xmm0);
@@ -238,7 +236,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
                 m_a.asm_mov_r64_m64(X64Reg::rax, &base, nullptr, 1, -8 * (1 + (int)localidx));
                 m_a.asm_push_r64(X64Reg::rax);
             } else if (var_type == "f64") {
-                m_a.asm_push_r64(X64Reg::rax); // temporary push to create space for value to be fetched
+                m_a.asm_sub_r64_imm32(X64Reg::rsp,  8); // create space for value to be fetched
                 m_a.asm_movsd_r64_m64(X64FReg::xmm0, &base, nullptr, 1, -8 * (1 + (int)localidx));
                 X64Reg stack_top = X64Reg::rsp;
                 m_a.asm_movsd_m64_r64(&stack_top, nullptr, 1, 0, X64FReg::xmm0);
@@ -261,7 +259,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
                 X64Reg stack_top = X64Reg::rsp;
                 m_a.asm_movsd_r64_m64(X64FReg::xmm0, &stack_top, nullptr, 1, 0);
                 m_a.asm_movsd_m64_r64(&base, nullptr, 1, 8 * (2 + localidx), X64FReg::xmm0);
-                m_a.asm_pop_r64(X64Reg::rax); // temporary pop to remove from stack top
+                m_a.asm_add_r64_imm32(X64Reg::rsp, 8); // remove from stack top
             } else {
                 throw CodeGenError("WASM_X64: Var type not supported");
             }
@@ -275,7 +273,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
                 X64Reg stack_top = X64Reg::rsp;
                 m_a.asm_movsd_r64_m64(X64FReg::xmm0, &stack_top, nullptr, 1, 0);
                 m_a.asm_movsd_m64_r64(&base, nullptr, 1, -8 * (1 + (int)localidx), X64FReg::xmm0);
-                m_a.asm_pop_r64(X64Reg::rax); // temporary pop to remove from stack top
+                m_a.asm_add_r64_imm32(X64Reg::rsp, 8); // remove from stack top
             } else {
                 throw CodeGenError("WASM_X64: Var type not supported");
             }
@@ -349,7 +347,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         m_a.asm_mov_r64_label(X64Reg::rax, label);
         X64Reg label_reg = X64Reg::rax;
         m_a.asm_movsd_r64_m64(X64FReg::xmm0, &label_reg, nullptr, 1, 0); // load into floating-point register
-        m_a.asm_push_r64(X64Reg::rax); // decrement stack and create space
+        m_a.asm_sub_r64_imm32(X64Reg::rsp, 8); // decrement stack and create space
         X64Reg stack_top = X64Reg::rsp;
         m_a.asm_movsd_m64_r64(&stack_top, nullptr, 1, 0, X64FReg::xmm0); // store float on integer stack top;
     }
@@ -360,7 +358,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         X64Reg stack_top = X64Reg::rsp;
         // load second operand into floating-point register
         m_a.asm_movsd_r64_m64(X64FReg::xmm1, &stack_top, nullptr, 1, 0);
-        m_a.asm_pop_r64(X64Reg::rax); // pop the argument
+        m_a.asm_add_r64_imm32(X64Reg::rsp, 8); // pop the argument
         // load first operand into floating-point register
         m_a.asm_movsd_r64_m64(X64FReg::xmm0, &stack_top, nullptr, 1, 0);
         // no need to pop this operand since we need space to output back result
@@ -405,13 +403,9 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
                 m_a.asm_push_r64(X64Reg::rbp);
                 m_a.asm_mov_r64_r64(X64Reg::rbp, X64Reg::rsp);
 
-                // Initialize local variables to zero and thus allocate space
-                m_a.asm_mov_r64_imm64(X64Reg::rax, 0u);
-                for (auto &local_var_info:codes[idx].locals) {
-                    for (uint32_t cnt = 0u; cnt < local_var_info.count; cnt++) {
-                        m_a.asm_push_r64(X64Reg::rax);
-                    }
-                }
+                // Allocate space for local variables
+                // TODO: locals is an array where every element has a count (currently wasm emits count = 1 always)
+                m_a.asm_sub_r64_imm32(X64Reg::rsp, 8 * codes[idx].locals.size());
 
                 offset = codes[idx].insts_start_index;
                 cur_func_idx = idx;
@@ -488,7 +482,7 @@ Result<int> wasm_to_x64(Vec<uint8_t> &wasm_bytes, Allocator &al,
     }
 
     //! Helpful for debugging
-    // std::cout << x64_visitor.m_a.get_asm() << std::endl;
+    std::cout << x64_visitor.m_a.get_asm() << std::endl;
 
     if (time_report) {
         std::cout << "Codegen Time report:" << std::endl;

--- a/src/libasr/codegen/x86_assembler.cpp
+++ b/src/libasr/codegen/x86_assembler.cpp
@@ -234,7 +234,7 @@ void emit_print_float(X86Assembler &a, const std::string &name) {
     // print the integral part
     {
         a.asm_call_label("print_i32");
-        a.asm_pop_r32(X86Reg::eax); // increament the stack pointer and thus remove space
+        a.asm_add_r32_imm32(X86Reg::esp, 4); // increment stack top and thus pop the value to be set
     }
 
     // print dot
@@ -255,7 +255,7 @@ void emit_print_float(X86Assembler &a, const std::string &name) {
         // print the fractional part
         {
             a.asm_call_label("print_i32");
-            a.asm_pop_r32(X86Reg::eax); // increament the stack pointer and thus remove space
+            a.asm_add_r32_imm32(X86Reg::esp, 4); // increment stack top and thus pop the value to be set
         }
     }
 

--- a/src/libasr/codegen/x86_assembler.cpp
+++ b/src/libasr/codegen/x86_assembler.cpp
@@ -395,7 +395,7 @@ void emit_print_int_64(X86Assembler &a, const std::string &name)
             a.asm_mov_r64_imm64(X64Reg::rdx, 1);
             a.asm_syscall();
         }
-        a.asm_pop_r64(X64Reg::r15); // increment stack pointer by pop operation
+        a.asm_add_r64_imm32(X64Reg::rsp, 8); // pop and increment stack pointer
         a.asm_jmp_label("_print_i64_digit");
 
     a.add_label("_print_i64_end");
@@ -421,7 +421,7 @@ void emit_print_double(X86Assembler &a, const std::string &name) {
     // print the integral part
     {
         a.asm_call_label("print_i64");
-        a.asm_pop_r64(X64Reg::rax); // remove the passed argument to print_i64
+        a.asm_add_r64_imm32(X64Reg::rsp, 8); // pop and increment stack pointer
     }
 
     // print dot
@@ -441,7 +441,7 @@ void emit_print_double(X86Assembler &a, const std::string &name) {
         // print the fractional part
         {
             a.asm_call_label("print_i64");
-            a.asm_pop_r64(X64Reg::rax); // pop the passed argument
+            a.asm_add_r64_imm32(X64Reg::rsp, 8); // pop and increment stack pointer
         }
     }
 

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -897,6 +897,24 @@ public:
         EMIT("sub " + r2s(r32) + ", " + i2s(imm8));
     }
 
+    void asm_sub_r32_imm32(X86Reg r32, uint32_t imm32) {
+        m_code.push_back(m_al, 0x81);
+        modrm_sib_disp(m_code, m_al,
+                X86Reg::ebp, &r32, nullptr, 1, 0, false);
+        push_back_uint32(m_code, m_al, imm32);
+        EMIT("sub " + r2s(r32) + ", " + i2s(imm32));
+    }
+
+    void asm_sub_r64_imm32(X64Reg r64, uint32_t imm32) {
+        X86Reg r32 = X86Reg(r64 & 7);
+        m_code.push_back(m_al, rex(1, 0, 0, r64 >> 3));
+        m_code.push_back(m_al, 0x81);
+        modrm_sib_disp(m_code, m_al,
+                X86Reg::ebp, &r32, nullptr, 1, 0, false);
+        push_back_uint32(m_code, m_al, imm32);
+        EMIT("sub " + r2s(r64) + ", " + i2s(imm32));
+    }
+
     void asm_sub_r64_r64(X64Reg r64, X64Reg s64) {
         X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
         m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));


### PR DESCRIPTION
This `PR` solves the following issue:

Currently, we update the `stack` pointer (mostly) using `push` and `pop` operations. We can also update the `stack pointer` by adding/subtracting the desired `offset` from it. In case of `floating-point` operations, instead of pushing an integer register onto `stack` to create required space, it could/would be better if we update the stack pointer by adding/subtracting value from `esp` to create the required space. To support `add`/`sub` desired value, we need support for `add`/`sub` instruction in the `wasm_x64` backend.

