### PR TITLE
Improve ``implied_do_loops`` pass and merge ``class_constructor``, ``implied_do_loops`` into ``init_expr`` for replacing ``Variable::m_symbolic_value``

### DIFF
--- a/src/libasr/CMakeLists.txt
+++ b/src/libasr/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SRC
     pass/global_stmts_program.cpp
     pass/global_symbols.cpp
     pass/select_case.cpp
+    pass/init_expr.cpp
     pass/implied_do_loops.cpp
     pass/array_op.cpp
     pass/subroutine_from_function.cpp

--- a/src/libasr/pass/class_constructor.cpp
+++ b/src/libasr/pass/class_constructor.cpp
@@ -8,7 +8,6 @@
 
 #include <vector>
 #include <utility>
-#include <queue>
 
 namespace LCompilers {
 
@@ -17,110 +16,25 @@ using ASR::is_a;
 
 class ReplaceStructTypeConstructor: public ASR::BaseExprReplacer<ReplaceStructTypeConstructor> {
 
-    private:
+    public:
 
     Allocator& al;
     Vec<ASR::stmt_t*>& pass_result;
     bool& remove_original_statement;
-    bool& inside_symtab;
-    std::map<SymbolTable*, Vec<ASR::stmt_t*>>& symtab2decls;
-
-    public:
 
     SymbolTable* current_scope;
     ASR::expr_t* result_var;
 
     ReplaceStructTypeConstructor(Allocator& al_, Vec<ASR::stmt_t*>& pass_result_,
-        bool& remove_original_statement_, bool& inside_symtab_,
-        std::map<SymbolTable*, Vec<ASR::stmt_t*>>& symtab2decls_) :
+        bool& remove_original_statement_) :
     al(al_), pass_result(pass_result_),
     remove_original_statement(remove_original_statement_),
-    inside_symtab(inside_symtab_), symtab2decls(symtab2decls_),
     current_scope(nullptr), result_var(nullptr) {}
 
     void replace_StructTypeConstructor(ASR::StructTypeConstructor_t* x) {
-        if( x->n_args == 0 ) {
-            remove_original_statement = true;
-            return ;
-        }
-        if( result_var == nullptr ) {
-            std::string result_var_name = current_scope->get_unique_name("temp_struct_var__");
-            result_var = PassUtils::create_auxiliary_variable(x->base.base.loc,
-                                result_var_name, al, current_scope, x->m_type);
-            *current_expr = result_var;
-        } else {
-            if( inside_symtab ) {
-                *current_expr = nullptr;
-            } else {
-                remove_original_statement = true;
-            }
-        }
-
-        std::deque<ASR::symbol_t*> constructor_arg_syms;
-        ASR::Struct_t* dt_der = ASR::down_cast<ASR::Struct_t>(x->m_type);
-        ASR::StructType_t* dt_dertype = ASR::down_cast<ASR::StructType_t>(
-                                         ASRUtils::symbol_get_past_external(dt_der->m_derived_type));
-        while( dt_dertype ) {
-            for( int i = (int) dt_dertype->n_members - 1; i >= 0; i-- ) {
-                constructor_arg_syms.push_front(
-                    dt_dertype->m_symtab->get_symbol(
-                        dt_dertype->m_members[i]));
-            }
-            if( dt_dertype->m_parent != nullptr ) {
-                ASR::symbol_t* dt_der_sym = ASRUtils::symbol_get_past_external(
-                                        dt_dertype->m_parent);
-                LCOMPILERS_ASSERT(ASR::is_a<ASR::StructType_t>(*dt_der_sym));
-                dt_dertype = ASR::down_cast<ASR::StructType_t>(dt_der_sym);
-            } else {
-                dt_dertype = nullptr;
-            }
-        }
-        LCOMPILERS_ASSERT(constructor_arg_syms.size() == x->n_args);
-
-        for( size_t i = 0; i < x->n_args; i++ ) {
-            if( x->m_args[i].m_value == nullptr ) {
-                 continue ;
-            }
-            ASR::symbol_t* member = constructor_arg_syms[i];
-            if( ASR::is_a<ASR::StructTypeConstructor_t>(*x->m_args[i].m_value) ) {
-                ASR::expr_t* result_var_copy = result_var;
-                ASR::symbol_t *v = nullptr;
-                if (ASR::is_a<ASR::Var_t>(*result_var_copy)) {
-                    v = ASR::down_cast<ASR::Var_t>(result_var_copy)->m_v;
-                }
-                result_var = ASRUtils::EXPR(ASRUtils::getStructInstanceMember_t(al,
-                                            x->base.base.loc, (ASR::asr_t*) result_var_copy, v,
-                                            member, current_scope));
-                ASR::expr_t** current_expr_copy = current_expr;
-                current_expr = &(x->m_args[i].m_value);
-                replace_expr(x->m_args[i].m_value);
-                current_expr = current_expr_copy;
-                result_var = result_var_copy;
-            } else {
-                Vec<ASR::stmt_t*>* result_vec = nullptr;
-                if( inside_symtab ) {
-                    if( symtab2decls.find(current_scope) == symtab2decls.end() ) {
-                        Vec<ASR::stmt_t*> result_vec_;
-                        result_vec_.reserve(al, 0);
-                        symtab2decls[current_scope] = result_vec_;
-                    }
-                    result_vec = &symtab2decls[current_scope];
-                } else {
-                    result_vec = &pass_result;
-                }
-                ASR::symbol_t *v = nullptr;
-                if (ASR::is_a<ASR::Var_t>(*result_var)) {
-                    v = ASR::down_cast<ASR::Var_t>(result_var)->m_v;
-                }
-                ASR::expr_t* derived_ref = ASRUtils::EXPR(ASRUtils::getStructInstanceMember_t(al,
-                                                x->base.base.loc, (ASR::asr_t*) result_var, v,
-                                                member, current_scope));
-                ASR::stmt_t* assign = ASRUtils::STMT(ASR::make_Assignment_t(al,
-                                            x->base.base.loc, derived_ref,
-                                            x->m_args[i].m_value, nullptr));
-                result_vec->push_back(al, assign);
-            }
-        }
+        Vec<ASR::stmt_t*>* result_vec = &pass_result;
+        PassUtils::ReplacerUtils::replace_StructTypeConstructor(
+            x, this, false, remove_original_statement, result_vec);
     }
 };
 
@@ -130,18 +44,14 @@ class StructTypeConstructorVisitor : public ASR::CallReplacerOnExpressionsVisito
 
         Allocator& al;
         bool remove_original_statement;
-        bool inside_symtab;
         ReplaceStructTypeConstructor replacer;
         Vec<ASR::stmt_t*> pass_result;
