### PR TITLE
Fixed Printing of Escape Sequences

### DIFF
--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -836,9 +836,9 @@ R"(#include <stdio.h>
             if (s[idx] == '\n') {
                 src += "\\n";
             } else if (s[idx] == '\\') {
-                src += "\\\\";
+                src += "\\";
             } else if (s[idx] == '\"') {
-                src += "\\\"";
+                src += "\"";
             } else {
                 src += s[idx];
             }

--- a/src/libasr/codegen/asr_to_julia.cpp
+++ b/src/libasr/codegen/asr_to_julia.cpp
@@ -1422,9 +1422,9 @@ public:
             if (s[idx] == '\n') {
                 src += "\\n";
             } else if (s[idx] == '\\') {
-                src += "\\\\";
+                src += "\\";
             } else if (s[idx] == '\"') {
-                src += "\\\"";
+                src += "\"";
             } else {
                 src += s[idx];
             }

--- a/src/lpython/parser/semantics.h
+++ b/src/lpython/parser/semantics.h
@@ -800,10 +800,10 @@ char* unescape(Allocator &al, LCompilers::Str &s) {
         if (s.p[idx] == '\\' && s.p[idx+1] == 'n') {
             x += "\n";
             idx++;
-        }else if (s.p[idx] == '\\' && s.p[idx+1] == '\'') {
+        } else if (s.p[idx] == '\\' && s.p[idx+1] == '\'') {
             x += "'";
             idx++;
-        }else {
+        } else {
             x += s.p[idx];
         }
     }

--- a/src/lpython/parser/semantics.h
+++ b/src/lpython/parser/semantics.h
@@ -800,7 +800,10 @@ char* unescape(Allocator &al, LCompilers::Str &s) {
         if (s.p[idx] == '\\' && s.p[idx+1] == 'n') {
             x += "\n";
             idx++;
-        } else {
+        }else if (s.p[idx] == '\\' && s.p[idx+1] == '\'') {
+            x += "'";
+            idx++;
+        }else {
             x += s.p[idx];
         }
     }

--- a/tests/reference/ast_new-string2-44323ea.json
+++ b/tests/reference/ast_new-string2-44323ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "ast_new-string2-44323ea.stdout",
-    "stdout_hash": "c53164138eddb106cd7e13ab552e7b9f5978e3a7649708ece0ceb1db",
+    "stdout_hash": "b6bd901a34260e3a2109285fb3f422406e6e5147e9932713dcd9f138",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/ast_new-string2-44323ea.stdout
+++ b/tests/reference/ast_new-string2-44323ea.stdout
@@ -8,5 +8,5 @@ class a:
 " ())] [])) (Expr (ConstantStr "
     "\\"
 " ())) (Expr (ConstantStr "
-    '\\'
+    '\'
 " ()))] [])


### PR DESCRIPTION
Fixes #1473
Modified LPython semantics, C and Julia backend so that they do not print the backslash even after it is recognized.

When asked to print the following string: 
```
s: str
s = 'I said \'Wow\' '
print(s)
``` 
LPython now prints:
`I said 'Wow' `

