### PR TITLE
Added cbrt() and exp2() functions in Math module

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -125,28 +125,6 @@ macro(RUN)
             if (${RUN_FAIL})
                 set_tests_properties(${name} PROPERTIES WILL_FAIL TRUE)
             endif()
-
-        elseif(KIND STREQUAL "cpython_3_11")
-            # We need this support for New Python 3.11 functions 
-            # CPython test
-            if (RUN_EXTRAFILES)
-                set(PY_MOD "${name}_mod")
-                add_library(${PY_MOD} SHARED ${RUN_EXTRAFILES})
-                set_target_properties(${PY_MOD} PROPERTIES LINKER_LANGUAGE C)
-            else()
-                set(PY_MOD "")
-            endif()
-
-            add_test(${name} python3.11 ${CMAKE_CURRENT_SOURCE_DIR}/${name}.py)
-            set_tests_properties(${name} PROPERTIES
-                ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/../src/runtime/ltypes:${CMAKE_SOURCE_DIR}/..;LPYTHON_PY_MOD_NAME=${PY_MOD};LPYTHON_PY_MOD_PATH=${CMAKE_CURRENT_BINARY_DIR}")
-            if (RUN_LABELS)
-                set_tests_properties(${name} PROPERTIES LABELS "${RUN_LABELS}")
-            endif()
-            if (${RUN_FAIL})
-                set_tests_properties(${name} PROPERTIES WILL_FAIL TRUE)
-            endif()
-
         elseif(KIND STREQUAL "x86")
             # x86 test
             add_custom_command(
@@ -317,7 +295,7 @@ RUN(NAME test_import_02      LABELS cpython llvm c)
 RUN(NAME test_import_03      LABELS cpython llvm c)
 RUN(NAME test_import_04      IMPORT_PATH ..
         LABELS cpython llvm c)
-RUN(NAME test_math           LABELS cpython_3_11 llvm)
+RUN(NAME test_math           LABELS cpython llvm)
 RUN(NAME test_numpy_01       LABELS cpython llvm c)
 RUN(NAME test_numpy_02       LABELS cpython llvm c)
 RUN(NAME test_numpy_03       LABELS cpython llvm c)
@@ -352,7 +330,8 @@ RUN(NAME test_builtin_round  LABELS cpython llvm c)
 RUN(NAME test_builtin_divmod LABELS cpython llvm c)
 RUN(NAME test_builtin_sum    LABELS cpython llvm c)
 RUN(NAME test_math1          LABELS cpython llvm c)
-RUN(NAME test_math_02        LABELS cpython_3_11 llvm)
+RUN(NAME test_math_02        LABELS cpython llvm)
+RUN(NAME test_math_03        LABELS llvm)
 RUN(NAME test_pass_compare   LABELS cpython llvm c)
 RUN(NAME test_c_interop_01   LABELS cpython llvm c)
 RUN(NAME test_c_interop_02   LABELS cpython llvm c

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -331,7 +331,7 @@ RUN(NAME test_builtin_divmod LABELS cpython llvm c)
 RUN(NAME test_builtin_sum    LABELS cpython llvm c)
 RUN(NAME test_math1          LABELS cpython llvm c)
 RUN(NAME test_math_02        LABELS cpython llvm)
-RUN(NAME test_math_03        LABELS llvm)
+RUN(NAME test_math_03        LABELS llvm)               #1595: TODO: Test using CPython (3.11 recommended)
 RUN(NAME test_pass_compare   LABELS cpython llvm c)
 RUN(NAME test_c_interop_01   LABELS cpython llvm c)
 RUN(NAME test_c_interop_02   LABELS cpython llvm c

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -125,6 +125,28 @@ macro(RUN)
             if (${RUN_FAIL})
                 set_tests_properties(${name} PROPERTIES WILL_FAIL TRUE)
             endif()
+
+        elseif(KIND STREQUAL "cpython_3_11")
+            # We need this support for New Python 3.11 functions 
+            # CPython test
+            if (RUN_EXTRAFILES)
+                set(PY_MOD "${name}_mod")
+                add_library(${PY_MOD} SHARED ${RUN_EXTRAFILES})
+                set_target_properties(${PY_MOD} PROPERTIES LINKER_LANGUAGE C)
+            else()
+                set(PY_MOD "")
+            endif()
+
+            add_test(${name} python3.11 ${CMAKE_CURRENT_SOURCE_DIR}/${name}.py)
+            set_tests_properties(${name} PROPERTIES
+                ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/../src/runtime/ltypes:${CMAKE_SOURCE_DIR}/..;LPYTHON_PY_MOD_NAME=${PY_MOD};LPYTHON_PY_MOD_PATH=${CMAKE_CURRENT_BINARY_DIR}")
+            if (RUN_LABELS)
+                set_tests_properties(${name} PROPERTIES LABELS "${RUN_LABELS}")
+            endif()
+            if (${RUN_FAIL})
+                set_tests_properties(${name} PROPERTIES WILL_FAIL TRUE)
+            endif()
+
         elseif(KIND STREQUAL "x86")
             # x86 test
             add_custom_command(
@@ -295,7 +317,7 @@ RUN(NAME test_import_02      LABELS cpython llvm c)
 RUN(NAME test_import_03      LABELS cpython llvm c)
 RUN(NAME test_import_04      IMPORT_PATH ..
         LABELS cpython llvm c)
-RUN(NAME test_math           LABELS cpython llvm)
+RUN(NAME test_math           LABELS cpython_3_11 llvm)
 RUN(NAME test_numpy_01       LABELS cpython llvm c)
 RUN(NAME test_numpy_02       LABELS cpython llvm c)
 RUN(NAME test_numpy_03       LABELS cpython llvm c)
@@ -330,7 +352,7 @@ RUN(NAME test_builtin_round  LABELS cpython llvm c)
 RUN(NAME test_builtin_divmod LABELS cpython llvm c)
 RUN(NAME test_builtin_sum    LABELS cpython llvm c)
 RUN(NAME test_math1          LABELS cpython llvm c)
-RUN(NAME test_math_02        LABELS cpython llvm)
+RUN(NAME test_math_02        LABELS cpython_3_11 llvm)
 RUN(NAME test_pass_compare   LABELS cpython llvm c)
 RUN(NAME test_c_interop_01   LABELS cpython llvm c)
 RUN(NAME test_c_interop_02   LABELS cpython llvm c

--- a/integration_tests/test_math.py
+++ b/integration_tests/test_math.py
@@ -1,6 +1,6 @@
 from math import (factorial, isqrt, perm, comb, degrees, radians, exp, pow,
                   ldexp, fabs, gcd, lcm, floor, ceil, remainder, expm1, fmod, log1p, trunc,
-                  modf, fsum, prod, dist, exp2)
+                  modf, fsum, prod, dist)
 import math
 from ltypes import i32, i64, f32, f64
 
@@ -59,11 +59,6 @@ def test_exp():
     i: f64
     i = exp(2.34)
     assert abs(i - 10.381236562731843) < eps
-
-def test_exp2():
-    i: f64
-    i = exp2(4.3)
-    assert abs(i - 19.698310613518657) < eps
 
 def test_pow():
     eps: f64
@@ -266,7 +261,6 @@ def check():
     test_degrees()
     test_radians()
     test_exp()
-    test_exp2()
     test_pow()
     test_fabs()
     test_ldexp()

--- a/integration_tests/test_math.py
+++ b/integration_tests/test_math.py
@@ -1,6 +1,6 @@
 from math import (factorial, isqrt, perm, comb, degrees, radians, exp, pow,
                   ldexp, fabs, gcd, lcm, floor, ceil, remainder, expm1, fmod, log1p, trunc,
-                  modf, fsum, prod, dist)
+                  modf, fsum, prod, dist, exp2)
 import math
 from ltypes import i32, i64, f32, f64
 
@@ -60,6 +60,10 @@ def test_exp():
     i = exp(2.34)
     assert abs(i - 10.381236562731843) < eps
 
+def test_exp2():
+    i: f64
+    i = exp2(4.3)
+    assert abs(i - 19.698310613518657) < eps
 
 def test_pow():
     eps: f64
@@ -262,6 +266,7 @@ def check():
     test_degrees()
     test_radians()
     test_exp()
+    test_exp2()
     test_pow()
     test_fabs()
     test_ldexp()

--- a/integration_tests/test_math_02.py
+++ b/integration_tests/test_math_02.py
@@ -1,6 +1,6 @@
 from math import (sin, cos, tan, pi, sqrt, log, log10, log2, erf, erfc, gamma,
                   lgamma, asin, acos, atan, atan2, asinh, acosh, atanh,
-                  tanh, sinh, cosh, hypot, copysign)
+                  tanh, sinh, cosh, hypot, copysign, cbrt)
 from ltypes import f64
 
 def test_trig():
@@ -20,6 +20,11 @@ def test_sqrt():
     eps: f64 = 1e-12
     assert abs(sqrt(2.0) - 1.4142135623730951) < eps
     assert abs(sqrt(9.0) - 3.0) < eps
+
+def test_cbrt():
+    eps: f64 = 1e-12
+    assert abs(cbrt(124.0) - 4.986630952238646) < eps
+    assert abs(cbrt(39.0) - 3.3912114430141664) < eps
 
 def test_log():
     eps: f64 = 1e-12
@@ -57,6 +62,7 @@ def test_hypot():
 def check():
     test_trig()
     test_sqrt()
+    test_cbrt()
     test_log()
     test_special()
     test_hyperbolic()

--- a/integration_tests/test_math_02.py
+++ b/integration_tests/test_math_02.py
@@ -1,6 +1,6 @@
 from math import (sin, cos, tan, pi, sqrt, log, log10, log2, erf, erfc, gamma,
                   lgamma, asin, acos, atan, atan2, asinh, acosh, atanh,
-                  tanh, sinh, cosh, hypot, copysign, cbrt)
+                  tanh, sinh, cosh, hypot, copysign)
 from ltypes import f64
 
 def test_trig():
@@ -20,11 +20,6 @@ def test_sqrt():
     eps: f64 = 1e-12
     assert abs(sqrt(2.0) - 1.4142135623730951) < eps
     assert abs(sqrt(9.0) - 3.0) < eps
-
-def test_cbrt():
-    eps: f64 = 1e-12
-    assert abs(cbrt(124.0) - 4.986630952238646) < eps
-    assert abs(cbrt(39.0) - 3.3912114430141664) < eps
 
 def test_log():
     eps: f64 = 1e-12
@@ -62,7 +57,6 @@ def test_hypot():
 def check():
     test_trig()
     test_sqrt()
-    test_cbrt()
     test_log()
     test_special()
     test_hyperbolic()

--- a/integration_tests/test_math_03.py
+++ b/integration_tests/test_math_03.py
@@ -1,0 +1,21 @@
+from math import (cbrt, exp2)
+from ltypes import f64
+
+eps: f64
+eps = 1e-12
+
+def test_exp2():
+    i: f64
+    i = exp2(4.3)
+    assert abs(i - 19.698310613518657) < eps
+
+def test_cbrt():
+    eps: f64 = 1e-12
+    assert abs(cbrt(124.0) - 4.986630952238646) < eps
+    assert abs(cbrt(39.0) - 3.3912114430141664) < eps
+
+def check():
+    test_cbrt()
+    test_exp2()
+
+check()

--- a/src/runtime/math.py
+++ b/src/runtime/math.py
@@ -469,7 +469,7 @@ def exp2(x: f64) -> f64:
     """
     Return `2` raised to the power `x`.
     """
-    return 2**x
+    return f64((2.0)**x)
 
 
 def mod(a: i32, b: i32) -> i32:

--- a/src/runtime/math.py
+++ b/src/runtime/math.py
@@ -465,6 +465,12 @@ def exp(x: f64) -> f64:
     """
     return e**x
 
+def exp2(x: f64) -> f64:
+    """
+    Return `2` raised to the power `x`.
+    """
+    return 2**x
+
 
 def mod(a: i32, b: i32) -> i32:
     """
@@ -540,7 +546,16 @@ def trunc(x: f32) -> i32:
         return ceil(x)
 
 def sqrt(x: f64) -> f64:
+    """
+    Returns square root of a number x
+    """
     return x**(1/2)
+
+def cbrt(x: f64) -> f64:
+    """
+    Returns cube root of a number x
+    """
+    return x**(1/3)
 
 @ccall
 def _lfortran_dsin(x: f64) -> f64:


### PR DESCRIPTION
Math Module enhancement:

- Added `cbrt()` or `cube root` function associated with Math module of LPython and it's associated integration tests
- Added `exp2()` or `exponential of 2` function associated with Math module of LPython and it's associated integration tests