### PR TITLE
WASM: Sync backend and other needed files

### DIFF
--- a/src/libasr/asdl_cpp.py
+++ b/src/libasr/asdl_cpp.py
@@ -1775,12 +1775,12 @@ class JsonVisitorVisitor(ASDLVisitor):
             elif field.type == "string" and not field.seq:
                 if field.opt:
                     self.emit("if (x.m_%s) {" % field.name, 2)
-                    self.emit(    's.append("\\"" + std::string(x.m_%s) + "\\"");' % field.name, 3)
+                    self.emit(    's.append("\\"" + get_escaped_str(x.m_%s) + "\\"");' % field.name, 3)
                     self.emit("} else {", 2)
                     self.emit(    's.append("[]");', 3)
                     self.emit("}", 2)
                 else:
-                    self.emit('s.append("\\"" + std::string(x.m_%s) + "\\"");' % field.name, 2)
+                    self.emit('s.append("\\"" + get_escaped_str(x.m_%s) + "\\"");' % field.name, 2)
             elif field.type == "int" and not field.seq:
                 if field.opt:
                     self.emit("if (x.m_%s) {" % field.name, 2)
@@ -2495,6 +2495,7 @@ HEAD = r"""#ifndef LFORTRAN_%(MOD2)s_H
 #include <libasr/containers.h>
 #include <libasr/exception.h>
 #include <libasr/asr_scopes.h>
+#include <libasr/string_utils.h>
 
 
 namespace LCompilers::%(MOD)s {

--- a/src/libasr/codegen/wasm_to_x64.cpp
+++ b/src/libasr/codegen/wasm_to_x64.cpp
@@ -60,7 +60,9 @@ class X64Visitor : public WASMDecoder<X64Visitor>,
     }
 
     void visit_Unreachable() {}
+
     void visit_EmtpyBlockType() {}
+
     void visit_Drop() { m_a.asm_pop_r64(X64Reg::rax); }
 
     void call_imported_function(uint32_t func_idx) {

--- a/src/libasr/pass/pass_array_by_data.cpp
+++ b/src/libasr/pass/pass_array_by_data.cpp
@@ -201,7 +201,7 @@ class PassArrayByDataProcedureVisitor : public PassUtils::PassVisitor<PassArrayB
                                             return_var, x_func_type->m_abi, x->m_access, x_func_type->m_deftype,
                                             s2c(al, new_bindc_name), x_func_type->m_elemental,
                                             x_func_type->m_pure, x_func_type->m_module, x_func_type->m_inline,
-                                            x_func_type->m_static, nullptr, 0, nullptr, 0, false, false, false);
+                                            x_func_type->m_static, x_func_type->m_type_params, x_func_type->n_type_params, nullptr, 0, false, false, false);
                 new_symbol = ASR::down_cast<ASR::symbol_t>(new_subrout);
             }
             current_scope->add_symbol(new_name, new_symbol);

--- a/src/libasr/pass/update_array_dim_intrinsic_calls.cpp
+++ b/src/libasr/pass/update_array_dim_intrinsic_calls.cpp
@@ -66,7 +66,7 @@ class ReplaceArrayDimIntrinsicCalls: public ASR::BaseExprReplacer<ReplaceArrayDi
         ASR::ttype_t* array_type = ASRUtils::expr_type(x->m_v);
         ASR::dimension_t* dims = nullptr;
         int n = ASRUtils::extract_dimensions_from_ttype(array_type, dims);
-        bool is_argument = v->m_intent == ASRUtils::intent_in || v->m_intent == ASRUtils::intent_out;
+        bool is_argument = v->m_intent == ASRUtils::intent_in || v->m_intent == ASRUtils::intent_out || v->m_intent == ASRUtils::intent_inout;
         if( !(n > 0 && is_argument &&
               !ASRUtils::is_dimension_empty(dims, n)) ) {
             return ;

--- a/src/libasr/string_utils.cpp
+++ b/src/libasr/string_utils.cpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <iomanip>
+#include <sstream>
 
 #include <libasr/string_utils.h>
 #include <libasr/containers.h>
@@ -83,6 +85,29 @@ std::string replace(const std::string &s,
     const std::string &regex, const std::string &replace)
 {
     return std::regex_replace(s, std::regex(regex), replace);
+}
+
+std::string get_escaped_str(const std::string &s) {
+    std::ostringstream o;
+    for (auto c = s.cbegin(); c != s.cend(); c++) {
+        switch (*c) {
+        case '"': o << "\\\""; break;
+        case '\\': o << "\\\\"; break;
+        case '\b': o << "\\b"; break;
+        case '\f': o << "\\f"; break;
+        case '\n': o << "\\n"; break;
+        case '\r': o << "\\r"; break;
+        case '\t': o << "\\t"; break;
+        default:
+            if ('\x00' <= *c && *c <= '\x1f') {
+                o << "\\u"
+                  << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(*c);
+            } else {
+                o << *c;
+            }
+        }
+    }
+    return o.str();
 }
 
 std::string read_file(const std::string &filename)

--- a/src/libasr/string_utils.h
+++ b/src/libasr/string_utils.h
@@ -24,6 +24,10 @@ char *s2c(Allocator &al, const std::string &s);
 std::string replace(const std::string &s,
     const std::string &regex, const std::string &replace);
 
+// Escapes special characters from the given string.
+// It is used during AST/R to Json conversion.
+std::string get_escaped_str(const std::string &s);
+
 std::string read_file(const std::string &filename);
 
 // Returns the parent path to the given path

--- a/tests/reference/c-c_interop1-e215531.json
+++ b/tests/reference/c-c_interop1-e215531.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-c_interop1-e215531.stdout",
-    "stdout_hash": "3bc9bc474cda656a2012aad05b9bf9b9a498016da571f8e5a4857138",
+    "stdout_hash": "11b48d84e0e873f5b2b5e8e92c721305af545a3a2b0038c2360d50e3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-c_interop1-e215531.stdout
+++ b/tests/reference/c-c_interop1-e215531.stdout
@@ -52,23 +52,6 @@ void l(double a, float b, int64_t c, int32_t d)
     printf("%s\n", "OK");
 }
 
-void main0()
-{
-    double i;
-    double x;
-    float y;
-    int64_t z;
-    int32_t zz;
-    x =   5.00000000000000000e+00;
-    i = f(x);
-    y =   5.40000000000000036e+00;
-    z = 3;
-    zz = 2;
-    g(x, y, z, zz);
-    i = h(x);
-    l(x, y, z, zz);
-}
-
 int main(int argc, char* argv[])
 {
     return 0;

--- a/tests/reference/cpp-assert1-ba60925.json
+++ b/tests/reference/cpp-assert1-ba60925.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-assert1-ba60925.stdout",
-    "stdout_hash": "9fb92dc2310b01633d4a2de3d1378200d4de8ed88b880c54ac69c72e",
+    "stdout_hash": "407c745929ee126426a33b3ba8f73b8f326d259e714ac66b078befe2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-assert1-ba60925.stdout
+++ b/tests/reference/cpp-assert1-ba60925.stdout
@@ -23,19 +23,10 @@ struct dimension_descriptor
     int32_t lower_bound, length;
 };
 // Forward declarations
-void test_assert();
 namespace {
 }
 
 // Implementations
-void test_assert()
-{
-    int32_t a;
-    a = 5;
-    assert (("a is not 5", a == 5));
-    assert (a != 10);
-}
-
 namespace {
 
 void main2() {

--- a/tests/reference/cpp-expr2-09c05ad.json
+++ b/tests/reference/cpp-expr2-09c05ad.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr2-09c05ad.stdout",
-    "stdout_hash": "69ef58997a788c80db293cfeeffb14d1bb1a94f630fff4c8d11b235b",
+    "stdout_hash": "407c745929ee126426a33b3ba8f73b8f326d259e714ac66b078befe2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr2-09c05ad.stdout
+++ b/tests/reference/cpp-expr2-09c05ad.stdout
@@ -23,25 +23,10 @@ struct dimension_descriptor
     int32_t lower_bound, length;
 };
 // Forward declarations
-void test_boolOp();
 namespace {
 }
 
 // Implementations
-void test_boolOp()
-{
-    bool a;
-    bool b;
-    a = false;
-    b = true;
-    a = a && b;
-    b = a || true;
-    a = a || b;
-    a = a && b == b;
-    a = a && b != b;
-    a = b || b;
-}
-
 namespace {
 
 void main2() {

--- a/tests/reference/cpp-expr5-1de0e30.json
+++ b/tests/reference/cpp-expr5-1de0e30.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr5-1de0e30.stdout",
-    "stdout_hash": "1f68a424d42810751fdd0169e4415cd9efcd4b7c5fb5932eddcf231c",
+    "stdout_hash": "407c745929ee126426a33b3ba8f73b8f326d259e714ac66b078befe2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr5-1de0e30.stdout
+++ b/tests/reference/cpp-expr5-1de0e30.stdout
@@ -23,19 +23,10 @@ struct dimension_descriptor
     int32_t lower_bound, length;
 };
 // Forward declarations
-void test_StrOp_concat();
 namespace {
 }
 
 // Implementations
-void test_StrOp_concat()
-{
-    std::string s;
-    s = std::string("3") + std::string("4");
-    s = std::string("a ") + std::string("test");
-    s = std::string(std::string("test") + std::string("test")) + std::string("test");
-}
-
 namespace {
 
 void main2() {

--- a/tests/reference/cpp-expr6-f337f4f.json
+++ b/tests/reference/cpp-expr6-f337f4f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr6-f337f4f.stdout",
-    "stdout_hash": "f804ce32ccbbaa39b2b00595c1a920caa64cd6edc786a3c4a11f4c50",
+    "stdout_hash": "407c745929ee126426a33b3ba8f73b8f326d259e714ac66b078befe2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr6-f337f4f.stdout
+++ b/tests/reference/cpp-expr6-f337f4f.stdout
@@ -23,21 +23,10 @@ struct dimension_descriptor
     int32_t lower_bound, length;
 };
 // Forward declarations
-void test_ifexp();
 namespace {
 }
 
 // Implementations
-void test_ifexp()
-{
-    int32_t a;
-    int32_t b;
-    bool c;
-    a = 2;
-    b = (a == 2) ? (6) : (8);
-    c = (b > 5) ? (true) : (false);
-}
-
 namespace {
 
 void main2() {

--- a/tests/reference/cpp-expr8-704cece.json
+++ b/tests/reference/cpp-expr8-704cece.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr8-704cece.stdout",
-    "stdout_hash": "7b462e24b8799e255f9c12dd05f4fe8a15806e20277426c325c663cf",
+    "stdout_hash": "0114926f9f033b9cbda860412fa9fadb1cebc84c57d89a6a6f6ce763",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr8-704cece.stdout
+++ b/tests/reference/cpp-expr8-704cece.stdout
@@ -23,47 +23,12 @@ struct dimension_descriptor
     int32_t lower_bound, length;
 };
 // Forward declarations
-void test_binop();
-bool __lpython_overloaded_6___lpython_floordiv(bool a, bool b);
 float _lfortran_caimag(std::complex<float> x);
 double _lfortran_zaimag(std::complex<double> x);
 namespace {
 }
 
 // Implementations
-void test_binop()
-{
-    bool b1;
-    bool b2;
-    int32_t x;
-    float x2;
-    x = std::pow(2, 3);
-    x2 = std::pow(  2.00000000000000000e+00,   3.50000000000000000e+00);
-    x = 54 - 100;
-    x2 =   3.45400000000000018e+00 -   7.65429999999999950e+02 +   5.34600000000000023e+02;
-    x2 =   5.34656499999999960e+03*  3.45000000000000018e+00;
-    x2 = std::pow(  5.34656499999999960e+03,   3.45000000000000018e+00);
-    x = (int)(true) + (int)(true);
-    x = (int)(true) - (int)(false);
-    x = (int)(true)*(int)(false);
-    x = std::pow((int)(true), (int)(false));
-    b1 = true;
-    b2 = false;
-    x = (int)(__lpython_overloaded_6___lpython_floordiv(b1, b1));
-    x = std::pow((int)(b1), (int)(b2));
-}
-
-bool __lpython_overloaded_6___lpython_floordiv(bool a, bool b)
-{
-    bool _lpython_return_variable;
-    if (b == false) {
-        std::cerr << "ERROR STOP" << std::endl;
-        exit(1);
-    }
-    _lpython_return_variable = a;
-    return _lpython_return_variable;
-}
-
 float _lfortran_caimag(std::complex<float> x);
 
 double _lfortran_zaimag(std::complex<double> x);

--- a/tests/reference/cpp-loop3-6020091.json
+++ b/tests/reference/cpp-loop3-6020091.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-loop3-6020091.stdout",
-    "stdout_hash": "f98dcda4a54fd19d7580613adcee035efef61bc3aa675d881f6de934",
+    "stdout_hash": "407c745929ee126426a33b3ba8f73b8f326d259e714ac66b078befe2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-loop3-6020091.stdout
+++ b/tests/reference/cpp-loop3-6020091.stdout
@@ -23,19 +23,10 @@ struct dimension_descriptor
     int32_t lower_bound, length;
 };
 // Forward declarations
-void test_pass();
 namespace {
 }
 
 // Implementations
-void test_pass()
-{
-    int32_t a;
-    a = 1;
-    while (a > 0) {
-    }
-}
-
 namespace {
 
 void main2() {

--- a/tests/reference/llvm-assert1-8df4f31.json
+++ b/tests/reference/llvm-assert1-8df4f31.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-assert1-8df4f31.stdout",
-    "stdout_hash": "548c0c52815267c5937b3877f09bb670683ce69013461d6bc9441cee",
+    "stdout_hash": "15764832892f7e0cd2a438b247a148564f5f83b3a00ca929bd9cc625",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-assert1-8df4f31.stdout
+++ b/tests/reference/llvm-assert1-8df4f31.stdout
@@ -1,50 +1,6 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@0 = private unnamed_addr constant [20 x i8] c"AssertionError: %s\0A\00", align 1
-@1 = private unnamed_addr constant [11 x i8] c"a is not 5\00", align 1
-@2 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
-
-define void @test_assert() {
-.entry:
-  %a = alloca i32, align 4
-  store i32 5, i32* %a, align 4
-  %0 = load i32, i32* %a, align 4
-  %1 = icmp eq i32 %0, 5
-  br i1 %1, label %then, label %else
-
-then:                                             ; preds = %.entry
-  br label %ifcont
-
-else:                                             ; preds = %.entry
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @0, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @1, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont
-
-ifcont:                                           ; preds = %else, %then
-  %2 = load i32, i32* %a, align 4
-  %3 = icmp ne i32 %2, 10
-  br i1 %3, label %then1, label %else2
-
-then1:                                            ; preds = %ifcont
-  br label %ifcont3
-
-else2:                                            ; preds = %ifcont
-  call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @2, i32 0, i32 0))
-  call void @exit(i32 1)
-  br label %ifcont3
-
-ifcont3:                                          ; preds = %else2, %then1
-  br label %return
-
-return:                                           ; preds = %ifcont3
-  ret void
-}
-
-declare void @_lcompilers_print_error(i8*, ...)
-
-declare void @exit(i32)
-
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)

--- a/tests/reference/llvm-expr14-b96b5b1.json
+++ b/tests/reference/llvm-expr14-b96b5b1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr14-b96b5b1.stdout",
-    "stdout_hash": "1c7f09339ec9e1be7e8a01d8a7977cbd38e4d2fd17c736228ef860fe",
+    "stdout_hash": "15764832892f7e0cd2a438b247a148564f5f83b3a00ca929bd9cc625",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr14-b96b5b1.stdout
+++ b/tests/reference/llvm-expr14-b96b5b1.stdout
@@ -1,50 +1,6 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-define void @test_boolean_comparison() {
-.entry:
-  %b1 = alloca i1, align 1
-  %b2 = alloca i1, align 1
-  %b3 = alloca i1, align 1
-  store i1 true, i1* %b1, align 1
-  store i1 true, i1* %b2, align 1
-  store i1 false, i1* %b3, align 1
-  %0 = load i1, i1* %b1, align 1
-  %1 = load i1, i1* %b2, align 1
-  %2 = zext i1 %0 to i32
-  %3 = zext i1 %1 to i32
-  %4 = icmp ugt i32 %2, %3
-  store i1 %4, i1* %b1, align 1
-  %5 = load i1, i1* %b1, align 1
-  %6 = load i1, i1* %b2, align 1
-  %7 = zext i1 %5 to i32
-  %8 = zext i1 %6 to i32
-  %9 = icmp eq i32 %7, %8
-  store i1 %9, i1* %b1, align 1
-  %10 = load i1, i1* %b2, align 1
-  %11 = load i1, i1* %b3, align 1
-  %12 = zext i1 %10 to i32
-  %13 = zext i1 %11 to i32
-  %14 = icmp ne i32 %12, %13
-  store i1 %14, i1* %b1, align 1
-  %15 = load i1, i1* %b2, align 1
-  %16 = load i1, i1* %b3, align 1
-  %17 = zext i1 %15 to i32
-  %18 = zext i1 %16 to i32
-  %19 = icmp uge i32 %17, %18
-  store i1 %19, i1* %b1, align 1
-  %20 = load i1, i1* %b2, align 1
-  %21 = load i1, i1* %b3, align 1
-  %22 = zext i1 %20 to i32
-  %23 = zext i1 %21 to i32
-  %24 = icmp ule i32 %22, %23
-  store i1 %24, i1* %b1, align 1
-  br label %return
-
-return:                                           ; preds = %.entry
-  ret void
-}
-
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)

--- a/tests/reference/llvm-lpython1-23c5987.json
+++ b/tests/reference/llvm-lpython1-23c5987.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-lpython1-23c5987.stdout",
-    "stdout_hash": "e159629de1a0c099150b091e961cc50a9388c3096ef63bc0d3aa12a1",
+    "stdout_hash": "15764832892f7e0cd2a438b247a148564f5f83b3a00ca929bd9cc625",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-lpython1-23c5987.stdout
+++ b/tests/reference/llvm-lpython1-23c5987.stdout
@@ -1,69 +1,6 @@
 ; ModuleID = 'LFortran'
 source_filename = "LFortran"
 
-@0 = private unnamed_addr constant [2 x i8] c" \00", align 1
-@1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@2 = private unnamed_addr constant [6 x i8] c"%hi%s\00", align 1
-@3 = private unnamed_addr constant [2 x i8] c" \00", align 1
-@4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@5 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1
-@6 = private unnamed_addr constant [2 x i8] c" \00", align 1
-@7 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@8 = private unnamed_addr constant [7 x i8] c"%lld%s\00", align 1
-@9 = private unnamed_addr constant [2 x i8] c" \00", align 1
-@10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@11 = private unnamed_addr constant [7 x i8] c"%hhi%s\00", align 1
-
-define void @test_i16() {
-.entry:
-  %i = alloca i16, align 2
-  store i16 4, i16* %i, align 2
-  %0 = load i16, i16* %i, align 2
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0), i16 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
-  br label %return
-
-return:                                           ; preds = %.entry
-  ret void
-}
-
-define void @test_i32() {
-.entry:
-  %i = alloca i32, align 4
-  store i32 3, i32* %i, align 4
-  %0 = load i32, i32* %i, align 4
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i32 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  br label %return
-
-return:                                           ; preds = %.entry
-  ret void
-}
-
-define void @test_i64() {
-.entry:
-  %i = alloca i64, align 8
-  store i64 2, i64* %i, align 4
-  %0 = load i64, i64* %i, align 4
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @8, i32 0, i32 0), i64 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
-  br label %return
-
-return:                                           ; preds = %.entry
-  ret void
-}
-
-define void @test_i8() {
-.entry:
-  %i = alloca i8, align 1
-  store i8 5, i8* %i, align 1
-  %0 = load i8, i8* %i, align 1
-  call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @11, i32 0, i32 0), i8 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
-  br label %return
-
-return:                                           ; preds = %.entry
-  ret void
-}
-
-declare void @_lfortran_printf(i8*, ...)
-
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)

--- a/tests/reference/wat-bool1-234bcd1.json
+++ b/tests/reference/wat-bool1-234bcd1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-bool1-234bcd1.stdout",
-    "stdout_hash": "4242c61474348c2a5f3f56b1ecc82284002826a13771b542875d6727",
+    "stdout_hash": "d1d2d4809bca0f1a1692d83c8c7a2829d8a7f3ecf1b42616297d6011",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-bool1-234bcd1.stdout
+++ b/tests/reference/wat-bool1-234bcd1.stdout
@@ -8,8 +8,10 @@
     (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
     (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
     (global $0 (mut i32) (i32.const 0))
-    (global $1 (mut f32) (f32.const 0.000000))
-    (global $2 (mut f64) (f64.const 0.000000))
+    (global $1 (mut i32) (i32.const 0))
+    (global $2 (mut i64) (i64.const 0))
+    (global $3 (mut f32) (f32.const 0.000000))
+    (global $4 (mut f64) (f64.const 0.000000))
     (func $2 (type 2) (param) (result)
         (local)
         call 3

--- a/tests/reference/wat-expr14-5e0cb96.json
+++ b/tests/reference/wat-expr14-5e0cb96.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-expr14-5e0cb96.stdout",
-    "stdout_hash": "95bfdfb006fa1e8d273e861935d577d05178fcb4d57958b72489476d",
+    "stdout_hash": "d8fc2f3d3de0b2d66baa6f91cca16cb6c68e4eb8c7020fe2c881fe97",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-expr14-5e0cb96.stdout
+++ b/tests/reference/wat-expr14-5e0cb96.stdout
@@ -5,41 +5,19 @@
     (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
     (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
     (global $0 (mut i32) (i32.const 0))
-    (global $1 (mut f32) (f32.const 0.000000))
-    (global $2 (mut f64) (f64.const 0.000000))
+    (global $1 (mut i32) (i32.const 0))
+    (global $2 (mut i64) (i64.const 0))
+    (global $3 (mut f32) (f32.const 0.000000))
+    (global $4 (mut f64) (f64.const 0.000000))
     (func $2 (type 2) (param) (result)
-        (local i32 i32 i32)
-        i32.const 1
-        local.set 0
-        i32.const 1
-        local.set 1
+        (local)
         i32.const 0
-        local.set 2
-        local.get 0
-        local.get 1
-        i32.gt_s
-        local.set 0
-        local.get 0
-        local.get 1
-        i32.eq
-        local.set 0
-        local.get 1
-        local.get 2
-        i32.ne
-        local.set 0
-        local.get 1
-        local.get 2
-        i32.ge_s
-        local.set 0
-        local.get 1
-        local.get 2
-        i32.le_s
-        local.set 0
+        call 0
         return
     )
     (memory (;0;) 100 100)
     (export "memory" (memory 0))
-    (export "test_boolean_comparison" (func 2))
+    (export "_start" (func 2))
     (data (;0;) (i32.const 4) "\0c\00\00\00\01\00\00\00")
     (data (;1;) (i32.const 12) "    ")
     (data (;2;) (i32.const 16) "\18\00\00\00\01\00\00\00")

--- a/tests/reference/wat-expr2-8b17723.json
+++ b/tests/reference/wat-expr2-8b17723.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-expr2-8b17723.stdout",
-    "stdout_hash": "b62ef7eaec557c1ff9de775d59e525aa458c4e08550886cf02bddc94",
+    "stdout_hash": "d8fc2f3d3de0b2d66baa6f91cca16cb6c68e4eb8c7020fe2c881fe97",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-expr2-8b17723.stdout
+++ b/tests/reference/wat-expr2-8b17723.stdout
@@ -5,47 +5,19 @@
     (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
     (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
     (global $0 (mut i32) (i32.const 0))
-    (global $1 (mut f32) (f32.const 0.000000))
-    (global $2 (mut f64) (f64.const 0.000000))
+    (global $1 (mut i32) (i32.const 0))
+    (global $2 (mut i64) (i64.const 0))
+    (global $3 (mut f32) (f32.const 0.000000))
+    (global $4 (mut f64) (f64.const 0.000000))
     (func $2 (type 2) (param) (result)
-        (local i32 i32)
+        (local)
         i32.const 0
-        local.set 0
-        i32.const 1
-        local.set 1
-        local.get 0
-        local.get 1
-        i32.and
-        local.set 0
-        local.get 0
-        i32.const 1
-        i32.or
-        local.set 1
-        local.get 0
-        local.get 1
-        i32.or
-        local.set 0
-        local.get 0
-        local.get 1
-        local.get 1
-        i32.eq
-        i32.and
-        local.set 0
-        local.get 0
-        local.get 1
-        local.get 1
-        i32.ne
-        i32.and
-        local.set 0
-        local.get 1
-        local.get 1
-        i32.or
-        local.set 0
+        call 0
         return
     )
     (memory (;0;) 100 100)
     (export "memory" (memory 0))
-    (export "test_boolOp" (func 2))
+    (export "_start" (func 2))
     (data (;0;) (i32.const 4) "\0c\00\00\00\01\00\00\00")
     (data (;1;) (i32.const 12) "    ")
     (data (;2;) (i32.const 16) "\18\00\00\00\01\00\00\00")

--- a/tests/reference/wat-expr9-f73afd1.json
+++ b/tests/reference/wat-expr9-f73afd1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-expr9-f73afd1.stdout",
-    "stdout_hash": "4e4ced8afad1806ee0f6af7cf74883e0731953cb8e3d0c1b7ae65e2a",
+    "stdout_hash": "1abbbc8caa76776e7ddda21597370a9712e50ff185fe6a08664cbc7f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-expr9-f73afd1.stdout
+++ b/tests/reference/wat-expr9-f73afd1.stdout
@@ -11,8 +11,10 @@
     (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
     (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
     (global $0 (mut i32) (i32.const 0))
-    (global $1 (mut f32) (f32.const 0.000000))
-    (global $2 (mut f64) (f64.const 0.000000))
+    (global $1 (mut i32) (i32.const 0))
+    (global $2 (mut i64) (i64.const 0))
+    (global $3 (mut f32) (f32.const 0.000000))
+    (global $4 (mut f64) (f64.const 0.000000))
     (func $2 (type 2) (param) (result)
         (local)
         call 3

--- a/tests/reference/wat-loop1-e0046d4.json
+++ b/tests/reference/wat-loop1-e0046d4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-loop1-e0046d4.stdout",
-    "stdout_hash": "fffdd5e8fec36d87423d61052cc9fefdcce6bd7a6ad36be43b583dac",
+    "stdout_hash": "5cd6d36d0e2f64306dc046cb2fa7c828f42c87b8e2744d6caeced048",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-loop1-e0046d4.stdout
+++ b/tests/reference/wat-loop1-e0046d4.stdout
@@ -10,8 +10,10 @@
     (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
     (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
     (global $0 (mut i32) (i32.const 0))
-    (global $1 (mut f32) (f32.const 0.000000))
-    (global $2 (mut f64) (f64.const 0.000000))
+    (global $1 (mut i32) (i32.const 0))
+    (global $2 (mut i64) (i64.const 0))
+    (global $3 (mut f32) (f32.const 0.000000))
+    (global $4 (mut f64) (f64.const 0.000000))
     (func $2 (type 2) (param) (result)
         (local)
         call 3

--- a/tests/reference/wat-print_str-385e953.json
+++ b/tests/reference/wat-print_str-385e953.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-print_str-385e953.stdout",
-    "stdout_hash": "ee6eba6afb6649829e7fcb6fa46118d74384af5ecd2fe287de41e26e",
+    "stdout_hash": "c3299fcf8ea6913cbf134219e19baab77b171231e0794764a75afd2d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-print_str-385e953.stdout
+++ b/tests/reference/wat-print_str-385e953.stdout
@@ -8,8 +8,10 @@
     (import "wasi_snapshot_preview1" "proc_exit" (func (;0;) (type 0)))
     (import "wasi_snapshot_preview1" "fd_write" (func (;1;) (type 1)))
     (global $0 (mut i32) (i32.const 0))
-    (global $1 (mut f32) (f32.const 0.000000))
-    (global $2 (mut f64) (f64.const 0.000000))
+    (global $1 (mut i32) (i32.const 0))
+    (global $2 (mut i64) (i64.const 0))
+    (global $3 (mut f32) (f32.const 0.000000))
+    (global $4 (mut f64) (f64.const 0.000000))
     (func $2 (type 2) (param) (result)
         (local)
         call 3


### PR DESCRIPTION
For upcoming PR(s), I think I would be needing changes from both LPython and LFortran wasm backends. Hence this PR which syncs the backends.

Related https://github.com/lfortran/lfortran/pull/1475.