### PR TITLE
Set ``current_scope`` before ``replace_expr`` call

### DIFF
--- a/src/libasr/pass/arr_slice.cpp
+++ b/src/libasr/pass/arr_slice.cpp
@@ -183,8 +183,8 @@ class ArraySectionVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArraySe
 
         void call_replacer() {
             replacer.current_expr = current_expr;
-            replacer.replace_expr(*current_expr);
             replacer.current_scope = current_scope;
+            replacer.replace_expr(*current_expr);
         }
 
         void transform_stmts(ASR::stmt_t **&m_body, size_t &n_body) {

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -722,8 +722,8 @@ class ArrayOpVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisit
 
         void call_replacer() {
             replacer.current_expr = current_expr;
-            replacer.replace_expr(*current_expr);
             replacer.current_scope = current_scope;
+            replacer.replace_expr(*current_expr);
         }
 
         void transform_stmts(ASR::stmt_t **&m_body, size_t &n_body) {


### PR DESCRIPTION
Taken from https://github.com/lfortran/lfortran/pull/1383