### PR TITLE
math.exp2 function implemented

### DIFF
--- a/integration_tests/test_math.py
+++ b/integration_tests/test_math.py
@@ -1,4 +1,4 @@
-from math import (factorial, isqrt, perm, comb, degrees, radians, exp, pow,
+from math import (factorial, isqrt, perm, comb, degrees, radians, exp, exp2, pow,
                   ldexp, fabs, gcd, lcm, floor, ceil, remainder, expm1, fmod, log1p, trunc,
                   modf, fsum, prod, dist)
 import math
@@ -59,6 +59,11 @@ def test_exp():
     i: f64
     i = exp(2.34)
     assert abs(i - 10.381236562731843) < eps
+
+def test_exp2():
+    i: f64
+    i = exp2(2.34)
+    assert abs(i - 5.06302637588112) < eps
 
 
 def test_pow():
@@ -262,6 +267,7 @@ def check():
     test_degrees()
     test_radians()
     test_exp()
+    test_exp2()
     test_pow()
     test_fabs()
     test_ldexp()

--- a/src/runtime/math.py
+++ b/src/runtime/math.py
@@ -466,6 +466,13 @@ def exp(x: f64) -> f64:
     return e**x
 
 
+def exp2(x: f64) -> f64:
+    """
+    Return 2 raised to the power `x`.
+    """
+    return 2**x
+
+
 def mod(a: i32, b: i32) -> i32:
     """
     Returns a%b


### PR DESCRIPTION
# Adding math.exp2

## Description
`exp2` is one of the power and logarithmic functions that are new in version 3.11.
The function simply returns 2 raised to the power x.


Related to #200

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Added an integration test in `test_math.py`

**Test Configuration**:
* Firmware version: Ubuntu 20.04.5 LTS
