### PR TITLE
WASM_X64: Support for globals

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -346,7 +346,7 @@ RUN(NAME bindc_06   LABELS llvm c
         EXTRAFILES bindc_06b.c)
 RUN(NAME test_generics_01    LABELS cpython llvm c)
 RUN(NAME test_cmath          LABELS cpython llvm c)
-RUN(NAME test_complex_01        LABELS cpython llvm c wasm)
+RUN(NAME test_complex_01        LABELS cpython llvm c wasm wasm_x64)
 RUN(NAME test_complex_02        LABELS cpython llvm c)
 RUN(NAME test_max_min        LABELS cpython llvm c)
 RUN(NAME test_global         LABELS cpython llvm c)

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -214,10 +214,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         int no_of_params = (int)cur_func_param_type.param_types.size();
         if ((int)localidx < no_of_params) {
             std::string var_type = var_type_to_string[cur_func_param_type.param_types[localidx]];
-            if (var_type == "i32") {
-                m_a.asm_mov_r64_m64(X64Reg::rax, &base, nullptr, 1, 8 * (2 + no_of_params - (int)localidx - 1));
-                m_a.asm_push_r64(X64Reg::rax);
-            } else if (var_type == "i64") {
+            if (var_type == "i32" || var_type == "i64") {
                 m_a.asm_mov_r64_m64(X64Reg::rax, &base, nullptr, 1, 8 * (2 + no_of_params - (int)localidx - 1));
                 m_a.asm_push_r64(X64Reg::rax);
             } else if (var_type == "f64") {
@@ -231,10 +228,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         } else {
             localidx -= no_of_params;
             std::string var_type = var_type_to_string[codes[cur_func_idx].locals[localidx].type];
-            if (var_type == "i32") {
-                m_a.asm_mov_r64_m64(X64Reg::rax, &base, nullptr, 1, -8 * (1 + (int)localidx));
-                m_a.asm_push_r64(X64Reg::rax);
-            } else if (var_type == "i64") {
+            if (var_type == "i32" || var_type == "i64") {
                 m_a.asm_mov_r64_m64(X64Reg::rax, &base, nullptr, 1, -8 * (1 + (int)localidx));
                 m_a.asm_push_r64(X64Reg::rax);
             } else if (var_type == "f64") {
@@ -254,10 +248,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         int no_of_params = (int)cur_func_param_type.param_types.size();
         if ((int)localidx < no_of_params) {
             std::string var_type = var_type_to_string[cur_func_param_type.param_types[localidx]];
-            if (var_type == "i32") {
-                m_a.asm_pop_r64(X64Reg::rax);
-                m_a.asm_mov_m64_r64(&base, nullptr, 1, 8 * (2 + no_of_params - (int)localidx - 1), X64Reg::rax);
-            } else if (var_type == "i64") {
+            if (var_type == "i32" || var_type == "i64") {
                 m_a.asm_pop_r64(X64Reg::rax);
                 m_a.asm_mov_m64_r64(&base, nullptr, 1, 8 * (2 + no_of_params - (int)localidx - 1), X64Reg::rax);
             } else if (var_type == "f64") {
@@ -271,10 +262,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         } else {
             localidx -= no_of_params;
             std::string var_type = var_type_to_string[codes[cur_func_idx].locals[localidx].type];
-            if (var_type == "i32") {
-                m_a.asm_pop_r64(X64Reg::rax);
-                m_a.asm_mov_m64_r64(&base, nullptr, 1, -8 * (1 + (int)localidx), X64Reg::rax);
-            } else if (var_type == "i64") {
+            if (var_type == "i32" || var_type == "i64") {
                 m_a.asm_pop_r64(X64Reg::rax);
                 m_a.asm_mov_m64_r64(&base, nullptr, 1, -8 * (1 + (int)localidx), X64Reg::rax);
             } else if (var_type == "f64") {
@@ -288,93 +276,28 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         }
     }
 
-    void visit_I32Const(int32_t value) {
-        m_a.asm_mov_r64_imm64(X64Reg::rax, labs((int64_t)value));
-        if (value < 0) m_a.asm_neg_r64(X64Reg::rax);
-        m_a.asm_push_r64(X64Reg::rax);
-    }
+    void visit_I32Const(int32_t value) { visit_I64Const(int64_t(value)); }
 
-    template<typename F>
-    void handleI32Opt(F && f) {
-        m_a.asm_pop_r64(X64Reg::rbx);
-        m_a.asm_pop_r64(X64Reg::rax);
-        f();
-        m_a.asm_push_r64(X64Reg::rax);
-    }
+    void visit_I32Add() { visit_I64Add(); }
+    void visit_I32Sub() { visit_I64Sub(); }
+    void visit_I32Mul() { visit_I64Mul(); }
+    void visit_I32DivS() { visit_I64DivS(); }
 
-    void visit_I32Add() {
-        handleI32Opt([&](){ m_a.asm_add_r64_r64(X64Reg::rax, X64Reg::rbx);});
-    }
-    void visit_I32Sub() {
-        handleI32Opt([&](){ m_a.asm_sub_r64_r64(X64Reg::rax, X64Reg::rbx);});
-    }
-    void visit_I32Mul() {
-        handleI32Opt([&](){ m_a.asm_mul_r64(X64Reg::rbx);});
-    }
-    void visit_I32DivS() {
-        handleI32Opt([&](){
-            m_a.asm_mov_r64_imm64(X64Reg::rdx, 0);
-            m_a.asm_div_r64(X64Reg::rbx);
-        });
-    }
+    void visit_I32And() { visit_I64And(); }
+    void visit_I32Or() { visit_I64Or(); }
+    void visit_I32Xor() { visit_I64Xor(); }
+    void visit_I32Shl() { visit_I64Shl(); }
+    void visit_I32ShrS() { visit_I64ShrS(); }
 
-    void visit_I32And() {
-        handleI32Opt([&](){ m_a.asm_and_r64_r64(X64Reg::rax, X64Reg::rbx);});
-    }
+    void visit_I32Eqz() { visit_I64Eqz(); }
+    void visit_I32Eq() { visit_I64Eq(); }
+    void visit_I32GtS() { visit_I64GtS(); }
+    void visit_I32GeS() { visit_I64GeS(); }
+    void visit_I32LtS() { visit_I64LtS(); }
+    void visit_I32LeS() { visit_I64LeS(); }
+    void visit_I32Ne() { visit_I64Ne(); }
 
-    void visit_I32Or() {
-        handleI32Opt([&](){ m_a.asm_or_r64_r64(X64Reg::rax, X64Reg::rbx);});
-    }
-
-    void visit_I32Xor() {
-        handleI32Opt([&](){ m_a.asm_xor_r64_r64(X64Reg::rax, X64Reg::rbx);});
-    }
-
-    void visit_I32Shl() {
-        m_a.asm_pop_r64(X64Reg::rcx);
-        m_a.asm_pop_r64(X64Reg::rax);
-        m_a.asm_shl_r64_cl(X64Reg::rax);
-        m_a.asm_push_r64(X64Reg::rax);
-    }
-    void visit_I32ShrS() {
-        m_a.asm_pop_r64(X64Reg::rcx);
-        m_a.asm_pop_r64(X64Reg::rax);
-        m_a.asm_sar_r64_cl(X64Reg::rax);
-        m_a.asm_push_r64(X64Reg::rax);
-     }
-
-    void visit_I32Eqz() {
-        m_a.asm_mov_r64_imm64(X64Reg::rax, 0);
-        m_a.asm_push_r64(X64Reg::rax);
-        handle_I32Compare<&X86Assembler::asm_je_label>();
-    }
-
-    using JumpFn = void(X86Assembler::*)(const std::string&);
-    template<JumpFn T>
-    void handle_I32Compare() {
-        std::string label = std::to_string(offset);
-        m_a.asm_pop_r64(X64Reg::rbx);
-        m_a.asm_pop_r64(X64Reg::rax);
-        // `rax` and `rbx` contain the left and right operands, respectively
-        m_a.asm_cmp_r64_r64(X64Reg::rax, X64Reg::rbx);
-
-        (m_a.*T)(".compare_1" + label);
-
-        // if the `compare` condition in `true`, jump to compare_1
-        // and assign `1` else assign `0`
-        m_a.asm_push_imm8(0);
-        m_a.asm_jmp_label(".compare.end_" + label);
-        m_a.add_label(".compare_1" + label);
-        m_a.asm_push_imm8(1);
-        m_a.add_label(".compare.end_" + label);
-    }
-
-    void visit_I32Eq() { handle_I32Compare<&X86Assembler::asm_je_label>(); }
-    void visit_I32GtS() { handle_I32Compare<&X86Assembler::asm_jg_label>(); }
-    void visit_I32GeS() { handle_I32Compare<&X86Assembler::asm_jge_label>(); }
-    void visit_I32LtS() { handle_I32Compare<&X86Assembler::asm_jl_label>(); }
-    void visit_I32LeS() { handle_I32Compare<&X86Assembler::asm_jle_label>(); }
-    void visit_I32Ne() { handle_I32Compare<&X86Assembler::asm_jne_label>(); }
+    void visit_I32WrapI64() { } // empty, since i32's and i64's are considered similar currently.
 
     void visit_I64Const(int64_t value) {
         m_a.asm_mov_r64_imm64(X64Reg::rax, labs((int64_t)value));
@@ -425,10 +348,6 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         m_a.asm_push_r64(X64Reg::rdx);
     }
 
-    void visit_I32WrapI64() {
-        // empty, since i32's and i64's are considered similar currently.
-    }
-
     void visit_I64Store(uint32_t /*mem_align*/, uint32_t /*mem_offset*/) {
         m_a.asm_pop_r64(X64Reg::rbx);
         m_a.asm_pop_r64(X64Reg::rax);
@@ -456,6 +375,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         handle_I64Compare<&X86Assembler::asm_je_label>();
     }
 
+    using JumpFn = void(X86Assembler::*)(const std::string&);
     template<JumpFn T>
     void handle_I64Compare() {
         std::string label = std::to_string(offset);
@@ -490,9 +410,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         m_a.asm_push_r64(X64Reg::rax);
     }
 
-    void visit_I64ExtendI32S() {
-        // empty, since all i32's are already considered as i64's currently.
-    }
+    void visit_I64ExtendI32S() { } // empty, since all i32's are already considered as i64's currently.
 
     std::string float_to_str(double z) {
         std::string float_str = "";

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -217,7 +217,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
             if (var_type == "i32" || var_type == "i64") {
                 m_a.asm_mov_r64_m64(X64Reg::rax, &base, nullptr, 1, 8 * (2 + no_of_params - (int)localidx - 1));
                 m_a.asm_push_r64(X64Reg::rax);
-            } else if (var_type == "f64") {
+            } else if (var_type == "f32" || var_type == "f64") {
                 m_a.asm_sub_r64_imm32(X64Reg::rsp,  8); // create space for value to be fetched
                 m_a.asm_movsd_r64_m64(X64FReg::xmm0, &base, nullptr, 1, 8 * (2 + no_of_params - (int)localidx - 1));
                 X64Reg stack_top = X64Reg::rsp;
@@ -231,7 +231,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
             if (var_type == "i32" || var_type == "i64") {
                 m_a.asm_mov_r64_m64(X64Reg::rax, &base, nullptr, 1, -8 * (1 + (int)localidx));
                 m_a.asm_push_r64(X64Reg::rax);
-            } else if (var_type == "f64") {
+            } else if (var_type == "f32" || var_type == "f64") {
                 m_a.asm_sub_r64_imm32(X64Reg::rsp,  8); // create space for value to be fetched
                 m_a.asm_movsd_r64_m64(X64FReg::xmm0, &base, nullptr, 1, -8 * (1 + (int)localidx));
                 X64Reg stack_top = X64Reg::rsp;
@@ -251,7 +251,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
             if (var_type == "i32" || var_type == "i64") {
                 m_a.asm_pop_r64(X64Reg::rax);
                 m_a.asm_mov_m64_r64(&base, nullptr, 1, 8 * (2 + no_of_params - (int)localidx - 1), X64Reg::rax);
-            } else if (var_type == "f64") {
+            } else if (var_type == "f32" || var_type == "f64") {
                 X64Reg stack_top = X64Reg::rsp;
                 m_a.asm_movsd_r64_m64(X64FReg::xmm0, &stack_top, nullptr, 1, 0);
                 m_a.asm_movsd_m64_r64(&base, nullptr, 1, 8 * (2 + no_of_params - (int)localidx - 1), X64FReg::xmm0);
@@ -265,7 +265,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
             if (var_type == "i32" || var_type == "i64") {
                 m_a.asm_pop_r64(X64Reg::rax);
                 m_a.asm_mov_m64_r64(&base, nullptr, 1, -8 * (1 + (int)localidx), X64Reg::rax);
-            } else if (var_type == "f64") {
+            } else if (var_type == "f32" || var_type == "f64") {
                 X64Reg stack_top = X64Reg::rsp;
                 m_a.asm_movsd_r64_m64(X64FReg::xmm0, &stack_top, nullptr, 1, 0);
                 m_a.asm_movsd_m64_r64(&base, nullptr, 1, -8 * (1 + (int)localidx), X64FReg::xmm0);
@@ -492,6 +492,22 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
         X64Reg stack_top = X64Reg::rsp;
         m_a.asm_movsd_m64_r64(&stack_top, nullptr, 1, 0, X64FReg::xmm0); // store float on integer stack top;
     }
+
+    void visit_F32Const(float z) { visit_F64Const(double(z)); }
+
+    void visit_F32Add() { visit_F64Add(); }
+    void visit_F32Sub() { visit_F64Sub(); }
+    void visit_F32Mul() { visit_F64Mul(); }
+    void visit_F32Div() { visit_F64Div(); }
+
+    void visit_F32Eq() { visit_F64Eq(); }
+    void visit_F32Gt() { visit_F64Gt(); }
+    void visit_F32Ge() { visit_F64Ge(); }
+    void visit_F32Lt() { visit_F64Lt(); }
+    void visit_F32Le() { visit_F64Le(); }
+    void visit_F32Ne() { visit_F64Ne(); }
+
+    void visit_F32ConvertI64S() { visit_F64ConvertI32S(); }
 
     void gen_x64_bytes() {
         emit_elf64_header(m_a);

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -60,9 +60,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
     }
 
     void visit_Unreachable() {}
-
     void visit_EmtpyBlockType() {}
-
     void visit_Drop() { m_a.asm_pop_r64(X64Reg::rax); }
 
     void call_imported_function(uint32_t func_idx) {
@@ -378,7 +376,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
     void visit_I32LeS() { handle_I32Compare<&X86Assembler::asm_jle_label>(); }
     void visit_I32Ne() { handle_I32Compare<&X86Assembler::asm_jne_label>(); }
 
-    void visit_I64Const(int32_t value) {
+    void visit_I64Const(int64_t value) {
         m_a.asm_mov_r64_imm64(X64Reg::rax, labs((int64_t)value));
         if (value < 0) m_a.asm_neg_r64(X64Reg::rax);
         m_a.asm_push_r64(X64Reg::rax);

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -456,9 +456,13 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
 
     std::string float_to_str(double z) {
         std::string float_str = "";
-        for (auto ch:std::to_string(z)) {
+        std::ostringstream strs;
+        strs << z;
+        for (auto ch:strs.str()) {
             if (ch == '-') {
                 float_str += "neg_";
+            } else if (ch == '+') {
+                float_str += "_plus_";
             } else if (ch == '.') {
                 float_str += "_dot_";
             } else {

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -552,7 +552,7 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
     void visit_F32ConvertI64S() { visit_F64ConvertI32S(); }
 
     void gen_x64_bytes() {
-        emit_elf64_header(m_a);
+        emit_elf64_header(m_a, 7U);
 
         // declare compile-time strings
         std::string base_memory = "    "; /* in wasm backend, memory starts after 4 bytes*/

--- a/src/libasr/codegen/x86_assembler.cpp
+++ b/src/libasr/codegen/x86_assembler.cpp
@@ -109,6 +109,22 @@ void emit_data_string(X86Assembler &a, const std::string &label,
     a.asm_db_imm8(s.c_str(), s.size());
 }
 
+void emit_i32_const(X86Assembler &a, const std::string &label,
+    const int32_t z) {
+    uint8_t encoded_i32[sizeof(z)];
+    std::memcpy(&encoded_i32, &z, sizeof(z));
+    a.add_label(label);
+    a.asm_db_imm8(encoded_i32, sizeof(z));
+}
+
+void emit_i64_const(X86Assembler &a, const std::string &label,
+    const int64_t z) {
+    uint8_t encoded_i64[sizeof(z)];
+    std::memcpy(&encoded_i64, &z, sizeof(z));
+    a.add_label(label);
+    a.asm_db_imm8(encoded_i64, sizeof(z));
+}
+
 void emit_float_const(X86Assembler &a, const std::string &label,
     const float z) {
     uint8_t encoded_float[sizeof(z)];

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1512,6 +1512,10 @@ void emit_exit2(X86Assembler &a, const std::string &name);
 
 void emit_data_string(X86Assembler &a, const std::string &label,
     const std::string &s);
+void emit_i32_const(X86Assembler &a, const std::string &label,
+    const int32_t z);
+void emit_i64_const(X86Assembler &a, const std::string &label,
+    const int64_t z);
 void emit_float_const(X86Assembler &a, const std::string &label,
     const float z);
 void emit_double_const(X86Assembler &a, const std::string &label,

--- a/src/libasr/codegen/x86_assembler.h
+++ b/src/libasr/codegen/x86_assembler.h
@@ -1491,6 +1491,17 @@ public:
         modrm_sib_disp(m_code, m_al, r32, &s32, nullptr, 1, 0, false);
         EMIT("comisd " + r2s(r64) + ", " + r2s(s64));
     }
+
+    // SQRTSD—Compute Square Root of Scalar Double Precision Floating-Point Value
+    void asm_sqrtsd_r64_r64(X64FReg r64, X64FReg s64) {
+        X86Reg r32 = X86Reg(r64 & 7), s32 = X86Reg(s64 & 7);
+        m_code.push_back(m_al, rex(1, r64 >> 3, 0, s64 >> 3));
+        m_code.push_back(m_al, 0xf2);
+        m_code.push_back(m_al, 0x0f);
+        m_code.push_back(m_al, 0x51);
+        modrm_sib_disp(m_code, m_al, r32, &s32, nullptr, 1, 0, false);
+        EMIT("sqrtsd " + r2s(r64) + ", " + r2s(s64));
+    }
 };
 
 


### PR DESCRIPTION
This PR implements support for global variables in the `wasm_x64` backend.