### PR TITLE
Add a test for struct initialization

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -369,6 +369,7 @@ RUN(NAME structs_16          LABELS cpython llvm c)
 RUN(NAME structs_17          LABELS cpython llvm c)
 RUN(NAME structs_18          LABELS llvm c
     EXTRAFILES structs_18b.c)
+RUN(NAME structs_19          LABELS llvm)
 RUN(NAME sizeof_01           LABELS llvm c
         EXTRAFILES sizeof_01b.c)
 RUN(NAME enum_01             LABELS cpython llvm c)

--- a/integration_tests/structs_19.py
+++ b/integration_tests/structs_19.py
@@ -1,0 +1,26 @@
+from ltypes import i32, CPtr, dataclass, c_p_pointer, p_c_pointer, \
+        pointer, empty_c_void_p
+
+@dataclass
+class S:
+    a: i32
+
+def f(c: CPtr):
+    # The following two lines are the actual test: we take an argument `c` of
+    # type CPtr, convert to type Pointer[S] and access the member `a`. This
+    # tests that the order of initialization is preserved in the generated LLVM
+    # or C code.
+    p: Pointer[S] = c_p_pointer(c, S)
+    A: i32 = p.a
+
+    # We check that we get the expected result:
+    print(A)
+    assert A == 3
+
+def main():
+    s: S = S(3)
+    p: CPtr = empty_c_void_p()
+    p_c_pointer(pointer(s, S), p)
+    f(p)
+
+main()


### PR DESCRIPTION
This currently only works with the LLVM backend, does not yet work with CPython or C.