### PR TITLE
WASM_X64: Print negative floats

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -226,6 +226,7 @@ RUN(NAME exit_02c    FAIL    LABELS cpython llvm c)
 RUN(NAME print_01            LABELS cpython llvm c wasm) # wasm not yet supports sep and end keywords
 RUN(NAME print_03            LABELS x86 c wasm wasm_x86 wasm_x64) # simple test case specifically for x86, wasm_x86 and wasm_x64
 RUN(NAME print_04            LABELS cpython llvm c)
+RUN(NAME print_float         LABELS cpython llvm wasm wasm_x64)
 RUN(NAME print_list_tuple    LABELS cpython c) # TODO: llvm doesn't completely support printing list
 
 # CPython and LLVM

--- a/integration_tests/comp_01.py
+++ b/integration_tests/comp_01.py
@@ -32,7 +32,7 @@ def compF64(x: f64, y: f64):
     if x != y:
         print("x ne y")
 
-def main0():
+def test_pos_ints_floats_comp():
     a: i32 = 4
     b: i32 = 5
     c: i32 = 5
@@ -42,6 +42,9 @@ def main0():
     compI32(a, d)
     compI32(b, c)
     compI32(c, b)
+    assert(a < b)
+    assert(a < d)
+    assert(b == c)
 
     x: f64 = 4.555
     y: f64 = 15.55
@@ -52,5 +55,39 @@ def main0():
     compF64(x, z)
     compF64(y, w)
     compF64(w, y)
+    assert(x < y)
+    assert(x < z)
+    assert(y == w)
+
+def test_neg_ints_floats_comp():
+    a: i32 = -4
+    b: i32 = -5
+    c: i32 = -5
+    d: i32 = -6
+    compI32(a, b)
+    compI32(b, a)
+    compI32(a, d)
+    compI32(b, c)
+    compI32(c, b)
+    assert(a > b)
+    assert(a > d)
+    assert(b == c)
+
+    x: f64 = -4.555
+    y: f64 = -15.55
+    w: f64 = -15.55
+    z: f64 = -25.12
+    compF64(x, y)
+    compF64(y, x)
+    compF64(x, z)
+    compF64(y, w)
+    compF64(w, y)
+    assert(x > y)
+    assert(x > z)
+    assert(y == w)
+
+def main0():
+    test_pos_ints_floats_comp()
+    test_neg_ints_floats_comp()
 
 main0()

--- a/integration_tests/print_float.py
+++ b/integration_tests/print_float.py
@@ -1,0 +1,13 @@
+from ltypes import f64
+
+def main0():
+    x: f64 = 0.00012
+    y: f64 = -0.00012
+    z: f64 = 9255.456
+    w: f64 = -9255.456
+    print(x)
+    print(y)
+    print(z)
+    print(w)
+
+main0()

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -346,9 +346,22 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
     void visit_I32LeS() { handle_I32Compare<&X86Assembler::asm_jle_label>(); }
     void visit_I32Ne() { handle_I32Compare<&X86Assembler::asm_jne_label>(); }
 
+    std::string float_to_str(double z) {
+        std::string float_str = "";
+        for (auto ch:std::to_string(z)) {
+            if (ch == '-') {
+                float_str += "neg_";
+            } else if (ch == '.') {
+                float_str += "_dot_";
+            } else {
+                float_str += ch;
+            }
+        }
+        return float_str;
+    }
+
     void visit_F64Const(double z) {
-        std::string label = "float_" + std::to_string(z);
-        // std::cerr << label << " " << z << std::endl;
+        std::string label = "float_" + float_to_str(z);
         double_consts[label] = z;
         m_a.asm_mov_r64_label(X64Reg::rax, label);
         X64Reg label_reg = X64Reg::rax;

--- a/src/libasr/codegen/x86_assembler.cpp
+++ b/src/libasr/codegen/x86_assembler.cpp
@@ -459,13 +459,46 @@ void emit_print_double(X86Assembler &a, const std::string &name) {
         a.asm_cvtsi2sd_r64_r64(X64FReg::xmm1, X64Reg::rax);
         a.asm_mulsd_r64_r64(X64FReg::xmm0, X64FReg::xmm1);
         a.asm_cvttsd2si_r64_r64(X64Reg::rax, X64FReg::xmm0);
-        a.asm_push_r64(X64Reg::rax);
 
-        // print the fractional part
-        {
-            a.asm_call_label("print_i64");
-            a.asm_add_r64_imm32(X64Reg::rsp, 8); // pop and increment stack pointer
-        }
+        a.asm_mov_r64_r64(X64Reg::r15, X64Reg::rax); // keep a safe copy in r15
+        a.asm_mov_r64_imm64(X64Reg::r8, 8); // 8 digits after decimal point to be printed
+        a.asm_mov_r64_imm64(X64Reg::r10, 10); // 10 as divisor
+
+        // count the number of digits available in the fractional part
+        a.add_label("_count_fract_part_digits_loop");
+            a.asm_mov_r64_imm64(X64Reg::rdx, 0);
+            a.asm_div_r64(X64Reg::r10);
+            a.asm_dec_r64(X64Reg::r8);
+            a.asm_cmp_r64_imm8(X64Reg::rax, 0);
+            a.asm_je_label("_print_fract_part_initial_zeroes_loop_head");
+            a.asm_jmp_label("_count_fract_part_digits_loop");
+
+        a.add_label("_print_fract_part_initial_zeroes_loop_head");
+            a.asm_mov_r64_imm64(X64Reg::rax, 48);
+            a.asm_push_r64(X64Reg::rax); // push zero ascii value on stack top
+
+        a.add_label("_print_fract_part_initial_zeroes_loop");
+            a.asm_cmp_r64_imm8(X64Reg::r8, 0);
+            a.asm_je_label("_print_fract_part");
+            {
+                // write() syscall
+                a.asm_mov_r64_imm64(X64Reg::rax, 1);
+                a.asm_mov_r64_imm64(X64Reg::rdi, 1);
+                a.asm_mov_r64_r64(X64Reg::rsi, X64Reg::rsp);
+                a.asm_mov_r64_imm64(X64Reg::rdx, 1);
+                a.asm_syscall();
+            }
+            a.asm_dec_r64(X64Reg::r8);
+            a.asm_jmp_label("_print_fract_part_initial_zeroes_loop");
+
+        a.add_label("_print_fract_part");
+            a.asm_pop_r64(X64Reg::rax); // pop the zero ascii value from stack top
+            a.asm_push_r64(X64Reg::r15);
+            // print the fractional part
+            {
+                a.asm_call_label("print_i64");
+                a.asm_add_r64_imm32(X64Reg::rsp, 8); // pop and increment stack pointer
+            }
     }
 
     // Restore stack


### PR DESCRIPTION
**Example:**
```python
from ltypes import f64

def main0():
    x: f64 = 0.00012
    y: f64 = -0.00012
    z: f64 = 9255.456
    w: f64 = -9255.456
    print(x)
    print(y)
    print(z)
    print(w)

main0()
```

**Output:**
```bash
(lp) lpython$ lpython examples/expr2.py --backend wasm_x64 -o tmp > main.asm
(lp) lpython$ ./tmp
0.00012000
-0.00012000
9255.45600000
-9255.45600000
(lp) lpython$ 
(wasm_asm) lpython$ nasm -fbin main.asm && chmod +x main && ./main
0.00012000
-0.00012000
9255.45600000
-9255.45600000
(wasm_asm) lpython$ 
```