-        std::map<SymbolTable*, Vec<ASR::stmt_t*>> symtab2decls;
 
     public:
 
         StructTypeConstructorVisitor(Allocator& al_) :
         al(al_), remove_original_statement(false),
-        inside_symtab(true), replacer(al_, pass_result,
-            remove_original_statement, inside_symtab,
-            symtab2decls) {
+        replacer(al_, pass_result, remove_original_statement) {
             pass_result.n = 0;
             pass_result.reserve(al, 0);
         }
@@ -153,18 +63,8 @@ class StructTypeConstructorVisitor : public ASR::CallReplacerOnExpressionsVisito
         }
 
         void transform_stmts(ASR::stmt_t **&m_body, size_t &n_body) {
-            bool inside_symtab_copy = inside_symtab;
-            inside_symtab = false;
             Vec<ASR::stmt_t*> body;
             body.reserve(al, n_body);
-
-            if( symtab2decls.find(current_scope) != symtab2decls.end() ) {
-                Vec<ASR::stmt_t*>& decls = symtab2decls[current_scope];
-                for (size_t j = 0; j < decls.size(); j++) {
-                    body.push_back(al, decls[j]);
-                }
-                symtab2decls.erase(current_scope);
-            }
 
             for (size_t i = 0; i < n_body; i++) {
                 pass_result.n = 0;
@@ -185,15 +85,10 @@ class StructTypeConstructorVisitor : public ASR::CallReplacerOnExpressionsVisito
             replacer.result_var = nullptr;
             pass_result.n = 0;
             pass_result.reserve(al, 0);
-            inside_symtab = inside_symtab_copy;
         }
 
-        void visit_Variable(const ASR::Variable_t &x) {
-            ASR::Variable_t& xx = const_cast<ASR::Variable_t&>(x);
-            replacer.result_var = ASRUtils::EXPR(ASR::make_Var_t(al,
-                                    x.base.base.loc, &(xx.base)));
-            ASR::CallReplacerOnExpressionsVisitor<
-                StructTypeConstructorVisitor>::visit_Variable(x);
+        void visit_Variable(const ASR::Variable_t& /*x*/) {
+            // Do nothing, already handled in init_expr pass
         }
 
         void visit_Assignment(const ASR::Assignment_t &x) {

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -6,282 +6,122 @@
 #include <libasr/pass/implied_do_loops.h>
 #include <libasr/pass/pass_utils.h>
 
+#include <vector>
+#include <utility>
 
 namespace LCompilers {
 
 using ASR::down_cast;
 using ASR::is_a;
 
-/*
-This ASR pass replaces implied do loops with do loops in array initialiser expressions.
-The function `pass_replace_implied_do_loops` transforms the ASR tree in-place.
+class ReplaceArrayConstant: public ASR::BaseExprReplacer<ReplaceArrayConstant> {
 
-Converts:
+    public:
 
-    x = [(i*2, i = 1, 6)]
+    Allocator& al;
+    Vec<ASR::stmt_t*>& pass_result;
+    bool& remove_original_statement;
 
-to:
+    SymbolTable* current_scope;
+    ASR::expr_t* result_var;
 
-    do i = 1, 6
-        x(i) = i*2
-    end do
-*/
+    ReplaceArrayConstant(Allocator& al_, Vec<ASR::stmt_t*>& pass_result_,
+        bool& remove_original_statement_) :
+    al(al_), pass_result(pass_result_),
+    remove_original_statement(remove_original_statement_),
+    current_scope(nullptr), result_var(nullptr) {}
 
-class ImpliedDoLoopVisitor : public PassUtils::PassVisitor<ImpliedDoLoopVisitor>
+    void replace_ArrayConstant(ASR::ArrayConstant_t* x) {
+        Vec<ASR::stmt_t*>* result_vec = &pass_result;
+        PassUtils::ReplacerUtils::replace_ArrayConstant(x, this,
+            remove_original_statement, result_vec);
+    }
+
+};
+
+class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayConstantVisitor>
 {
-private:
-    bool contains_array;
-    std::string rl_path;
-public:
-    // Public to suppress a warning
-    ASR::TranslationUnit_t &unit;
+    private:
 
-    ImpliedDoLoopVisitor(Allocator &al, ASR::TranslationUnit_t& unit,
-        const std::string &rl_path) :
-             PassVisitor(al, nullptr), contains_array{false}, rl_path{rl_path},
-             unit{unit} {
-        pass_result.reserve(al, 1);
-    }
+        Allocator& al;
+        bool remove_original_statement;
+        ReplaceArrayConstant replacer;
+        Vec<ASR::stmt_t*> pass_result;
 
-    void visit_Var(const ASR::Var_t& x) {
-        ASR::expr_t* x_expr = (ASR::expr_t*)(&(x.base));
-        contains_array = PassUtils::is_array(x_expr);
-    }
+    public:
 
-    void visit_IntegerConstant(const ASR::IntegerConstant_t&) {
-        contains_array = false;
-    }
-
-    void visit_RealConstant(const ASR::RealConstant_t&) {
-        contains_array = false;
-    }
-
-    void visit_ComplexConstant(const ASR::ComplexConstant_t&) {
-        contains_array = false;
-    }
-
-    void visit_LogicalConstant(const ASR::LogicalConstant_t&) {
-        contains_array = false;
-    }
-
-    void visit_IntegerBinOp(const ASR::IntegerBinOp_t& x) {
-        handle_BinOp(x);
-    }
-
-    void visit_RealBinOp(const ASR::RealBinOp_t& x) {
-        handle_BinOp(x);
-    }
-
-    void visit_ComplexBinOp(const ASR::ComplexBinOp_t& x) {
-        handle_BinOp(x);
-    }
-
-    void visit_LogicalBinOp(const ASR::LogicalBinOp_t& x) {
-        handle_BinOp(x);
-    }
-
-    template <typename T>
-    void handle_BinOp(const T& x) {
-        if( contains_array ) {
-            return ;
+        ArrayConstantVisitor(Allocator& al_) :
+        al(al_), remove_original_statement(false),
+        replacer(al_, pass_result,
+            remove_original_statement) {
+            pass_result.n = 0;
+            pass_result.reserve(al, 0);
         }
-        bool left_array, right_array;
-        visit_expr(*(x.m_left));
-        left_array = contains_array;
-        visit_expr(*(x.m_right));
-        right_array = contains_array;
-        contains_array = left_array || right_array;
-    }
 
-    void create_do_loop(ASR::ImpliedDoLoop_t* idoloop, ASR::Var_t* arr_var, ASR::expr_t* arr_idx=nullptr) {
-        ASR::do_loop_head_t head;
-        head.m_v = idoloop->m_var;
-        head.m_start = idoloop->m_start;
-        head.m_end = idoloop->m_end;
-        head.m_increment = idoloop->m_increment;
-        head.loc = head.m_v->base.loc;
-        Vec<ASR::stmt_t*> doloop_body;
-        doloop_body.reserve(al, 1);
-        ASR::ttype_t *_type = ASRUtils::expr_type(idoloop->m_start);
-        ASR::expr_t* const_1 = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, arr_var->base.base.loc, 1, _type));
-        ASR::expr_t *const_n, *offset, *num_grps, *grp_start;
-        const_n = offset = num_grps = grp_start = nullptr;
-        if( arr_idx == nullptr ) {
-            const_n = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, arr_var->base.base.loc, idoloop->n_values, _type));
-            offset = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.base.loc, idoloop->m_var, ASR::binopType::Sub, idoloop->m_start, _type, nullptr));
-            num_grps = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.base.loc, offset, ASR::binopType::Mul, const_n, _type, nullptr));
-            grp_start = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.base.loc, num_grps, ASR::binopType::Add, const_1, _type, nullptr));
+        void call_replacer() {
+            replacer.current_expr = current_expr;
+            replacer.current_scope = current_scope;
+            replacer.replace_expr(*current_expr);
         }
