### PR TITLE
Fix _mod function to fix the % operator results

### DIFF
--- a/src/lpython/semantics/python_comptime_eval.h
+++ b/src/lpython/semantics/python_comptime_eval.h
@@ -211,7 +211,7 @@ struct PythonIntrinsicProcedures {
             int64_t a = ASR::down_cast<ASR::IntegerConstant_t>(arg1)->m_n;
             int64_t b = ASR::down_cast<ASR::IntegerConstant_t>(arg2)->m_n;
             return ASR::down_cast<ASR::expr_t>(
-                ASR::make_IntegerConstant_t(al, loc, a%b, type));
+                ASR::make_IntegerConstant_t(al, loc, ((a%b)+b)%b, type));
         } else if (ASRUtils::is_real(*type)) {
             double a = ASR::down_cast<ASR::RealConstant_t>(arg1)->m_r;
             double b = ASR::down_cast<ASR::RealConstant_t>(arg2)->m_r;

--- a/src/runtime/lpython_builtin.py
+++ b/src/runtime/lpython_builtin.py
@@ -470,19 +470,32 @@ def _lpython_floordiv(a: bool, b: bool) -> bool:
 
 @overload
 def _mod(a: i32, b: i32) -> i32:
-    return a - _lpython_floordiv(a, b)*b
+    """
+    Returns a%b
+    """
+    return a - i32(_floor(a/b))*b
 
 @overload
 def _mod(a: f32, b: f32) -> f32:
-    return a - _lpython_floordiv(a, b)*b
+    """
+    Returns a%b
+    """
+    return a - f32(_floor(a/b))*b
 
 @overload
 def _mod(a: i64, b: i64) -> i64:
-    return a - _lpython_floordiv(a, b)*b
+    """
+    Returns a%b
+    """
+    print("its i64 mod")
+    return a - i64(_floor(a/b))*b 
 
 @overload
 def _mod(a: f64, b: f64) -> f64:
-    return a - _lpython_floordiv(a, b)*b
+    """
+    Returns a%b
+    """
+    return a - f64(_floor(a/b))*b  
 
 
 @overload
@@ -549,6 +562,13 @@ def min(a: f64, b: f64) -> f64:
     else:
         return b
 
+@overload
+def _floor(x: i32) -> i32:
+    return x
+
+@overload
+def _floor(x: i64) -> i64:
+    return x
 
 @overload
 def _floor(x: f64) -> i64:

--- a/src/runtime/lpython_builtin.py
+++ b/src/runtime/lpython_builtin.py
@@ -484,7 +484,9 @@ def _mod(a: f32, b: f32) -> f32:
 
 @overload
 def _mod(a: i64, b: i64) -> i64:
-    print("its i64 mod")
+    """
+    Returns a%b
+    """
     return a - i64(_floor(a/b))*b 
 
 @overload
@@ -597,9 +599,7 @@ def _mod(a: i64, b: i64) -> i64:
     """
     Returns a%b
     """
-    r: i64
-    r = _floor(a/b)
-    return a - r*b
+    return a - i64(_floor(a/b))*b
 
 
 @overload

--- a/src/runtime/lpython_builtin.py
+++ b/src/runtime/lpython_builtin.py
@@ -484,9 +484,6 @@ def _mod(a: f32, b: f32) -> f32:
 
 @overload
 def _mod(a: i64, b: i64) -> i64:
-    """
-    Returns a%b
-    """
     print("its i64 mod")
     return a - i64(_floor(a/b))*b 
 


### PR DESCRIPTION
Closing [1562](https://github.com/lcompilers/lpython/issues/1562)

**Task List:**

- Replaced the `_lpython_floordiv` function in all the `_mod` function with `_floor` function I created based on the `math.floor` function. 

On Branch: 
```
def f():
    print((8)%3)
    print((8)%(3))
    print(-(8)%3)       
    print((8)%-3)          
    print(-(8)%-3)
    print((-8)%3)          
    print(-8%3)            
    
f()

(base) seif@seif:~/Documents/GSoC/lpython$ ./src/bin/lpython examples/try.py
2
2
1
-1
-2
1
1

```