### PR TITLE
Remove ``*_nameless_enum`` checks from ASR verify pass

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1846,8 +1846,9 @@ inline int extract_kind(ASR::expr_t* kind_expr, const Location& loc) {
                     kind_variable->m_parent_symtab->asr_owner);
                 is_parent_enum = ASR::is_a<ASR::EnumType_t>(*s);
             }
-            if( kind_variable->m_storage == ASR::storage_typeType::Parameter
-                    || is_parent_enum) {
+            if( is_parent_enum ) {
+                a_kind = ASRUtils::extract_kind_from_ttype_t(kind_variable->m_type);
+            } else if( kind_variable->m_storage == ASR::storage_typeType::Parameter ) {
                 if( kind_variable->m_type->type == ASR::ttypeType::Integer ) {
                     LCOMPILERS_ASSERT( kind_variable->m_value != nullptr );
                     a_kind = ASR::down_cast<ASR::IntegerConstant_t>(kind_variable->m_value)->m_n;

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -625,20 +625,8 @@ public:
                 || is_a<Function_t>(*x.m_v) || is_a<ASR::EnumType_t>(*x.m_v),
             "Var_t::m_v " + x_mv_name + " does not point to a Variable_t, ExternalSymbol_t, " \
             "Function_t, Subroutine_t or EnumType_t");
-        bool var_present_in_enum = false;
-        {
-            int i = 1;
-            std::string enum_name = "_nameless_enum";
-            while (!var_present_in_enum && current_symtab->resolve_symbol(
-                    std::to_string(i) + enum_name) != nullptr) {
-                ASR::symbol_t *enum_s = current_symtab->resolve_symbol(
-                    std::to_string(i) + enum_name);
-                var_present_in_enum = symtab_in_scope(ASR::down_cast<
-                    ASR::EnumType_t>(enum_s)->m_symtab, x.m_v);
-                i ++;
-            }
-        }
-        require(symtab_in_scope(current_symtab, x.m_v) || var_present_in_enum,
+
+        require(symtab_in_scope(current_symtab, x.m_v),
             "Var::m_v `" + x_mv_name + "` cannot point outside of its symbol table");
         variable_dependencies.push_back(x_mv_name);
     }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -609,7 +609,7 @@ public:
                     type_ptr = llvm::Type::getInt64Ty(context);
                     break;
                 default:
-                    throw CodeGenError("Only 8, 16, 32 and 64 bits integer kinds are supported.");
+                    throw CodeGenError("Only 8, 16, 32 and 64 bits integer kinds are supported, found " + std::to_string(a_kind));
             }
         }
         return type_ptr;


### PR DESCRIPTION
Corresponding LFortran PR - https://github.com/lfortran/lfortran/pull/1468