-        for( size_t i = 0; i < idoloop->n_values; i++ ) {
-            Vec<ASR::array_index_t> args;
-            ASR::array_index_t ai;
-            ai.loc = arr_var->base.base.loc;
-            ai.m_left = nullptr;
-            if( arr_idx == nullptr ) {
-                ASR::expr_t* const_i = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, arr_var->base.base.loc, i, _type));
-                ASR::expr_t* idx = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.base.loc,
-                                                            grp_start, ASR::binopType::Add, const_i, _type, nullptr));
-                ai.m_right = idx;
-            } else {
-                ai.m_right = arr_idx;
+
+        void transform_stmts(ASR::stmt_t **&m_body, size_t &n_body) {
+            Vec<ASR::stmt_t*> body;
+            body.reserve(al, n_body);
+
+            for (size_t i = 0; i < n_body; i++) {
+                pass_result.n = 0;
+                pass_result.reserve(al, 1);
+                remove_original_statement = false;
+                replacer.result_var = nullptr;
+                visit_stmt(*m_body[i]);
+                for (size_t j = 0; j < pass_result.size(); j++) {
+                    body.push_back(al, pass_result[j]);
+                }
+                if( !remove_original_statement ) {
+                    body.push_back(al, m_body[i]);
+                }
+                remove_original_statement = false;
             }
-            ai.m_step = nullptr;
-            args.reserve(al, 1);
-            args.push_back(al, ai);
-            ASR::ttype_t* array_ref_type = ASRUtils::expr_type(ASRUtils::EXPR((ASR::asr_t*)arr_var));
-            Vec<ASR::dimension_t> empty_dims;
-            empty_dims.reserve(al, 1);
-            array_ref_type = ASRUtils::duplicate_type(al, array_ref_type, &empty_dims);
-            ASR::expr_t* array_ref = ASRUtils::EXPR(ASR::make_ArrayItem_t(al, arr_var->base.base.loc,
-                                                              ASRUtils::EXPR((ASR::asr_t*)arr_var),
-                                                              args.p, args.size(),
-                                                              array_ref_type, ASR::arraystorageType::RowMajor,
-                                                              nullptr));
-            if( idoloop->m_values[i]->type == ASR::exprType::ImpliedDoLoop ) {
-                throw LCompilersException("Pass for nested ImpliedDoLoop nodes isn't implemented yet."); // idoloop->m_values[i]->base.loc
-            }
-            ASR::stmt_t* doloop_stmt = ASRUtils::STMT(ASR::make_Assignment_t(al, arr_var->base.base.loc, array_ref, idoloop->m_values[i], nullptr));
-            doloop_body.push_back(al, doloop_stmt);
-            if( arr_idx != nullptr ) {
-                ASR::expr_t* increment = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.base.loc, arr_idx, ASR::binopType::Add, const_1, ASRUtils::expr_type(arr_idx), nullptr));
-                ASR::stmt_t* assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(al, arr_var->base.base.loc, arr_idx, increment, nullptr));
-                doloop_body.push_back(al, assign_stmt);
-            }
-        }
-        ASR::stmt_t* doloop = ASRUtils::STMT(ASR::make_DoLoop_t(al, arr_var->base.base.loc, head, doloop_body.p, doloop_body.size()));
-        pass_result.push_back(al, doloop);
-    }
-
-    void visit_Assignment(const ASR::Assignment_t &x) {
-        if( (ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(x.m_target)) &&
-            ASR::is_a<ASR::GetPointer_t>(*x.m_value)) ||
-            ASR::is_a<ASR::ArrayReshape_t>(*x.m_value) ) {
-            return ;
+            m_body = body.p;
+            n_body = body.size();
+            replacer.result_var = nullptr;
+            pass_result.n = 0;
+            pass_result.reserve(al, 0);
         }
 
