### PR TITLE
WASM_X64: Float comparison operations

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -414,5 +414,6 @@ RUN(NAME func_dep_04    LABELS cpython llvm c)
 
 RUN(NAME float_01 LABELS cpython llvm wasm wasm_x64)
 RUN(NAME recursive_01 LABELS cpython llvm wasm wasm_x64 wasm_x86)
+RUN(NAME comp_01 LABELS cpython llvm wasm wasm_x64)
 
 RUN(NAME test_argv_01    LABELS llvm) # TODO: Test using CPython

--- a/integration_tests/comp_01.py
+++ b/integration_tests/comp_01.py
@@ -1,0 +1,56 @@
+from ltypes import i32, f64
+
+def compI32(x: i32, y: i32):
+    print(x)
+    print(y)
+    if x < y:
+        print("x lt y")
+    if x > y:
+        print("x gt y")
+    if x == y:
+        print("x eq y")
+    if x >= y:
+        print("x ge y")
+    if x <= y:
+        print("x le y")
+    if x != y:
+        print("x ne y")
+
+def compF64(x: f64, y: f64):
+    print(x)
+    print(y)
+    if x < y:
+        print("x lt y")
+    if x > y:
+        print("x gt y")
+    if x == y:
+        print("x eq y")
+    if x >= y:
+        print("x ge y")
+    if x <= y:
+        print("x le y")
+    if x != y:
+        print("x ne y")
+
+def main0():
+    a: i32 = 4
+    b: i32 = 5
+    c: i32 = 5
+    d: i32 = 6
+    compI32(a, b)
+    compI32(b, a)
+    compI32(a, d)
+    compI32(b, c)
+    compI32(c, b)
+
+    x: f64 = 4.555
+    y: f64 = 15.55
+    w: f64 = 15.55
+    z: f64 = 25.12
+    compF64(x, y)
+    compF64(y, x)
+    compF64(x, z)
+    compF64(y, w)
+    compF64(w, y)
+
+main0()

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -374,6 +374,17 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
     void visit_F64Mul() { handleF64Operations<&X86Assembler::asm_mulsd_r64_r64>(); }
     void visit_F64Div() { handleF64Operations<&X86Assembler::asm_divsd_r64_r64>(); }
 
