### PR TITLE
Adding file write to os module

### DIFF
--- a/integration_tests/test_os.py
+++ b/integration_tests/test_os.py
@@ -1,5 +1,5 @@
 from lpython import i64
-from os import (open, read, close, O_RDONLY)
+from os import (open, read, close, write, O_RDONLY, O_WRONLY)
 
 def test():
     path: str
@@ -9,6 +9,11 @@ def test():
     fd = open(path, O_RDONLY)
     n = i64(100)
     print(read(fd, n))
+    close(fd)
+
+    path = "../tmp.txt"
+    fd = open(path, O_WRONLY)
+    write(fd, "Hello World!\n")
     close(fd)
 
 test()

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1221,6 +1221,17 @@ LFORTRAN_API void _lpython_close(int64_t fd)
     }
 }
 
+LFORTRAN_API void _lpython_write(int64_t fd, char *str)
+{
+    if (fd < 0)
+    {
+        printf("Error in writing to the file!\n");
+        exit(1);
+    }
+    fwrite(str, 1, strlen(str), fd);
+    // fwrite returns the number of items written
+}
+
 LFORTRAN_API int32_t _lfortran_ichar(char *c) {
      return (int32_t) c[0];
 }

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -211,6 +211,7 @@ LFORTRAN_API void _lfortran_dp_rand_num(double *x);
 LFORTRAN_API int64_t _lpython_open(char *path, char *flags);
 LFORTRAN_API char* _lpython_read(int64_t fd, int64_t n);
 LFORTRAN_API void _lpython_close(int64_t fd);
+LFORTRAN_API void _lpython_write(int64_t fd, char *str);
 LFORTRAN_API int32_t _lfortran_ichar(char *c);
 LFORTRAN_API int32_t _lfortran_iachar(char *c);
 LFORTRAN_API int32_t _lfortran_all(bool *mask, int32_t n);

--- a/src/runtime/os.py
+++ b/src/runtime/os.py
@@ -1,7 +1,7 @@
 from lpython import i32, i64, ccall
 
-O_RDONLY: i32 # = 0 FIXME: Assign the value 0 to O_RDONLY
-# O_WRONLY: i32 = 1
+O_RDONLY: i32 = 0 # FIXME: Assign the value 0 to O_RDONLY
+O_WRONLY: i32 = 1
 # O_RDWR  : i32 = 2
 # O_CREAT : i32 = 64
 # O_APPEND: i32 = 1024
@@ -14,6 +14,8 @@ def open(path: str, flag: i32) -> i64:
     sflag: str
     if flag == O_RDONLY:
         sflag = "r"
+    elif flag == O_WRONLY:
+        sflag = "w"
     else:
         quit(1) # not implemented yet
     return _lpython_open(path, sflag)
@@ -41,4 +43,16 @@ def close(fd: i64):
 
 @ccall
 def _lpython_close(fd: i64):
+    pass
+
+def write(fd: i64, s: str):
+    """
+    Writes `s` to the file descriptor.
+    May write partially
+    """
+    _lpython_write(fd, s)
+    return
+
+@ccall
+def _lpython_write(fd: i64, s: str):
     pass


### PR DESCRIPTION
I have added code to allow file writes. The tests are failing with this error:
```
/usr/bin/ld: test_os.o: in function `__module_os_write':
LFortran:(.text+0xb8): undefined reference to `_lpython_write'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/test_os.dir/build.make:88: test_os] Error 1
make[1]: *** [CMakeFiles/Makefile2:3095: CMakeFiles/test_os.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```
I am not sure where the error is. Are the files `lfortran_intrinsic.h/cpp` not supposed to be modified?