### PR TITLE
Updated error message related to for loops being used on undeclared iterables

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -4361,7 +4361,7 @@ public:
                     x.base.base.loc);
             }
             if (call_name != "range") {
-                throw SemanticError("Only range(..) supported as for loop iteration for now",
+                throw SemanticError(call_name + "(..) is not supported as for loop iteration for now",
                     x.base.base.loc);
             }
             Vec<ASR::expr_t*> args;


### PR DESCRIPTION
Addresses https://github.com/lcompilers/lpython/issues/1475#issuecomment-1405246377

On the comitted branch we now get `semantic error: reverse(..) is not supported as for loop iteration for now` rather than `semantic error: Only range(..) supported as for loop iteration for now` which we get on main for the following
```
def main0():
    s : str
    for s in reverse("abc"):
        print(s)

main0()
```

I'll be working on the implementation part of things soon , but being new to lpython , I wanted to get familiar with the development workflow with a relatively smaller pr first.