### PR TITLE
WASM: Initial support for BlockCall

### DIFF
--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -1085,13 +1085,13 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         for (size_t i = 0; i < x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
         }
+
         if (strcmp(x.m_name, "_start") == 0) {
             wasm::emit_i32_const(m_code_section, m_al, 0 /* zero exit code */);
             wasm::emit_call(m_code_section, m_al, m_import_func_idx_map[proc_exit]);
         }
-        if ((x.n_body == 0) ||
-            ((x.n_body > 0) &&
-             !ASR::is_a<ASR::Return_t>(*x.m_body[x.n_body - 1]))) {
+
+        if (x.n_body == 0 || !ASR::is_a<ASR::Return_t>(*x.m_body[x.n_body - 1])) {
             handle_return();
         }
         wasm::emit_expr_end(m_code_section, m_al);

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -102,7 +102,6 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     uint32_t cur_loop_nesting_level;
     bool is_prototype_only;
     bool is_local_vars_only;
-    bool is_initialize_vars_only;
     ASR::Function_t* main_func;
 
     Vec<uint8_t> m_type_section;
@@ -141,7 +140,6 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         : m_al(al), diag(diagnostics) {
         is_prototype_only = false;
         is_local_vars_only = false;
-        is_initialize_vars_only = false;
         main_func = nullptr;
         nesting_level = 0;
         cur_loop_nesting_level = 0;
@@ -1075,12 +1073,7 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
             is_local_vars_only = false;
         }
 
-        {
-            is_initialize_vars_only = true;
-            initialize_local_vars(x.m_symtab);
-            visit_BlockStatements(x);
-            is_initialize_vars_only = false;
-        }
+        initialize_local_vars(x.m_symtab);
 
         for (size_t i = 0; i < x.n_body; i++) {
             this->visit_stmt(*x.m_body[i]);
@@ -1155,10 +1148,8 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
         if (is_local_vars_only) {
             emit_local_vars(block->m_symtab);
             visit_BlockStatements(*block);
-        } else if (is_initialize_vars_only) {
-            initialize_local_vars(block->m_symtab);
-            visit_BlockStatements(*block);
         } else {
+            initialize_local_vars(block->m_symtab);
             for (size_t i = 0; i < block->n_body; i++) {
                 this->visit_stmt(*block->m_body[i]);
             }


### PR DESCRIPTION
This PR implements initial support for `visit_BlockCall` in the `wasm` backend.
- Varaibles and statements inside a block are supported (their support is yet to be verfied by adding a test case)
    - For variables declared inside the block scope, we are declaring them as local variables of the function (thus they are now available throughout the whole function scope).
- GoTo and GoToTarget are not yet supported