### PR TITLE
Make LCompilers CLI check if source file exists

### DIFF
--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -1559,6 +1559,9 @@ int main(int argc, char *argv[])
         // TODO: for now we ignore the other filenames, only handle
         // the first:
         std::string arg_file = arg_files[0];
+        if (CLI::NonexistentPath(arg_file).empty()){
+            throw LCompilers::LCompilersException("No such file or directory: " + arg_file);
+        }
 
         std::string outfile;
         std::string basename;


### PR DESCRIPTION
Closes https://github.com/lcompilers/lpython/issues/1490

On master
```
(lp) C:\Users\kunni\lpython>python wrong_name.py
python: can't open file 'C:\\Users\\kunni\\lpython\\wrong_name.py': [Errno 2] No such file or directory

(lp) C:\Users\kunni\lpython>src\bin\lpython wrong_name.py

(lp) C:\Users\kunni\lpython>src\bin\lpython --show-ast wrong_name.py
(Module [] [])
```

On branch-
```
(lp) C:\Users\kunni\lpython>src\bin\lpython wrong_name.py
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
LCompilersException: No such file or directory: wrong_name.py

(lp) C:\Users\kunni\lpython>src\bin\lpython --show-ast wrong_name.py
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
LCompilersException: No such file or directory: wrong_name.py

```