+    void handleF64Compare(Fcmp cmp) {
+        m_a.asm_cmpsd_r64_r64(X64FReg::xmm0, X64FReg::xmm1, cmp);
+    }
+
+    void visit_F64Eq() { handleF64Compare(Fcmp::eq); }
+    void visit_F64Gt() { handleF64Compare(Fcmp::gt); }
+    void visit_F64Ge() { handleF64Compare(Fcmp::ge); }
+    void visit_F64Lt() { handleF64Compare(Fcmp::lt); }
+    void visit_F64Le() { handleF64Compare(Fcmp::le); }
+    void visit_F64Ne() { handleF64Compare(Fcmp::ne); }
+
     void gen_x64_bytes() {
         {   // Initialize/Modify values of entities
             exports.back().name = "_start"; // Update _lcompilers_main() to _start

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -380,10 +380,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
     void visit_F64Mul() { handleF64Operations<&X86Assembler::asm_mulsd_r64_r64>(); }
     void visit_F64Div() { handleF64Operations<&X86Assembler::asm_divsd_r64_r64>(); }
 
-    template<JumpFn T>
-    void handleF64Compare() {
-        std::string label = std::to_string(offset);
-
+    void handleF64Compare(Fcmp cmp) {
         X64Reg stack_top = X64Reg::rsp;
         // load second operand into floating-point register
         m_a.asm_movsd_r64_m64(X64FReg::xmm1, &stack_top, nullptr, 1, 0);
@@ -392,26 +389,21 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         m_a.asm_movsd_r64_m64(X64FReg::xmm0, &stack_top, nullptr, 1, 0);
         m_a.asm_add_r64_imm32(X64Reg::rsp, 8); // pop the argument
 
-        // m_a.asm_uomisd_r64_r64(X64FReg::xmm0, X64FReg::xmm1);
-        m_a.asm_comisd_r64_r64(X64FReg::xmm0, X64FReg::xmm1);
-
-        (m_a.*T)(".compare_1" + label);
-
-        // if the `compare` condition in `true`, jump to compare_1
-        // and assign `1` else assign `0`
-        m_a.asm_push_imm8(0);
-        m_a.asm_jmp_label(".compare.end_" + label);
-        m_a.add_label(".compare_1" + label);
-        m_a.asm_push_imm8(1);
-        m_a.add_label(".compare.end_" + label);
+        m_a.asm_cmpsd_r64_r64(X64FReg::xmm0, X64FReg::xmm1, cmp);
+        /* From Assembly Docs:
+            The result of the compare is a 64-bit value of all 1s (TRUE) or all 0s (FALSE).
+        */
+        m_a.asm_pmovmskb_r32_r64(X86Reg::eax, X64FReg::xmm0);
+        m_a.asm_and_r64_imm8(X64Reg::rax, 1);
+        m_a.asm_push_r64(X64Reg::rax);
     }
 
-    void visit_F64Eq() { handleF64Compare<&X86Assembler::asm_je_label>(); }
-    void visit_F64Gt() { handleF64Compare<&X86Assembler::asm_jg_label>(); }
-    void visit_F64Ge() { handleF64Compare<&X86Assembler::asm_jge_label>(); }
-    void visit_F64Lt() { handleF64Compare<&X86Assembler::asm_jl_label>(); }
-    void visit_F64Le() { handleF64Compare<&X86Assembler::asm_jle_label>(); }
-    void visit_F64Ne() { handleF64Compare<&X86Assembler::asm_jne_label>(); }
+    void visit_F64Eq() { handleF64Compare(Fcmp::eq); }
+    void visit_F64Gt() { handleF64Compare(Fcmp::gt); }
+    void visit_F64Ge() { handleF64Compare(Fcmp::ge); }
+    void visit_F64Lt() { handleF64Compare(Fcmp::lt); }
+    void visit_F64Le() { handleF64Compare(Fcmp::le); }
+    void visit_F64Ne() { handleF64Compare(Fcmp::ne); }
 
     void gen_x64_bytes() {
         {   // Initialize/Modify values of entities

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -219,11 +219,11 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         if ((int)localidx < no_of_params) {
             std::string var_type = var_type_to_string[cur_func_param_type.param_types[localidx]];
             if (var_type == "i32") {
-                m_a.asm_mov_r64_m64(X64Reg::rax, &base, nullptr, 1, 8 * (2 + localidx));
+                m_a.asm_mov_r64_m64(X64Reg::rax, &base, nullptr, 1, 8 * (2 + no_of_params - (int)localidx - 1));
                 m_a.asm_push_r64(X64Reg::rax);
             } else if (var_type == "f64") {
                 m_a.asm_sub_r64_imm32(X64Reg::rsp,  8); // create space for value to be fetched
-                m_a.asm_movsd_r64_m64(X64FReg::xmm0, &base, nullptr, 1, 8 * (2 + localidx));
+                m_a.asm_movsd_r64_m64(X64FReg::xmm0, &base, nullptr, 1, 8 * (2 + no_of_params - (int)localidx - 1));
                 X64Reg stack_top = X64Reg::rsp;
                 m_a.asm_movsd_m64_r64(&stack_top, nullptr, 1, 0, X64FReg::xmm0);
             } else {
@@ -254,11 +254,11 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
             std::string var_type = var_type_to_string[cur_func_param_type.param_types[localidx]];
             if (var_type == "i32") {
                 m_a.asm_pop_r64(X64Reg::rax);
-                m_a.asm_mov_m64_r64(&base, nullptr, 1, 8 * (2 + localidx), X64Reg::rax);
+                m_a.asm_mov_m64_r64(&base, nullptr, 1, 8 * (2 + no_of_params - (int)localidx - 1), X64Reg::rax);
             } else if (var_type == "f64") {
                 X64Reg stack_top = X64Reg::rsp;
                 m_a.asm_movsd_r64_m64(X64FReg::xmm0, &stack_top, nullptr, 1, 0);
-                m_a.asm_movsd_m64_r64(&base, nullptr, 1, 8 * (2 + localidx), X64FReg::xmm0);
+                m_a.asm_movsd_m64_r64(&base, nullptr, 1, 8 * (2 + no_of_params - (int)localidx - 1), X64FReg::xmm0);
                 m_a.asm_add_r64_imm32(X64Reg::rsp, 8); // remove from stack top
             } else {
                 throw CodeGenError("WASM_X64: Var type not supported");

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -917,7 +917,7 @@ public:
 
     void asm_sub_r64_r64(X64Reg r64, X64Reg s64) {
         X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
-        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, rex(1, s64 >> 3, 0, r64 >> 3));
         m_code.push_back(m_al, 0x29);
         modrm_sib_disp(m_code, m_al,
                 s32, &r32, nullptr, 1, 0, false);
@@ -962,7 +962,7 @@ public:
 
     void asm_cmp_r64_r64(X64Reg r64, X64Reg s64) {
         X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
-        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, rex(1, s64 >> 3, 0, r64 >> 3));
         m_code.push_back(m_al, 0x39);
         modrm_sib_disp(m_code, m_al,
                 s32, &r32, nullptr, 1, 0, false);

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1401,6 +1401,28 @@ public:
         modrm_sib_disp(m_code, m_al, r32, &s32, nullptr, 1, 0, false);
         EMIT("pmovmskb " + r2s(r64) + ", " + r2s(s64));
     }
+
+    // UCOMISD—Unordered Compare Scalar Double Precision Floating-Point Values and Set EFLAGS
+    void asm_ucomisd_r64_r64(X64FReg r64, X64FReg s64) {
+        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, 0x66);
+        m_code.push_back(m_al, 0x0f);
+        m_code.push_back(m_al, 0x2e);
+        modrm_sib_disp(m_code, m_al, r32, &s32, nullptr, 1, 0, false);
+        EMIT("ucomisd " + r2s(r64) + ", " + r2s(s64));
+    }
+
+    // COMISD—Compare Scalar Ordered Double Precision Floating-Point Values and Set EFLAGS
+    void asm_comisd_r64_r64(X64FReg r64, X64FReg s64) {
+        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, 0x66);
+        m_code.push_back(m_al, 0x0f);
+        m_code.push_back(m_al, 0x2f);
+        modrm_sib_disp(m_code, m_al, r32, &s32, nullptr, 1, 0, false);
+        EMIT("comisd " + r2s(r64) + ", " + r2s(s64));
+    }
 };
 
 

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -186,6 +186,15 @@ static std::string r2s(X64FReg xmm) {
     }
 }
 
+enum Fcmp : uint8_t {
+    eq = 0x00,
+    gt = 0x06, // (NLE in docs)
+    ge = 0x05, // (NLT in docs)
+    lt = 0x01,
+    le = 0x02,
+    ne = 0x04
+};
+
 static std::string m2s(X64Reg *base, X64Reg *index, uint8_t scale, int64_t disp) {
     std::string r;
     r = "[";
@@ -974,6 +983,19 @@ public:
         modrm_sib_disp(m_code, m_al,
                 s32, &r32, nullptr, 1, 0, false);
         EMIT("cmp " + r2s(r32) + ", " + r2s(s32));
+    }
+
+    // CMPSD—Compare Scalar Double Precision Floating-Point Value
+    void asm_cmpsd_r64_r64(X64FReg r64, X64FReg s64, uint8_t imm8) {
+        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, 0xf2);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, 0x0f);
+        m_code.push_back(m_al, 0xc2);
+        modrm_sib_disp(m_code, m_al,
+                r32, &s32, nullptr, 1, 0, false);
+        m_code.push_back(m_al, imm8);
+        EMIT("cmpsd " + r2s(r64) + ", " + r2s(s64) + ", " + i2s(imm8));
     }
 
     void asm_jmp_imm8(uint8_t imm8) {

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1391,15 +1391,15 @@ public:
     // PMOVMSKB—Move Byte Mask
     // Creates a mask made up of the most significant bit of each byte
     // of the source operand (second operand) and stores the result in the low byte
-    // or word of the destination operand (first operand).
-    void asm_pmovmskb_r64_r64(X64Reg r64, X64FReg s64) {
-        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
-        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+    // or word of the destination operand (first operand)
+    void asm_pmovmskb_r32_r64(X86Reg r32, X64FReg s64) {
+        X86Reg s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, rex(1, 0, 0, s64 >> 3));
         m_code.push_back(m_al, 0x66);
         m_code.push_back(m_al, 0x0f);
         m_code.push_back(m_al, 0xd7);
         modrm_sib_disp(m_code, m_al, r32, &s32, nullptr, 1, 0, false);
-        EMIT("pmovmskb " + r2s(r64) + ", " + r2s(s64));
+        EMIT("pmovmskb " + r2s(r32) + ", " + r2s(s64));
     }
 
     // UCOMISD—Unordered Compare Scalar Double Precision Floating-Point Values and Set EFLAGS


### PR DESCRIPTION
This PR adds support of floating point comparison operations in the `wasm_x64` backend.

**Example:**
```bash
(lp) lpython$ cat examples/expr2.py 
from ltypes import f64

def compF64(x: f64, y: f64):
    print(x)
    print(y)
    if x < y:
        print("x lt y")
    if x > y:
        print("x gt y")
    if x == y:
        print("x eq y")
    if x >= y:
        print("x ge y")
    if x <= y:
        print("x le y")
    if x != y:
        print("x ne y")

def main0():
    x: f64 = 4.555
    y: f64 = 15.55
    w: f64 = 15.55
    z: f64 = 25.12
    compF64(x, y)
    compF64(y, x)
    compF64(x, z)
    compF64(y, w)
    compF64(w, y)

main0()
(lp) lpython$ lpython examples/expr2.py --backend wasm_x64 -o tmp > main.asm
(lp) lpython$ ./tmp
4.55499999
15.55000000
x lt y
x le y
x ne y
15.55000000
4.55499999
x gt y
x ge y
x ne y
4.55499999
25.12000000
x lt y
x le y
x ne y
15.55000000
15.55000000
x eq y
x ge y
x le y
15.55000000
15.55000000
x eq y
x ge y
x le y
(wasm_asm) lpython$ nasm -fbin main.asm && chmod +x main && ./main
4.55499999
15.55000000
x lt y
x le y
x ne y
15.55000000
4.55499999
x gt y
x ge y
x ne y
4.55499999
25.12000000
x lt y
x le y
x ne y
15.55000000
15.55000000
x eq y
x ge y
x le y
15.55000000
15.55000000
x eq y
x ge y
x le y
(wasm_asm) lpython$ 
```