### PR TITLE
replaced all "has to" and "needs to" with "must"

### DIFF
--- a/doc/src/design.md
+++ b/doc/src/design.md
@@ -91,7 +91,7 @@ ASR is the simplest way to generate Fortran code, as one does not
 have to worry about the detailed syntax (as in AST) about how and where
 things are declared. One specifies the symbol table for a module, then for
 each symbol (functions, global variables, types, ...) one specifies the local
-variables and if this is an interface then one needs to specify where one can
+variables and if this is an interface then one must specify where one can
 find an implementation, otherwise a body is supplied with statements, those
 nodes are almost the same as in AST, except that each variable is just a
 reference to a symbol in the symbol table (so by construction one cannot have

--- a/src/bin/CLI11.hpp
+++ b/src/bin/CLI11.hpp
@@ -4191,7 +4191,7 @@ class Option : public OptionBase<Option> {
     bool flag_like_{false};
     /// Control option to run the callback to set the default
     bool run_callback_for_default_{false};
-    /// flag indicating a separator needs to be injected after each argument call
+    /// flag indicating a separator must be injected after each argument call
     bool inject_separator_{false};
     ///@}
 
@@ -4745,7 +4745,7 @@ class Option : public OptionBase<Option> {
         }
 
         if(!envname_.empty()) {
-            // this needs to be the original since envname_ shouldn't match on case insensitivity
+            // this must be the original since envname_ shouldn't match on case insensitivity
             return (name == envname_);
         }
         return false;
@@ -7585,7 +7585,7 @@ class App {
     }
 
     /// Parse "one" argument (some may eat more than one), delegate to parent if fails, add to missing if missing
-    /// from master return false if the parse has failed and needs to return to parent
+    /// from master return false if the parse has failed and must return to parent
     bool _parse_single(std::vector<std::string> &args, bool &positional_only) {
         bool retval = true;
         detail::Classifier classifier = positional_only ? detail::Classifier::NONE : _recognize(args.back());
@@ -7886,7 +7886,7 @@ class App {
         int min_num = (std::min)(op->get_type_size_min(), op->get_items_expected_min());
         int max_num = op->get_items_expected_max();
         // check container like options to limit the argument size to a single type if the allow_extra_flags argument is
-        // set. 16 is somewhat arbitrary (needs to be at least 4)
+        // set. 16 is somewhat arbitrary (must be at least 4)
         if(max_num >= detail::expected_max_vector_size / 16 && !op->get_allow_extra_args()) {
             auto tmax = op->get_type_size_max();
             max_num = detail::checked_multiply(tmax, op->get_expected_min()) ? tmax : detail::expected_max_vector_size;

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -131,7 +131,7 @@ presence = Required | Optional
 -- the code in optimizations).
 
 -- abi=LFortranModule/GFortranModule/BindC: the symbol's implementation is
--- stored as machine code in some object file that needs to be linked in. It
+-- stored as machine code in some object file that must be linked in. It
 -- uses the specified ABI (one of LFortran module, GFortran module or C ABI).
 -- An interface that uses `iso_c_binding` and `bind(c)` is represented using
 -- abi=BindC.

--- a/src/libasr/asdl.py
+++ b/src/libasr/asdl.py
@@ -107,7 +107,7 @@ class Product(AST):
 
 # A generic visitor for the meta-AST that describes ASDL. This can be used by
 # emitters. Note that this visitor does not provide a generic visit method, so a
-# subclass needs to define visit methods from visitModule to as deep as the
+# subclass must define visit methods from visitModule to as deep as the
 # interesting node.
 # We also define a Check visitor that makes sure the parsed ASDL is well-formed.
 

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1495,7 +1495,7 @@ public:
 
 
 // Generate an ELF 32 bit header and footer
-// With these two functions, one only has to generate a `_start` assembly
+// With these two functions, one only must generate a `_start` assembly
 // function to have a working binary on Linux.
 void emit_elf32_header(X86Assembler &a, uint32_t p_flags=5);
 void emit_elf32_footer(X86Assembler &a);
@@ -1504,7 +1504,7 @@ void emit_exit(X86Assembler &a, const std::string &name,
     uint32_t exit_code);
 
 // this is similar to emit_exit() but takes the argument (i.e. exit code)
-// from top of stack. To call this exit2, one needs to jump to it
+// from top of stack. To call this exit2, one must jump to it
 // instead of call it. (Because calling pushes the instruction address and
 // base pointer value (ebp) of previous function and thus makes the
 // exit code parameter less reachable)
@@ -1522,7 +1522,7 @@ void emit_print_int(X86Assembler &a, const std::string &name);
 void emit_print_float(X86Assembler &a, const std::string &name);
 
 // Generate an ELF 64 bit header and footer
-// With these two functions, one only has to generate a `_start` assembly
+// With these two functions, one only must generate a `_start` assembly
 // function to have a working binary on Linux.
 void emit_elf64_header(X86Assembler &a, uint32_t p_flags=5);
 void emit_elf64_footer(X86Assembler &a);

--- a/src/libasr/diagnostics.cpp
+++ b/src/libasr/diagnostics.cpp
@@ -90,7 +90,7 @@ std::string Diagnostics::render(LocationManager &lm,
                 out += "\n\n";
                 out += bold + "Note" + reset
                     + ": if any of the above error or warning messages are not clear or are lacking\n";
-                out += "context please report it to us (we consider that a bug that needs to be fixed).\n";
+                out += "context please report it to us (we consider that a bug that must be fixed).\n";
             }
         }
     }

--- a/src/libasr/stacktrace.cpp
+++ b/src/libasr/stacktrace.cpp
@@ -40,7 +40,7 @@
 
 #ifdef HAVE_LFORTRAN_BFD
 // For bfd_* family of functions for loading debugging symbols from the binary
-// This is the only nonstandard header file and the binary needs to be linked
+// This is the only nonstandard header file and the binary must be linked
 // with "-lbfd".
 // Note: on macOS, one must call `dsymutil` on any binary in order for BFD to
 // be able to find line number information. Example:
@@ -189,9 +189,9 @@ void get_local_address(StacktraceItem &item)
 
 
 /* Demangles the function name if needed (if the 'name' is coming from C, it
-   doesn't have to be demangled, if it's coming from C++, it needs to be).
+   doesn't have to be demangled, if it's coming from C++, it must be).
 
-   Makes sure that it ends with (), which is automatic in C++, but it has to be
+   Makes sure that it ends with (), which is automatic in C++, but it must be
    added by hand in C.
 */
 std::string demangle_function_name(std::string name)

--- a/src/lpython/parser/parser_stype.h
+++ b/src/lpython/parser/parser_stype.h
@@ -110,7 +110,7 @@ union YYSTYPE {
 static_assert(std::is_standard_layout<YYSTYPE>::value);
 static_assert(std::is_trivial<YYSTYPE>::value);
 // Ensure the YYSTYPE size is equal to Vec<AST::ast_t*>, which is a required member, so
-// YYSTYPE has to be at least as big, but it should not be bigger, otherwise it
+// YYSTYPE must be at least as big, but it should not be bigger, otherwise it
 // would reduce performance.
 static_assert(sizeof(YYSTYPE) == sizeof(Vec<LPython::AST::ast_t*>));
 

--- a/src/tests/doctest.h
+++ b/src/tests/doctest.h
@@ -1880,7 +1880,7 @@ struct QueryData
 
 struct DOCTEST_INTERFACE IReporter
 {
-    // The constructor has to accept "const ContextOptions&" as a single argument
+    // The constructor must accept "const ContextOptions&" as a single argument
     // which has most of the options for the run + a pointer to the stdout stream
     // Reporter(const ContextOptions& in)
 


### PR DESCRIPTION
refereing to issue [#1493](url) 

I replaced all "has to" and "needs to" with "must" for better formal English in the docs. 