### PR TITLE
WASM: Support global section

### DIFF
--- a/src/libasr/codegen/wasm_assembler.h
+++ b/src/libasr/codegen/wasm_assembler.h
@@ -236,6 +236,18 @@ void emit_set_local(Vec<uint8_t> &code, Allocator &al, uint32_t idx) {
     emit_u32(code, al, idx);
 }
 
+// function to emit get global variable at given index
+void emit_get_global(Vec<uint8_t> &code, Allocator &al, uint32_t idx) {
+    code.push_back(al, 0x23);
+    emit_u32(code, al, idx);
+}
+
+// function to emit set global variable at given index
+void emit_set_global(Vec<uint8_t> &code, Allocator &al, uint32_t idx) {
+    code.push_back(al, 0x24);
+    emit_u32(code, al, idx);
+}
+
 // function to emit call instruction
 void emit_call(Vec<uint8_t> &code, Allocator &al, uint32_t idx) {
     code.push_back(al, 0x10);

--- a/src/libasr/codegen/wasm_decoder.h
+++ b/src/libasr/codegen/wasm_decoder.h
@@ -60,6 +60,7 @@ class WASMDecoder {
     Vec<wasm::Import> imports;
     Vec<uint32_t> type_indices;
     Vec<std::pair<uint32_t, uint32_t>> memories;
+    Vec<wasm::Global> globals;
     Vec<wasm::Export> exports;
     Vec<wasm::Code> codes;
     Vec<wasm::Data> data_segments;
@@ -223,6 +224,19 @@ class WASMDecoder {
         }
     }
 
+    void decode_global_section(uint32_t offset) {
+        // read global section contents
+        uint32_t no_of_globals = read_u32(wasm_bytes, offset);
+        DEBUG("no_of_globals: " + std::to_string(no_of_globals));
+        globals.resize(al, no_of_globals);
+
+        for (uint32_t i = 0; i < no_of_globals; i++) {
+            globals.p[i].type = read_b8(wasm_bytes, offset);
+            globals.p[i].mut = read_b8(wasm_bytes, offset);
+            globals.p[i].insts_start_idx = offset;
+        }
+    }
+
     void decode_export_section(uint32_t offset) {
         // read export section contents
         uint32_t no_of_exports = read_u32(wasm_bytes, offset);
@@ -340,6 +354,10 @@ class WASMDecoder {
                     break;
                 case 5U:
                     decode_memory_section(index);
+                    // exit(0);
+                    break;
+                case 6U:
+                    decode_global_section(index);
                     // exit(0);
                     break;
                 case 7U:

--- a/src/libasr/codegen/wasm_to_wat.cpp
+++ b/src/libasr/codegen/wasm_to_wat.cpp
@@ -41,6 +41,12 @@ class WATVisitor : public WASMDecoder<WATVisitor>,
     void visit_LocalSet(uint32_t localidx) {
         src += indent + "local.set " + std::to_string(localidx);
     }
+    void visit_GlobalGet(uint32_t globalidx) {
+        src += indent + "global.get " + std::to_string(globalidx);
+    }
+    void visit_GlobalSet(uint32_t globalidx) {
+        src += indent + "global.set " + std::to_string(globalidx);
+    }
     void visit_EmtpyBlockType() {}
     void visit_If() {
         src += indent + "if";
@@ -333,6 +339,20 @@ class WATVisitor : public WASMDecoder<WATVisitor>,
                     std::to_string(imports[i].mem_page_size_limits.second) +
                     "))";
             }
+        }
+
+        for (uint32_t i = 0; i < globals.size(); i++) {
+            std::string global_initialization_insts = "";
+            {
+                this->offset = globals.p[i].insts_start_idx;
+                this->indent = "";
+                this->src = "";
+                decode_instructions();
+                global_initialization_insts = this->src;
+            }
+            result += indent + "(global $" + std::to_string(i);
+            result += " " + var_type_to_string[globals[i].type];
+            result += " (" + global_initialization_insts + "))";
         }
 
         for (uint32_t i = 0; i < type_indices.size(); i++) {

--- a/src/libasr/codegen/wasm_utils.h
+++ b/src/libasr/codegen/wasm_utils.h
@@ -16,6 +16,12 @@ struct FuncType {
     Vec<uint8_t> result_types;
 };
 
+struct Global {
+    uint8_t type;
+    uint8_t mut;
+    uint32_t insts_start_idx;
+};
+
 struct Export {
     std::string name;
     uint8_t kind;

--- a/tests/reference/wat-bool1-234bcd1.json
+++ b/tests/reference/wat-bool1-234bcd1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-bool1-234bcd1.stdout",
-    "stdout_hash": "9d7405a88da887d95c18dc2f71c9b516f8ede0664c9e61033976e5c1",
+    "stdout_hash": "9509a512bd279e27e1c1a4573a344b98e984e93521cef089eb3bb334",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-bool1-234bcd1.stdout
+++ b/tests/reference/wat-bool1-234bcd1.stdout
@@ -8,6 +8,7 @@
     (type (;6;) (func (param) (result)))
     (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
     (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
+    (global $0 i32 (i32.const 0))
     (func $2 (type 2) (param i64) (result)
         (local i64 i64 i64 i64)
         local.get 0

--- a/tests/reference/wat-expr14-5e0cb96.json
+++ b/tests/reference/wat-expr14-5e0cb96.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-expr14-5e0cb96.stdout",
-    "stdout_hash": "8dd0860fcf3d6380112b1f3b8011b794ffc386a86628aad179297a53",
+    "stdout_hash": "96f90f190be31d02b145de3fe293bc74b4a79a3a8aa4c8ebb236a4e9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-expr14-5e0cb96.stdout
+++ b/tests/reference/wat-expr14-5e0cb96.stdout
@@ -7,6 +7,7 @@
     (type (;5;) (func (param) (result)))
     (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
     (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
+    (global $0 i32 (i32.const 0))
     (func $2 (type 2) (param i64) (result)
         (local i64 i64 i64 i64)
         local.get 0

--- a/tests/reference/wat-expr2-8b17723.json
+++ b/tests/reference/wat-expr2-8b17723.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-expr2-8b17723.stdout",
-    "stdout_hash": "b3bd5faae5f1632c099d408d9d18c58cb2cfd4f7be1dec2133ec2b1c",
+    "stdout_hash": "a38ec604027092a7cd322473580201a022de5e7ea948c3b63a8ab798",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-expr2-8b17723.stdout
+++ b/tests/reference/wat-expr2-8b17723.stdout
@@ -7,6 +7,7 @@
     (type (;5;) (func (param) (result)))
     (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
     (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
+    (global $0 i32 (i32.const 0))
     (func $2 (type 2) (param i64) (result)
         (local i64 i64 i64 i64)
         local.get 0

--- a/tests/reference/wat-expr9-f73afd1.json
+++ b/tests/reference/wat-expr9-f73afd1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-expr9-f73afd1.stdout",
-    "stdout_hash": "d1025281003011357a1e1e39c7b2eec7752f209d50805aa5a81d83fd",
+    "stdout_hash": "d1618163ab287b71613fd75147ae7362a7955ebc6e9f32810b21b824",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-expr9-f73afd1.stdout
+++ b/tests/reference/wat-expr9-f73afd1.stdout
@@ -12,6 +12,7 @@
     (type (;10;) (func (param) (result)))
     (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
     (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
+    (global $0 i32 (i32.const 0))
     (func $2 (type 2) (param i64) (result)
         (local i64 i64 i64 i64)
         local.get 0

--- a/tests/reference/wat-loop1-e0046d4.json
+++ b/tests/reference/wat-loop1-e0046d4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-loop1-e0046d4.stdout",
-    "stdout_hash": "21c5d32f395a2daee2e25240b5a225f6090d2905440973edef350f44",
+    "stdout_hash": "07cd13d55836deabb991c7762567db212b10e869075d06a6b34476a2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-loop1-e0046d4.stdout
+++ b/tests/reference/wat-loop1-e0046d4.stdout
@@ -11,6 +11,7 @@
     (type (;9;) (func (param) (result)))
     (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
     (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
+    (global $0 i32 (i32.const 0))
     (func $2 (type 2) (param i64) (result)
         (local i64 i64 i64 i64)
         local.get 0

--- a/tests/reference/wat-print_str-385e953.json
+++ b/tests/reference/wat-print_str-385e953.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-print_str-385e953.stdout",
-    "stdout_hash": "51176be242a4d758284827adeb446b6455b2e7a64f15a73daf493efb",
+    "stdout_hash": "5c741b7c4d2def2a49b189d20e307eba2c157d714d278fc3cc924d7f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-print_str-385e953.stdout
+++ b/tests/reference/wat-print_str-385e953.stdout
@@ -9,6 +9,7 @@
     (type (;7;) (func (param) (result)))
     (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
     (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
+    (global $0 i32 (i32.const 0))
     (func $2 (type 2) (param i64) (result)
         (local i64 i64 i64 i64)
         local.get 0


### PR DESCRIPTION
This `PR` implements support for `global` sections in the `wasm` and `wat` backends.