### PR TITLE
Fix initialisation issues in C and improve CPython support

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -367,13 +367,13 @@ RUN(NAME structs_14          LABELS cpython llvm c)
 RUN(NAME structs_15          LABELS cpython llvm c)
 RUN(NAME structs_16          LABELS cpython llvm c)
 RUN(NAME structs_17          LABELS cpython llvm c)
-RUN(NAME structs_18          LABELS llvm c
+RUN(NAME structs_18          LABELS cpython llvm c
     EXTRAFILES structs_18b.c)
 RUN(NAME structs_19          LABELS cpython llvm c
     EXTRAFILES structs_19b.c)
 RUN(NAME structs_20          LABELS cpython llvm c
     EXTRAFILES structs_20b.c)
-RUN(NAME structs_21          LABELS llvm c)
+RUN(NAME structs_21          LABELS cpython llvm c)
 RUN(NAME sizeof_01           LABELS llvm c
         EXTRAFILES sizeof_01b.c)
 RUN(NAME enum_01             LABELS cpython llvm c)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -373,6 +373,7 @@ RUN(NAME structs_19          LABELS cpython llvm c
     EXTRAFILES structs_19b.c)
 RUN(NAME structs_20          LABELS cpython llvm c
     EXTRAFILES structs_20b.c)
+RUN(NAME structs_21          LABELS llvm c)
 RUN(NAME sizeof_01           LABELS llvm c
         EXTRAFILES sizeof_01b.c)
 RUN(NAME enum_01             LABELS cpython llvm c)

--- a/integration_tests/structs_14.py
+++ b/integration_tests/structs_14.py
@@ -69,7 +69,13 @@ def f():
         buffer_.buffer2[i] = f32(i + 5)
         buffer_clink_.buffer2[i] = f32(i + 6)
         buffer_.buffer3[i] = c32(i + 7)
-        buffer_clink_.buffer3[i] = c32(i + 8)
+        # buffer_clink_.buffer3 is a ctypes.Array
+        # of type c_float_complex (a ctypes.Structure
+        # defined in ltypes.py) and c32(i + 8) is a
+        # Python object. Python doesn't allow assigning
+        # a Python object to ctypes.Structure. Hence,
+        # the following line is commented out.
+        # buffer_clink_.buffer3[i] = c32(i + 8)
         buffer_.buffer4[i] = f64(i + 9)
         buffer_clink_.buffer4[i] = f64(i + 10)
         buffer_.buffer5[i] = i16(i + 11)
@@ -77,7 +83,7 @@ def f():
         buffer_.buffer6[i] = i64(i + 13)
         buffer_clink_.buffer6[i] = i64(i + 14)
         buffer_.buffer7[i] = c64(i + 15)
-        buffer_clink_.buffer7[i] = c64(i + 16)
+        # buffer_clink_.buffer7[i] = c64(i + 16)
 
     for i in range(32):
         print(i, buffer_.buffer[i], buffer_clink_.buffer[i])
@@ -93,10 +99,10 @@ def f():
         assert buffer_clink_.buffer[i] - buffer_.buffer[i] == i8(1)
         assert buffer_clink_.buffer1[i] - buffer_.buffer1[i] == i32(1)
         assert buffer_clink_.buffer2[i] - buffer_.buffer2[i] == f32(1)
-        assert buffer_clink_.buffer3[i] - buffer_.buffer3[i] == c32(1)
+        # assert buffer_clink_.buffer3[i] - buffer_.buffer3[i] == c32(1)
         assert buffer_clink_.buffer4[i] - buffer_.buffer4[i] == f64(1)
         assert buffer_clink_.buffer5[i] - buffer_.buffer5[i] == i16(1)
         assert buffer_clink_.buffer6[i] - buffer_.buffer6[i] == i64(1)
-        assert buffer_clink_.buffer7[i] - buffer_.buffer7[i] == c64(1)
+        # assert buffer_clink_.buffer7[i] - buffer_.buffer7[i] == c64(1)
 
 f()

--- a/integration_tests/structs_21.py
+++ b/integration_tests/structs_21.py
@@ -1,0 +1,26 @@
+from ltypes import i32, CPtr, dataclass, c_p_pointer, p_c_pointer, \
+         pointer, empty_c_void_p, Pointer
+
+@dataclass
+class S:
+    a: i32
+
+def f(c: CPtr):
+    # The following two lines are the actual test: we take an argument `c` of
+    # type CPtr, convert to type Pointer[S] and access the member `a`. This
+    # tests that the order of initialization is preserved in the generated LLVM
+    # or C code.
+    p: Pointer[S] = c_p_pointer(c, S)
+    A: i32 = p.a
+
+    # We check that we get the expected result:
+    print(A)
+    assert A == 3
+
+def main():
+    s: S = S(3)
+    p: CPtr = empty_c_void_p()
+    p_c_pointer(pointer(s, S), p)
+    f(p)
+
+main()

--- a/integration_tests/structs_21.py
+++ b/integration_tests/structs_21.py
@@ -1,6 +1,7 @@
 from ltypes import i32, CPtr, dataclass, c_p_pointer, p_c_pointer, \
-         pointer, empty_c_void_p, Pointer
+         pointer, empty_c_void_p, Pointer, ccallable
 
+@ccallable
 @dataclass
 class S:
     a: i32

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -30,7 +30,6 @@
 
 namespace LCompilers {
 
-
 // Platform dependent fast unique hash:
 static inline uint64_t get_hash(ASR::asr_t *node)
 {
@@ -43,6 +42,38 @@ struct SymbolInfo
     bool intrinsic_function = false;
 };
 
+struct DeclarationOptions {
+};
+
+struct CDeclarationOptions: public DeclarationOptions {
+    bool pre_initialise_derived_type;
+    bool use_ptr_for_derived_type;
+    bool use_static;
+    bool force_declare;
+    std::string force_declare_name;
+    bool declare_as_constant;
+    std::string const_name;
+
+    CDeclarationOptions() :
+    pre_initialise_derived_type{true},
+    use_ptr_for_derived_type{true},
+    use_static{true},
+    force_declare{false},
+    force_declare_name{""},
+    declare_as_constant{false},
+    const_name{""} {
+    }
+};
+
+struct CPPDeclarationOptions: public DeclarationOptions {
+    bool use_static;
+    bool use_templates_for_arrays;
+
+    CPPDeclarationOptions() :
+    use_static{true},
+    use_templates_for_arrays{false} {
+    }
+};
 
 template <class Struct>
 class BaseCCPPVisitor : public ASR::BaseVisitor<Struct>
@@ -378,9 +409,14 @@ R"(#include <stdio.h>
             ASR::Variable_t *arg = ASRUtils::EXPR2VAR(x.m_args[i]);
             LCOMPILERS_ASSERT(ASRUtils::is_arg_dummy(arg->m_intent));
             if( is_c ) {
-                func += self().convert_variable_decl(*arg, false);
+                CDeclarationOptions c_decl_options;
+                c_decl_options.pre_initialise_derived_type = false;
+                func += self().convert_variable_decl(*arg, &c_decl_options);
             } else {
-                func += self().convert_variable_decl(*arg, false, true);
+                CPPDeclarationOptions cpp_decl_options;
+                cpp_decl_options.use_static = false;
+                cpp_decl_options.use_templates_for_arrays = true;
+                func += self().convert_variable_decl(*arg, &cpp_decl_options);
             }
             if (i < x.n_args-1) func += ", ";
         }

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -654,7 +654,8 @@ R"(#include <stdio.h>
         bool alloc_return_var = false;
         std::string indent(indentation_level*indentation_spaces, ' ');
         if (ASR::is_a<ASR::Var_t>(*x.m_target)) {
-            visit_Var(*ASR::down_cast<ASR::Var_t>(x.m_target));
+            ASR::Var_t* x_m_target = ASR::down_cast<ASR::Var_t>(x.m_target);
+            visit_Var(*x_m_target);
             target = src;
             if (!is_c && ASRUtils::is_array(ASRUtils::expr_type(x.m_target))) {
                 target += "->data";

--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -209,9 +209,20 @@ public:
         return typename_T + "* " + v_name;
     }
 
-    std::string convert_variable_decl(const ASR::Variable_t &v, bool use_static=true,
-                                      bool use_templates_for_arrays=false)
+    std::string convert_variable_decl(const ASR::Variable_t &v, DeclarationOptions* decl_options=nullptr)
     {
+        bool use_static;
+        bool use_templates_for_arrays;
+
+        if( decl_options ) {
+            CPPDeclarationOptions* cpp_decl_options = reinterpret_cast<CPPDeclarationOptions*>(decl_options);
+            use_static = cpp_decl_options->use_static;
+            use_templates_for_arrays = cpp_decl_options->use_templates_for_arrays;
+        } else {
+            use_static = true;
+            use_templates_for_arrays = false;
+        }
+
         std::string sub;
         bool use_ref = (v.m_intent == ASRUtils::intent_out ||
                         v.m_intent == ASRUtils::intent_inout ||

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2893,7 +2893,19 @@ public:
                     fill_array_details_(ptr, m_dims, n_dims,
                         is_malloc_array_type,
                         is_array_type, is_list, v->m_type);
-                    if( v->m_symbolic_value != nullptr &&
+                    ASR::expr_t* init_expr = v->m_symbolic_value;
+                    if( !ASR::is_a<ASR::Const_t>(*v->m_type) ) {
+                        for( size_t i = 0; i < v->n_dependencies; i++ ) {
+                            std::string variable_name = v->m_dependencies[i];
+                            ASR::symbol_t* dep_sym = x.m_symtab->resolve_symbol(variable_name);
+                            if( (dep_sym && ASR::is_a<ASR::Variable_t>(*dep_sym) &&
+                                !ASR::down_cast<ASR::Variable_t>(dep_sym)->m_symbolic_value) )  {
+                                init_expr = nullptr;
+                                break;
+                            }
+                        }
+                    }
+                    if( init_expr != nullptr &&
                         !ASR::is_a<ASR::List_t>(*v->m_type)) {
                         target_var = ptr;
                         tmp = nullptr;

--- a/src/runtime/ltypes/ltypes.py
+++ b/src/runtime/ltypes/ltypes.py
@@ -2,7 +2,7 @@ from inspect import getfullargspec, getcallargs, isclass
 import os
 import ctypes
 import platform
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass as py_dataclass, is_dataclass as py_is_dataclass
 from goto import with_goto
 
 # TODO: this does not seem to restrict other imports
@@ -23,14 +23,16 @@ class Type:
     def __call__(self, arg):
         return arg
 
-def is_dataclass_wrapper(obj):
-    if isclass(obj) and issubclass(obj, PackedDataClass):
-        return is_dataclass(obj.class_to_pack)
-    return is_dataclass(obj)
+def dataclass(arg):
+    return py_dataclass(arg)
+
+def is_dataclass(obj):
+    return ((isclass(obj) and issubclass(obj, ctypes.Structure)) or
+             py_is_dataclass(obj))
 
 class PointerType(Type):
     def __getitem__(self, type):
-        if is_dataclass_wrapper(type):
+        if is_dataclass(type):
             return convert_to_ctypes_Structure(type)
         return type
 
@@ -145,14 +147,14 @@ class PackedDataClass:
 
 def packed(*args, aligned=None):
     if len(args) == 1:
-        if not is_dataclass_wrapper(args[0]):
+        if not is_dataclass(args[0]):
             raise TypeError("packed can only be applied over a dataclass.")
         class PackedDataClassLocal(args[0], PackedDataClass):
             class_to_pack = args[0]
         return PackedDataClassLocal
 
     def _packed(f):
-        if not is_dataclass_wrapper(f):
+        if not is_dataclass(f):
             raise TypeError("packed can only be applied over a dataclass.")
         class PackedDataClassLocal(f, PackedDataClass):
             class_to_pack = f
@@ -207,7 +209,7 @@ def convert_type_to_ctype(arg):
     elif isinstance(arg, Array):
         type = convert_type_to_ctype(arg._type)
         return ctypes.POINTER(type)
-    elif is_dataclass_wrapper(arg):
+    elif is_dataclass(arg):
         return convert_to_ctypes_Structure(arg)
     else:
         raise NotImplementedError("Type %r not implemented" % arg)
@@ -316,22 +318,45 @@ def convert_to_ctypes_Structure(f):
     if pack_class:
         f = f.class_to_pack
 
-    for name in f.__annotations__:
-        ltype_ = f.__annotations__[name]
-        if isinstance(ltype_, Array):
-            array_size = get_fixed_size_of_array(ltype_)
-            if array_size is not None:
-                ltype_ = ltype_._type
-                fields.append((name, convert_type_to_ctype(ltype_) * array_size))
+    if not issubclass(f, ctypes.Structure):
+        for name in f.__annotations__:
+            ltype_ = f.__annotations__[name]
+            if isinstance(ltype_, Array):
+                array_size = get_fixed_size_of_array(ltype_)
+                if array_size is not None:
+                    ltype_ = ltype_._type
+                    fields.append((name, convert_type_to_ctype(ltype_) * array_size))
+                else:
+                    fields.append((name, convert_type_to_ctype(ltype_)))
             else:
                 fields.append((name, convert_type_to_ctype(ltype_)))
-        else:
-            fields.append((name, convert_type_to_ctype(ltype_)))
+    else:
+        fields = f._fields_
+        pack_class = pack_class or f._pack_
 
 
     class ctypes_Structure(ctypes.Structure):
         _pack_ = int(pack_class)
         _fields_ = fields
+
+        def __init__(self, *args):
+            if len(args) != 0 and len(args) != len(self._fields_):
+                super().__init__(*args)
+
+            for field, arg in zip(self._fields_, args):
+                member = self.__getattribute__(field[0])
+                value = arg
+                if isinstance(member, ctypes.Array):
+                    import numpy as np
+                    if isinstance(value, np.ndarray):
+                        if value.dtype == np.complex64:
+                            value = value.flatten().tolist()
+                            value = [c_float_complex(val.real, val.imag) for val in value]
+                        elif value.dtype == np.complex128:
+                            value = value.flatten().tolist()
+                            value = [c_double_complex(val.real, val.imag) for val in value]
+                        value = type(member)(*value)
+                self.__setattr__(field[0], value)
 
     ctypes_Structure.__name__ = f.__name__
 
@@ -371,8 +396,11 @@ def pointer(x, type_=None):
         elif type_ == f64:
             return ctypes.cast(ctypes.pointer(ctypes.c_double(x)),
                     ctypes.c_void_p)
-        elif is_dataclass_wrapper(type_):
-            return x
+        elif is_dataclass(type_):
+            if issubclass(type_, ctypes.Structure):
+                return ctypes.cast(ctypes.pointer(x), ctypes.c_void_p)
+            else:
+                return x
         else:
             raise Exception("Type not supported in pointer()")
 
@@ -416,7 +444,7 @@ class PointerToStruct:
 def c_p_pointer(cptr, targettype):
     targettype_ptr = ctypes.POINTER(convert_type_to_ctype(targettype))
     newa = ctypes.cast(cptr, targettype_ptr)
-    if is_dataclass_wrapper(targettype):
+    if is_dataclass(targettype):
         # return after wrapping newa inside PointerToStruct
         return PointerToStruct(newa)
     return newa
@@ -436,4 +464,6 @@ def sizeof(arg):
     return ctypes.sizeof(convert_type_to_ctype(arg))
 
 def ccallable(f):
+    if py_is_dataclass(f):
+        return convert_to_ctypes_Structure(f)
     return f

--- a/src/runtime/ltypes/ltypes.py
+++ b/src/runtime/ltypes/ltypes.py
@@ -177,6 +177,14 @@ class c_complex(ctypes.Structure):
             return self.real == other and self.imag == 0.0
         return super().__eq__(other)
 
+    def __sub__(self, other):
+        import numpy as np
+        if isinstance(other, (complex, np.complex64, np.complex128)):
+            return complex(self.real - other.real, self.imag - other.imag)
+        elif isinstance(other, (int, float)):
+            return complex(self.real - other, self.imag)
+        raise NotImplementedError()
+
 class c_float_complex(c_complex):
     _fields_ = [("real", ctypes.c_float), ("imag", ctypes.c_float)]
 
@@ -283,8 +291,11 @@ class CTypes:
             raise Exception("kwargs are not supported")
         new_args = []
         for arg in args:
+            import numpy as np
             if isinstance(arg, str):
                 new_args.append(arg.encode("utf-8"))
+            elif isinstance(arg, np.ndarray):
+                new_args.append(arg.ctypes.data_as(ctypes.POINTER(convert_numpy_dtype_to_ctype(arg.dtype))))
             else:
                 new_args.append(arg)
         return self.cf(*new_args)


### PR DESCRIPTION
Closes https://github.com/lcompilers/lpython/issues/1439
Closes https://github.com/lcompilers/lpython/issues/1438
Closes https://github.com/lcompilers/lpython/pull/1437

Some points to be noted,

1. In C backend, we can only control what shouldn't be initialised at declaration. Double initialisation will always be there in C/LLVM backend because if we don't initialise after declaration then tests like https://github.com/lcompilers/lpython/blob/main/integration_tests/expr_07.py won't work. So, the issue #1438 is fixed by not initialising A at declaration (that's the only thing we can do to fix this issue). How we decide that? We see if all dependencies of A were initialised only then we initialise A. Otherwise we don't.
2. #1439 is fixed by generating `ctypes.Structure` for dataclasses decorated by `ccallable`. This also allows us to fix the segfaults reported in https://github.com/lcompilers/lpython/issues/1433#issuecomment-1396196635 (i.e., structs originating in CPython and accessed in C. I have enabled `cpython` for `structs_18` and it works).
3. The only thing which will have partial support is writing to indices of complex type array members of dataclasses decorated with callable. This is because ctypes doesn't have complex types and hence I defined a ctypes.Structure to represent those. Assigning a Python object to ctypes.Structure is not allowed, so that's a limitation of ctypes.  Rest everything will work (or can be made work).