-        if( ASR::is_a<ASR::ArrayConstant_t>(*x.m_value) ) {
-            ASR::ArrayConstant_t* arr_init = ASR::down_cast<ASR::ArrayConstant_t>(x.m_value);
-            if( arr_init->n_args == 0 ) {
-                remove_original_stmt = true;
+        void visit_Assignment(const ASR::Assignment_t &x) {
+            if( (ASR::is_a<ASR::Pointer_t>(*ASRUtils::expr_type(x.m_target)) &&
+                ASR::is_a<ASR::GetPointer_t>(*x.m_value)) ||
+                ASR::is_a<ASR::ArrayReshape_t>(*x.m_value) ) {
                 return ;
             }
 
-            if( ASR::is_a<ASR::Var_t>(*x.m_target) ) {
-                LCOMPILERS_ASSERT_MSG(PassUtils::get_rank(x.m_target) == 1,
-                                    "Initialisation using ArrayConstant is "
-                                    "supported only for single dimensional arrays.")
-                ASR::Var_t* arr_var = ASR::down_cast<ASR::Var_t>(x.m_target);
-                Vec<ASR::expr_t*> idx_vars;
-                PassUtils::create_idx_vars(idx_vars, 1, x.base.base.loc, al, current_scope);
-                ASR::expr_t* idx_var = idx_vars[0];
-                ASR::expr_t* lb = PassUtils::get_bound(x.m_target, 1, "lbound", al);
-                ASR::expr_t* const_1 = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, 1,
-                                            ASRUtils::expr_type(idx_var)));
-                ASR::stmt_t* assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(al,
-                                                arr_var->base.base.loc, idx_var, lb, nullptr));
-                pass_result.push_back(al, assign_stmt);
-                for( size_t k = 0; k < arr_init->n_args; k++ ) {
-                    ASR::expr_t* curr_init = arr_init->m_args[k];
-                    if( ASR::is_a<ASR::ImpliedDoLoop_t>(*curr_init) ) {
-                        ASR::ImpliedDoLoop_t* idoloop = ASR::down_cast<ASR::ImpliedDoLoop_t>(curr_init);
-                        create_do_loop(idoloop, arr_var, idx_var);
-                    } else {
-                        Vec<ASR::array_index_t> args;
-                        ASR::array_index_t ai;
-                        ai.loc = arr_var->base.base.loc;
-                        ai.m_left = nullptr;
-                        ai.m_right = idx_var;
-                        ai.m_step = nullptr;
-                        args.reserve(al, 1);
-                        args.push_back(al, ai);
-                        ASR::ttype_t* array_ref_type = ASRUtils::expr_type(ASRUtils::EXPR((ASR::asr_t*)arr_var));
-                        Vec<ASR::dimension_t> empty_dims;
-                        empty_dims.reserve(al, 1);
-                        array_ref_type = ASRUtils::duplicate_type(al, array_ref_type, &empty_dims);
-                        ASR::expr_t* array_ref = ASRUtils::EXPR(ASR::make_ArrayItem_t(al, arr_var->base.base.loc,
-                                                                            ASRUtils::EXPR((ASR::asr_t*)arr_var),
-                                                                            args.p, args.size(),
-                                                                            array_ref_type, ASR::arraystorageType::RowMajor,
-                                                                            nullptr));
-                        ASR::stmt_t* assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(al, arr_var->base.base.loc, array_ref, arr_init->m_args[k], nullptr));
-                        pass_result.push_back(al, assign_stmt);
-                        ASR::expr_t* increment = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, arr_var->base.base.loc, idx_var, ASR::binopType::Add, const_1, ASRUtils::expr_type(idx_var), nullptr));
-                        assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(al, arr_var->base.base.loc, idx_var, increment, nullptr));
-                        pass_result.push_back(al, assign_stmt);
-                    }
-                }
-            } else if( ASR::is_a<ASR::ArraySection_t>(*x.m_target) ) {
-                ASR::ArraySection_t* target_section = ASR::down_cast<ASR::ArraySection_t>(x.m_target);
-                int sliced_dims_count = 0;
-                size_t sliced_dim_index = 0;
-                for( size_t i = 0; i < target_section->n_args; i++ ) {
-                    if( !(target_section->m_args[i].m_left == nullptr &&
-                          target_section->m_args[i].m_right != nullptr &&
-                          target_section->m_args[i].m_step == nullptr) ) {
-                        sliced_dims_count += 1;
-                        sliced_dim_index = i + 1;
-                    }
-                }
-                if( sliced_dims_count != 1 ) {
-                    throw LCompilersException("Target expressions only having one "
-                                                "dimension sliced are supported for now.");
-                }
+            if( !ASR::is_a<ASR::ArrayConstant_t>(*x.m_value) ) {
+                return ;
+            }
 
-                Vec<ASR::expr_t*> idx_vars;
-                PassUtils::create_idx_vars(idx_vars, 1, x.base.base.loc, al, current_scope);
-                ASR::expr_t* idx_var = idx_vars[0];
-                ASR::expr_t* lb = PassUtils::get_bound(target_section->m_v, sliced_dim_index, "lbound", al);
-                ASR::expr_t* const_1 = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, 1,
-                                            ASRUtils::expr_type(idx_var)));
-                ASR::stmt_t* assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(al,
-                                                target_section->base.base.loc, idx_var, lb, nullptr));
-                pass_result.push_back(al, assign_stmt);
-                for( size_t k = 0; k < arr_init->n_args; k++ ) {
-                    ASR::expr_t* curr_init = arr_init->m_args[k];
-                    if( ASR::is_a<ASR::ImpliedDoLoop_t>(*curr_init) ) {
-                        throw LCompilersException("Do loops in array initialiser expressions not supported yet.");
-                    } else {
-                        Vec<ASR::array_index_t> args;
-                        args.reserve(al, target_section->n_args);
-                        for( size_t i = 0; i < target_section->n_args; i++ ) {
-                            if( i + 1 == sliced_dim_index ) {
-                                ASR::array_index_t ai;
-                                ai.loc = target_section->base.base.loc;
-                                ai.m_left = nullptr;
-                                ai.m_step = nullptr;
-                                ai.m_right = idx_var;
-                                args.push_back(al, ai);
-                            } else {
-                                args.push_back(al, target_section->m_args[i]);
-                            }
-                        }
+            if (x.m_overloaded) {
+                this->visit_stmt(*x.m_overloaded);
+                remove_original_statement = false;
+                return ;
+            }
 
-                        ASR::ttype_t* array_ref_type = ASRUtils::expr_type(x.m_target);
-                        Vec<ASR::dimension_t> empty_dims;
-                        empty_dims.reserve(al, 1);
-                        array_ref_type = ASRUtils::duplicate_type(al, array_ref_type, &empty_dims);
-
-                        ASR::expr_t* array_ref = ASRUtils::EXPR(ASR::make_ArrayItem_t(al, target_section->base.base.loc,
-                                                                            target_section->m_v,
-                                                                            args.p, args.size(),
-                                                                            array_ref_type, ASR::arraystorageType::RowMajor,
-                                                                            nullptr));
-                        ASR::stmt_t* assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(al, target_section->base.base.loc, array_ref, arr_init->m_args[k], nullptr));
-                        pass_result.push_back(al, assign_stmt);
-                        ASR::expr_t* increment = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(al, target_section->base.base.loc, idx_var, ASR::binopType::Add, const_1, ASRUtils::expr_type(idx_var), nullptr));
-                        assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(al, target_section->base.base.loc, idx_var, increment, nullptr));
-                        pass_result.push_back(al, assign_stmt);
-                    }
-                }
+            replacer.result_var = x.m_target;
+            ASR::expr_t** current_expr_copy_9 = current_expr;
+            current_expr = const_cast<ASR::expr_t**>(&(x.m_value));
+            this->call_replacer();
+            current_expr = current_expr_copy_9;
+            if( !remove_original_statement ) {
+                this->visit_expr(*x.m_value);
             }
         }
-    }
+
 };
 
