### PR TITLE
Treating Integer and Real types as immutable

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1145,7 +1145,7 @@ static inline std::string binop_to_str_python(const ASR::binopType t) {
 
 static inline bool is_immutable(const ASR::ttype_t *type) {
     return ((ASR::is_a<ASR::Character_t>(*type) || ASR::is_a<ASR::Tuple_t>(*type)
-        || ASR::is_a<ASR::Complex_t>(*type)));
+        || ASR::is_a<ASR::Complex_t>(*type)) || ASR::is_a<ASR::Integer_t>(*type) || ASR::is_a<ASR::Real_t>(*type));
 }
 
 // Returns a list of values

--- a/tests/errors/test_assign10.py
+++ b/tests/errors/test_assign10.py
@@ -1,0 +1,8 @@
+from ltypes import f64
+
+def f():
+    i: f64
+    i = 3.14
+    i[0] = 3.1415926359
+
+f()

--- a/tests/errors/test_assign9.py
+++ b/tests/errors/test_assign9.py
@@ -1,0 +1,8 @@
+from ltypes import i32
+
+def f():
+    i: i32
+    i = 100
+    i[0] = 500
+
+f()

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -753,6 +753,14 @@ filename = "errors/test_assign8.py"
 asr = true
 
 [[test]]
+filename = "errors/test_assign9.py"
+asr = true
+
+[[test]]
+filename = "errors/test_assign10.py"
+asr = true
+
+[[test]]
 filename = "errors/test_binop1.py"
 asr = true
 


### PR DESCRIPTION
The concept of immutable has a deeper meaning than being a variable that is easy to modify. You can checkout this post of reference. - https://stackoverflow.com/questions/62177372/is-integer-immutable-or-mutable

```
def f():
    i: f64
    i = 3.14
    print(i)
    i = 3.1415926359
    print(i)

f()

(lp) C:\Users\kunni\lpython>python try.py
3.14
3.1415926359

(lp) C:\Users\kunni\lpython>src\bin\lpython try.py
3.14000000000000012e+00
3.14159263589999993e+00
```
But assignment is not correct in python -
Such an error is not given on master
```

def f():
    i: f64
    i = 3.14
    i[0] = 3.1415926359
    print(i)

f()
(lp) C:\Users\kunni\lpython>python try.py
Traceback (most recent call last):
  File "C:\Users\kunni\lpython\try.py", line 14, in <module>
    f()
  File "C:\Users\kunni\lpython\try.py", line 11, in f
    i[0] = 3.1415926359
TypeError: 'float' object does not support item assignment

(lp) C:\Users\kunni\lpython>src\bin\lpython try.py
semantic error: 'f64' object does not support item assignment
  --> try.py:11:5
   |
11 |     i[0] = 3.1415926359
   |     ^^^^^^^^^^^^^^^^^^^


Note: if any of the above error or warning messages are not clear or are lacking
context please report it to us (we consider that a bug that must be fixed).

```