### PR TITLE
Restrict step size 0 in for loop

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -4493,6 +4493,10 @@ public:
         int64_t inc_int = 1;
         bool is_value_present = ASRUtils::extract_value(inc_value, inc_int);
         if (is_value_present) {
+            if (inc_int == 0) {
+                throw SemanticError("For loop increment should not be zero.", loc);
+            }
+
             // Loop end depends upon the sign of m_increment.
             // if inc > 0 then: loop_end -=1 else loop_end += 1
             ASR::binopType offset_op;


### PR DESCRIPTION
On master :
```
def f():
    i:i32 = 0
    for i in range(1,5,0):
        print(i)
    
f()

(lp) C:\Users\kunni\lpython>python try.py
Traceback (most recent call last):
  File "C:\Users\kunni\lpython\try.py", line 6, in <module>
    f()
  File "C:\Users\kunni\lpython\try.py", line 3, in f
    for i in range(1,5,0):
ValueError: range() arg 3 must not be zero

(lp) C:\Users\kunni\lpython>src\bin\lpython try.py
1
1
1
1
.... #Goes into infinite loop
```

On branch :
```
(lp) C:\Users\kunni\lpython>src\bin\lpython try.py
semantic error: For loop increment should not be zero.
 --> try.py:3:5 - 4:16
  |
3 |        for i in range(1,5,0):
  |        ^^^^^^^^^^^^^^^^^^^^^^...
```
