### PR TITLE
WASM: give an error message if sections are in wrong order

### DIFF
--- a/src/libasr/codegen/wasm_decoder.h
+++ b/src/libasr/codegen/wasm_decoder.h
@@ -361,35 +361,27 @@ class WASMDecoder {
             switch (section_id) {
                 case 1U:
                     decode_type_section(index);
-                    // exit(0);
                     break;
                 case 2U:
                     decode_imports_section(index);
-                    // exit(0);
                     break;
                 case 3U:
                     decode_function_section(index);
-                    // exit(0);
                     break;
                 case 5U:
                     decode_memory_section(index);
-                    // exit(0);
                     break;
                 case 6U:
                     decode_global_section(index);
-                    // exit(0);
                     break;
                 case 7U:
                     decode_export_section(index);
-                    // exit(0);
                     break;
                 case 10U:
                     decode_code_section(index);
-                    // exit(0)
                     break;
                 case 11U:
                     decode_data_section(index);
-                    // exit(0)
                     break;
                 default:
                     std::cout << "Unknown section id: " << section_id

--- a/src/libasr/codegen/wasm_decoder.h
+++ b/src/libasr/codegen/wasm_decoder.h
@@ -349,9 +349,15 @@ class WASMDecoder {
                 "Expected: 0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00");
         }
         index += PREAMBLE_SIZE;
+        uint32_t expected_min_section_id = 1;
         while (index < wasm_bytes.size()) {
             uint32_t section_id = read_u32(wasm_bytes, index);
             uint32_t section_size = read_u32(wasm_bytes, index);
+            if (section_id < expected_min_section_id) {
+                throw CodeGenError("DecodeWASM: Invalid sectionId, expected id >= "
+                    + std::to_string(expected_min_section_id));
+            }
+            expected_min_section_id = section_id + 1;
             switch (section_id) {
                 case 1U:
                     decode_type_section(index);


### PR DESCRIPTION
fixes https://github.com/lcompilers/lpython/issues/1486