-void pass_replace_implied_do_loops(Allocator &al, ASR::TranslationUnit_t &unit,
-                                   const LCompilers::PassOptions& pass_options) {
-    std::string rl_path = pass_options.runtime_library_dir;
-    ImpliedDoLoopVisitor v(al, unit, rl_path);
+void pass_replace_implied_do_loops(Allocator &al,
+    ASR::TranslationUnit_t &unit,
+    const LCompilers::PassOptions& /*pass_options*/) {
+    ArrayConstantVisitor v(al);
     v.visit_TranslationUnit(unit);
 }
 

--- a/src/libasr/pass/init_expr.cpp
+++ b/src/libasr/pass/init_expr.cpp
@@ -1,0 +1,161 @@
+#include <libasr/asr.h>
+#include <libasr/containers.h>
+#include <libasr/exception.h>
+#include <libasr/asr_utils.h>
+#include <libasr/asr_verify.h>
+#include <libasr/pass/init_expr.h>
+#include <libasr/pass/pass_utils.h>
+
+#include <vector>
+#include <utility>
+
+namespace LCompilers {
+
+using ASR::down_cast;
+using ASR::is_a;
+
+class ReplaceInitExpr: public ASR::BaseExprReplacer<ReplaceInitExpr> {
+
+    public:
+
+    Allocator& al;
+    std::map<SymbolTable*, Vec<ASR::stmt_t*>>& symtab2decls;
+
+    SymbolTable* current_scope;
+    ASR::expr_t* result_var;
+
+    ReplaceInitExpr(
+        Allocator& al_,
+        std::map<SymbolTable*, Vec<ASR::stmt_t*>>& symtab2decls_) :
+    al(al_), symtab2decls(symtab2decls_),
+    current_scope(nullptr), result_var(nullptr) {}
+
+    void replace_ArrayConstant(ASR::ArrayConstant_t* x) {
+        if( symtab2decls.find(current_scope) == symtab2decls.end() ) {
+            Vec<ASR::stmt_t*> result_vec_;
+            result_vec_.reserve(al, 0);
+            symtab2decls[current_scope] = result_vec_;
+        }
+        Vec<ASR::stmt_t*>* result_vec = &symtab2decls[current_scope];
+        bool remove_original_statement = false;
+        PassUtils::ReplacerUtils::replace_ArrayConstant(x, this,
+            remove_original_statement, result_vec);
+    }
+
+    void replace_StructTypeConstructor(ASR::StructTypeConstructor_t* x) {
+        if( symtab2decls.find(current_scope) == symtab2decls.end() ) {
+            Vec<ASR::stmt_t*> result_vec_;
+            result_vec_.reserve(al, 0);
+            symtab2decls[current_scope] = result_vec_;
+        }
+        Vec<ASR::stmt_t*>* result_vec = &symtab2decls[current_scope];
+        bool remove_original_statement = false;
+        PassUtils::ReplacerUtils::replace_StructTypeConstructor(
+            x, this, true, remove_original_statement, result_vec);
+    }
+
+};
+
+class InitExprVisitor : public ASR::CallReplacerOnExpressionsVisitor<InitExprVisitor>
+{
+    private:
+
+        Allocator& al;
+        ReplaceInitExpr replacer;
+        std::map<SymbolTable*, Vec<ASR::stmt_t*>> symtab2decls;
+
+    public:
+
+        InitExprVisitor(Allocator& al_) :
+        al(al_), replacer(al_, symtab2decls) {
+        }
+
+        void call_replacer() {
+            replacer.current_expr = current_expr;
+            replacer.current_scope = current_scope;
+            replacer.replace_expr(*current_expr);
+        }
+
+        void transform_stmts(ASR::stmt_t **&m_body, size_t &n_body) {
+            Vec<ASR::stmt_t*> body;
+            body.reserve(al, n_body);
+
+            if( symtab2decls.find(current_scope) != symtab2decls.end() ) {
+                Vec<ASR::stmt_t*>& decls = symtab2decls[current_scope];
+                for (size_t j = 0; j < decls.size(); j++) {
+                    body.push_back(al, decls[j]);
+                }
+                symtab2decls.erase(current_scope);
+            }
+
+            for (size_t i = 0; i < n_body; i++) {
+                body.push_back(al, m_body[i]);
+            }
+            m_body = body.p;
+            n_body = body.size();
+        }
+
+        void visit_SymbolsContainingSymbolTable() {
+            std::vector<std::string> var_order = ASRUtils::determine_variable_declaration_order(current_scope);
+            for (auto &a : var_order) {
+                ASR::symbol_t* sym = current_scope->get_symbol(a);
+                this->visit_symbol(*sym);
+            }
+        }
+
+        void visit_Program(const ASR::Program_t& x) {
+            ASR::Program_t& xx = const_cast<ASR::Program_t&>(x);
+            SymbolTable* current_scope_copy = current_scope;
+            current_scope = xx.m_symtab;
+            visit_SymbolsContainingSymbolTable();
+            transform_stmts(xx.m_body, xx.n_body);
+            current_scope = current_scope_copy;
+        }
+
+        void visit_Function(const ASR::Function_t& x) {
+            ASR::Function_t& xx = const_cast<ASR::Function_t&>(x);
+            SymbolTable* current_scope_copy = current_scope;
+            current_scope = xx.m_symtab;
+            visit_SymbolsContainingSymbolTable();
+            transform_stmts(xx.m_body, xx.n_body);
+            current_scope = current_scope_copy;
+        }
+
+        void visit_Module(const ASR::Module_t& x) {
+            ASR::Module_t& xx = const_cast<ASR::Module_t&>(x);
+            SymbolTable* current_scope_copy = current_scope;
+            current_scope = xx.m_symtab;
+            visit_SymbolsContainingSymbolTable();
+            current_scope = current_scope_copy;
+        }
+
+        void visit_Variable(const ASR::Variable_t &x) {
+            ASR::symbol_t* asr_owner = ASRUtils::get_asr_owner(&(x.base));
+            if( !(x.m_symbolic_value &&
+                  (ASR::is_a<ASR::ArrayConstant_t>(*x.m_symbolic_value) ||
+                   ASR::is_a<ASR::StructTypeConstructor_t>(*x.m_symbolic_value))) ||
+                 (ASR::is_a<ASR::Module_t>(*asr_owner) &&
+                  ASR::is_a<ASR::ArrayConstant_t>(*x.m_symbolic_value)) ) {
+                return ;
+            }
+
+            ASR::Variable_t& xx = const_cast<ASR::Variable_t&>(x);
+            replacer.result_var = ASRUtils::EXPR(ASR::make_Var_t(al,
+                                    x.base.base.loc, &(xx.base)));
+            ASR::CallReplacerOnExpressionsVisitor<
+                InitExprVisitor>::visit_Variable(x);
+        }
+
+};
+
+void pass_replace_init_expr(Allocator &al,
+    ASR::TranslationUnit_t &unit,
+    const LCompilers::PassOptions& /*pass_options*/) {
+    InitExprVisitor v(al);
+    v.visit_TranslationUnit(unit);
+    PassUtils::UpdateDependenciesVisitor w(al);
+    w.visit_TranslationUnit(unit);
+}
+
+
+} // namespace LCompilers

--- a/src/libasr/pass/init_expr.h
+++ b/src/libasr/pass/init_expr.h
@@ -1,0 +1,14 @@
+#ifndef LFORTRAN_PASS_INIT_EXPR_H
+#define LFORTRAN_PASS_INIT_EXPR_H
+
+#include <libasr/asr.h>
+#include <libasr/utils.h>
+
+namespace LCompilers {
+
+    void pass_replace_init_expr(Allocator &al, ASR::TranslationUnit_t &unit,
+                                const LCompilers::PassOptions& pass_options);
+
+} // namespace LCompilers
+
+#endif // LFORTRAN_PASS_INIT_EXPR_H

--- a/src/libasr/pass/pass_manager.h
+++ b/src/libasr/pass/pass_manager.h
@@ -34,6 +34,7 @@
 #include <libasr/pass/inline_function_calls.h>
 #include <libasr/pass/dead_code_removal.h>
 #include <libasr/pass/for_all.h>
+#include <libasr/pass/init_expr.h>
 #include <libasr/pass/select_case.h>
 #include <libasr/pass/loop_vectorise.h>
 #include <libasr/pass/update_array_dim_intrinsic_calls.h>
@@ -83,7 +84,8 @@ namespace LCompilers {
             {"pass_list_expr", &pass_list_expr},
             {"pass_array_by_data", &pass_array_by_data},
             {"subroutine_from_function", &pass_create_subroutine_from_function},
-            {"transform_optional_argument_functions", &pass_transform_optional_argument_functions}
+            {"transform_optional_argument_functions", &pass_transform_optional_argument_functions},
+            {"init_expr", &pass_replace_init_expr}
         };
 
         bool is_fast;
@@ -143,6 +145,7 @@ namespace LCompilers {
         PassManager(): is_fast{false}, apply_default_passes{false} {
             _passes = {
                 "global_stmts",
+                "init_expr",
                 "class_constructor",
                 "implied_do_loops",
                 "pass_list_expr",
@@ -163,6 +166,7 @@ namespace LCompilers {
 
             _with_optimization_passes = {
                 "global_stmts",
+                "init_expr",
                 "class_constructor",
                 "implied_do_loops",
                 "pass_array_by_data",

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -4,6 +4,8 @@
 #include <libasr/asr.h>
 #include <libasr/containers.h>
 
+#include <queue>
+
 namespace LCompilers {
 
     namespace PassUtils {
@@ -395,6 +397,284 @@ namespace LCompilers {
                     }
                 }
         };
+
+    namespace ReplacerUtils {
+        template <typename T>
+        void replace_StructTypeConstructor(ASR::StructTypeConstructor_t* x,
+            T* replacer, bool inside_symtab, bool& remove_original_statement,
+            Vec<ASR::stmt_t*>* result_vec) {
+            if( x->n_args == 0 ) {
+                if( !inside_symtab ) {
+                    remove_original_statement = true;
+                }
+                return ;
+            }
+            if( replacer->result_var == nullptr ) {
+                std::string result_var_name = replacer->current_scope->get_unique_name("temp_struct_var__");
+                replacer->result_var = PassUtils::create_auxiliary_variable(x->base.base.loc,
+                                    result_var_name, replacer->al, replacer->current_scope, x->m_type);
+                *replacer->current_expr = replacer->result_var;
+            } else {
+                if( inside_symtab ) {
+                    *replacer->current_expr = nullptr;
+                } else {
+                    remove_original_statement = true;
+                }
+            }
+
+            std::deque<ASR::symbol_t*> constructor_arg_syms;
+            ASR::Struct_t* dt_der = ASR::down_cast<ASR::Struct_t>(x->m_type);
+            ASR::StructType_t* dt_dertype = ASR::down_cast<ASR::StructType_t>(
+                                            ASRUtils::symbol_get_past_external(dt_der->m_derived_type));
+            while( dt_dertype ) {
+                for( int i = (int) dt_dertype->n_members - 1; i >= 0; i-- ) {
+                    constructor_arg_syms.push_front(
+                        dt_dertype->m_symtab->get_symbol(
+                            dt_dertype->m_members[i]));
+                }
+                if( dt_dertype->m_parent != nullptr ) {
+                    ASR::symbol_t* dt_der_sym = ASRUtils::symbol_get_past_external(
+                                            dt_dertype->m_parent);
+                    LCOMPILERS_ASSERT(ASR::is_a<ASR::StructType_t>(*dt_der_sym));
+                    dt_dertype = ASR::down_cast<ASR::StructType_t>(dt_der_sym);
+                } else {
+                    dt_dertype = nullptr;
+                }
+            }
+            LCOMPILERS_ASSERT(constructor_arg_syms.size() == x->n_args);
+
+            for( size_t i = 0; i < x->n_args; i++ ) {
+                if( x->m_args[i].m_value == nullptr ) {
+                    continue ;
+                }
+                ASR::symbol_t* member = constructor_arg_syms[i];
+                if( ASR::is_a<ASR::StructTypeConstructor_t>(*x->m_args[i].m_value) ) {
+                    ASR::expr_t* result_var_copy = replacer->result_var;
+                    ASR::symbol_t *v = nullptr;
+                    if (ASR::is_a<ASR::Var_t>(*result_var_copy)) {
+                        v = ASR::down_cast<ASR::Var_t>(result_var_copy)->m_v;
+                    }
+                    replacer->result_var = ASRUtils::EXPR(ASRUtils::getStructInstanceMember_t(replacer->al,
+                                                x->base.base.loc, (ASR::asr_t*) result_var_copy, v,
+                                                member, replacer->current_scope));
+                    ASR::expr_t** current_expr_copy = replacer->current_expr;
+                    replacer->current_expr = &(x->m_args[i].m_value);
+                    replacer->replace_expr(x->m_args[i].m_value);
+                    replacer->current_expr = current_expr_copy;
+                    replacer->result_var = result_var_copy;
+                } else {
+                    ASR::symbol_t *v = nullptr;
+                    if (ASR::is_a<ASR::Var_t>(*replacer->result_var)) {
+                        v = ASR::down_cast<ASR::Var_t>(replacer->result_var)->m_v;
+                    }
+                    ASR::expr_t* derived_ref = ASRUtils::EXPR(ASRUtils::getStructInstanceMember_t(replacer->al,
+                                                    x->base.base.loc, (ASR::asr_t*) replacer->result_var, v,
+                                                    member, replacer->current_scope));
+                    ASR::stmt_t* assign = ASRUtils::STMT(ASR::make_Assignment_t(replacer->al,
+                                                x->base.base.loc, derived_ref,
+                                                x->m_args[i].m_value, nullptr));
+                    result_vec->push_back(replacer->al, assign);
+                }
+            }
+        }
+
+        template <typename T>
+        void create_do_loop(T* replacer, ASR::ImpliedDoLoop_t* idoloop,
+        ASR::Var_t* arr_var, Vec<ASR::stmt_t*>* result_vec,
+        ASR::expr_t* arr_idx=nullptr) {
+            ASR::do_loop_head_t head;
+            head.m_v = idoloop->m_var;
+            head.m_start = idoloop->m_start;
+            head.m_end = idoloop->m_end;
+            head.m_increment = idoloop->m_increment;
+            head.loc = head.m_v->base.loc;
+            Vec<ASR::stmt_t*> doloop_body;
+            doloop_body.reserve(replacer->al, 1);
+            ASR::ttype_t *_type = ASRUtils::expr_type(idoloop->m_start);
+            ASR::expr_t* const_1 = ASRUtils::EXPR(ASR::make_IntegerConstant_t(replacer->al, arr_var->base.base.loc, 1, _type));
+            ASR::expr_t *const_n, *offset, *num_grps, *grp_start;
+            const_n = offset = num_grps = grp_start = nullptr;
+            if( arr_idx == nullptr ) {
+                const_n = ASRUtils::EXPR(ASR::make_IntegerConstant_t(replacer->al, arr_var->base.base.loc, idoloop->n_values, _type));
+                offset = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(replacer->al, arr_var->base.base.loc, idoloop->m_var,
+                            ASR::binopType::Sub, idoloop->m_start, _type, nullptr));
+                num_grps = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(replacer->al, arr_var->base.base.loc, offset,
+                                ASR::binopType::Mul, const_n, _type, nullptr));
+                grp_start = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(replacer->al, arr_var->base.base.loc, num_grps,
+                                ASR::binopType::Add, const_1, _type, nullptr));
+            }
+            for( size_t i = 0; i < idoloop->n_values; i++ ) {
+                Vec<ASR::array_index_t> args;
+                ASR::array_index_t ai;
+                ai.loc = arr_var->base.base.loc;
+                ai.m_left = nullptr;
+                if( arr_idx == nullptr ) {
+                    ASR::expr_t* const_i = ASRUtils::EXPR(ASR::make_IntegerConstant_t(replacer->al, arr_var->base.base.loc, i, _type));
+                    ASR::expr_t* idx = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(replacer->al, arr_var->base.base.loc,
+                                            grp_start, ASR::binopType::Add, const_i, _type, nullptr));
+                    ai.m_right = idx;
+                } else {
+                    ai.m_right = arr_idx;
+                }
+                ai.m_step = nullptr;
+                args.reserve(replacer->al, 1);
+                args.push_back(replacer->al, ai);
+                ASR::ttype_t* array_ref_type = ASRUtils::expr_type(ASRUtils::EXPR((ASR::asr_t*)arr_var));
+                Vec<ASR::dimension_t> empty_dims;
+                empty_dims.reserve(replacer->al, 1);
+                array_ref_type = ASRUtils::duplicate_type(replacer->al, array_ref_type, &empty_dims);
+                ASR::expr_t* array_ref = ASRUtils::EXPR(ASR::make_ArrayItem_t(replacer->al, arr_var->base.base.loc,
+                                            ASRUtils::EXPR((ASR::asr_t*)arr_var),
+                                            args.p, args.size(),
+                                            array_ref_type, ASR::arraystorageType::RowMajor,
+                                            nullptr));
+                if( ASR::is_a<ASR::ImpliedDoLoop_t>(*idoloop->m_values[i]) ) {
+                    throw LCompilersException("Pass for nested ImpliedDoLoop nodes isn't implemented yet."); // idoloop->m_values[i]->base.loc
+                }
+                ASR::stmt_t* doloop_stmt = ASRUtils::STMT(ASR::make_Assignment_t(replacer->al, arr_var->base.base.loc,
+                                                array_ref, idoloop->m_values[i], nullptr));
+                doloop_body.push_back(replacer->al, doloop_stmt);
+                if( arr_idx != nullptr ) {
+                    ASR::expr_t* increment = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(replacer->al, arr_var->base.base.loc,
+                                                arr_idx, ASR::binopType::Add, const_1, ASRUtils::expr_type(arr_idx), nullptr));
+                    ASR::stmt_t* assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(replacer->al, arr_var->base.base.loc,
+                                                arr_idx, increment, nullptr));
+                    doloop_body.push_back(replacer->al, assign_stmt);
+                }
+            }
+            ASR::stmt_t* doloop = ASRUtils::STMT(ASR::make_DoLoop_t(replacer->al, arr_var->base.base.loc,
+                                                                    head, doloop_body.p, doloop_body.size()));
+            result_vec->push_back(replacer->al, doloop);
+        }
+
+        template <typename T>
+        void replace_ArrayConstant(ASR::ArrayConstant_t* x, T* replacer,
+            bool& remove_original_statement, Vec<ASR::stmt_t*>* result_vec) {
+            if( !replacer->result_var ) {
+                return ;
+            }
+            if( x->n_args == 0 ) {
+                remove_original_statement = true;
+                return ;
+            }
+
+            const Location& loc = x->base.base.loc;
+            if( ASR::is_a<ASR::Var_t>(*replacer->result_var) ) {
+                LCOMPILERS_ASSERT_MSG(PassUtils::get_rank(replacer->result_var) == 1,
+                                    "Initialisation using ArrayConstant is "
+                                    "supported only for single dimensional arrays.")
+                ASR::Var_t* arr_var = ASR::down_cast<ASR::Var_t>(replacer->result_var);
+                Vec<ASR::expr_t*> idx_vars;
+                PassUtils::create_idx_vars(idx_vars, 1, loc, replacer->al, replacer->current_scope);
+                ASR::expr_t* idx_var = idx_vars[0];
+                ASR::expr_t* lb = PassUtils::get_bound(replacer->result_var, 1, "lbound", replacer->al);
+                ASR::expr_t* const_1 = ASRUtils::EXPR(ASR::make_IntegerConstant_t(replacer->al, loc, 1,
+                                            ASRUtils::expr_type(idx_var)));
+                ASR::stmt_t* assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(replacer->al,
+                                                arr_var->base.base.loc, idx_var, lb, nullptr));
+                result_vec->push_back(replacer->al, assign_stmt);
+                for( size_t k = 0; k < x->n_args; k++ ) {
+                    ASR::expr_t* curr_init = x->m_args[k];
+                    if( ASR::is_a<ASR::ImpliedDoLoop_t>(*curr_init) ) {
+                        ASR::ImpliedDoLoop_t* idoloop = ASR::down_cast<ASR::ImpliedDoLoop_t>(curr_init);
+                        create_do_loop(replacer, idoloop, arr_var, result_vec, idx_var);
+                    } else {
+                        Vec<ASR::array_index_t> args;
+                        ASR::array_index_t ai;
+                        ai.loc = arr_var->base.base.loc;
+                        ai.m_left = nullptr;
+                        ai.m_right = idx_var;
+                        ai.m_step = nullptr;
+                        args.reserve(replacer->al, 1);
+                        args.push_back(replacer->al, ai);
+                        ASR::ttype_t* array_ref_type = ASRUtils::expr_type(ASRUtils::EXPR((ASR::asr_t*)arr_var));
+                        Vec<ASR::dimension_t> empty_dims;
+                        empty_dims.reserve(replacer->al, 1);
+                        array_ref_type = ASRUtils::duplicate_type(replacer->al, array_ref_type, &empty_dims);
+                        ASR::expr_t* array_ref = ASRUtils::EXPR(ASR::make_ArrayItem_t(replacer->al, arr_var->base.base.loc,
+                                                        ASRUtils::EXPR((ASR::asr_t*)arr_var),
+                                                        args.p, args.size(),
+                                                        array_ref_type, ASR::arraystorageType::ColMajor,
+                                                        nullptr));
+                        ASR::stmt_t* assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(replacer->al, arr_var->base.base.loc,
+                                                        array_ref, x->m_args[k], nullptr));
+                        result_vec->push_back(replacer->al, assign_stmt);
+                        ASR::expr_t* increment = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(replacer->al, arr_var->base.base.loc, idx_var,
+                                                    ASR::binopType::Add, const_1, ASRUtils::expr_type(idx_var), nullptr));
+                        assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(replacer->al, arr_var->base.base.loc, idx_var, increment, nullptr));
+                        result_vec->push_back(replacer->al, assign_stmt);
+                    }
+                }
+            } else if( ASR::is_a<ASR::ArraySection_t>(*replacer->result_var) ) {
+                ASR::ArraySection_t* target_section = ASR::down_cast<ASR::ArraySection_t>(replacer->result_var);
+                int sliced_dims_count = 0;
+                size_t sliced_dim_index = 0;
+                for( size_t i = 0; i < target_section->n_args; i++ ) {
+                    if( !(target_section->m_args[i].m_left == nullptr &&
+                            target_section->m_args[i].m_right != nullptr &&
+                            target_section->m_args[i].m_step == nullptr) ) {
+                        sliced_dims_count += 1;
+                        sliced_dim_index = i + 1;
+                    }
+                }
+                if( sliced_dims_count != 1 ) {
+                    throw LCompilersException("Target expressions only having one "
+                                            "dimension sliced are supported for now.");
+                }
+
+                Vec<ASR::expr_t*> idx_vars;
+                PassUtils::create_idx_vars(idx_vars, 1, loc, replacer->al, replacer->current_scope);
+                ASR::expr_t* idx_var = idx_vars[0];
+                ASR::expr_t* lb = PassUtils::get_bound(target_section->m_v, sliced_dim_index, "lbound", replacer->al);
+                ASR::expr_t* const_1 = ASRUtils::EXPR(ASR::make_IntegerConstant_t(replacer->al, loc, 1,
+                                            ASRUtils::expr_type(idx_var)));
+                ASR::stmt_t* assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(replacer->al,
+                                                target_section->base.base.loc, idx_var, lb, nullptr));
+                result_vec->push_back(replacer->al, assign_stmt);
+                for( size_t k = 0; k < x->n_args; k++ ) {
+                    ASR::expr_t* curr_init = x->m_args[k];
+                    if( ASR::is_a<ASR::ImpliedDoLoop_t>(*curr_init) ) {
+                        throw LCompilersException("Do loops in array initialiser expressions not supported yet.");
+                    } else {
+                        Vec<ASR::array_index_t> args;
+                        args.reserve(replacer->al, target_section->n_args);
+                        for( size_t i = 0; i < target_section->n_args; i++ ) {
+                            if( i + 1 == sliced_dim_index ) {
+                                ASR::array_index_t ai;
+                                ai.loc = target_section->base.base.loc;
+                                ai.m_left = nullptr;
+                                ai.m_step = nullptr;
+                                ai.m_right = idx_var;
+                                args.push_back(replacer->al, ai);
+                            } else {
+                                args.push_back(replacer->al, target_section->m_args[i]);
+                            }
+                        }
+
+                        ASR::ttype_t* array_ref_type = ASRUtils::expr_type(replacer->result_var);
+                        Vec<ASR::dimension_t> empty_dims;
+                        empty_dims.reserve(replacer->al, 1);
+                        array_ref_type = ASRUtils::duplicate_type(replacer->al, array_ref_type, &empty_dims);
+
+                        ASR::expr_t* array_ref = ASRUtils::EXPR(ASR::make_ArrayItem_t(replacer->al,
+                                                        target_section->base.base.loc,
+                                                        target_section->m_v,
+                                                        args.p, args.size(),
+                                                        array_ref_type, ASR::arraystorageType::RowMajor,
+                                                        nullptr));
+                        ASR::stmt_t* assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(replacer->al, target_section->base.base.loc,
+                                                        array_ref, x->m_args[k], nullptr));
+                        result_vec->push_back(replacer->al, assign_stmt);
+                        ASR::expr_t* increment = ASRUtils::EXPR(ASR::make_IntegerBinOp_t(replacer->al, target_section->base.base.loc,
+                                                    idx_var, ASR::binopType::Add, const_1, ASRUtils::expr_type(idx_var), nullptr));
+                        assign_stmt = ASRUtils::STMT(ASR::make_Assignment_t(replacer->al, target_section->base.base.loc, idx_var, increment, nullptr));
+                        result_vec->push_back(replacer->al, assign_stmt);
+                    }
+                }
+            }
+            remove_original_statement = true;
+        }
+    }
 
     } // namespace PassUtils
 


### PR DESCRIPTION
Corresponding LFortran PR - https://github.com/lfortran/lfortran/pull/1459