### PR TITLE
Fix paths to the runtime library header files

### DIFF
--- a/src/lpython/utils.cpp
+++ b/src/lpython/utils.cpp
@@ -79,7 +79,27 @@ std::string get_runtime_library_header_dir()
     char *env_p = std::getenv("LFORTRAN_RUNTIME_LIBRARY_HEADER_DIR");
     if (env_p) return env_p;
 
-    return get_runtime_library_dir() + "/impure";
+    // The header file is in src/libasr/runtime for development, but in impure
+    // in installed version
+    std::string path;
+    int dirname_length;
+    get_executable_path(path, dirname_length);
+    std::string dirname = path.substr(0,dirname_length);
+    if (   endswith(dirname, "src/bin")
+        || endswith(dirname, "src\\bin")
+        || endswith(dirname, "SRC\\BIN")) {
+        // Development version
+        return dirname + "/../libasr/runtime";
+    } else if (endswith(dirname, "src/lpython/tests") ||
+               endswith(to_lower(dirname), "src\\lpython\\tests")) {
+        // CTest Tests
+        return dirname + "/../../libasr/runtime";
+    } else {
+        // Installed version
+        return dirname + "/../share/lpython/lib/impure";
+    }
+
+    return path;
 }
 
 bool is_directory(std::string path) {


### PR DESCRIPTION
We should refactor how we handle the runtime library, see https://github.com/lcompilers/lpython/issues/1413. Also this code should be refactored.

But this PR fixes an important bug, now it can find the location of the `.h` file correctly.