### PR TITLE
Initial implementation of the time module

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -9,6 +9,7 @@
 #include <float.h>
 #include <limits.h>
 #include <ctype.h>
+#include <sys/time.h>
 
 #include <libasr/runtime/lfortran_intrinsics.h>
 #include <libasr/config.h>
@@ -1185,6 +1186,16 @@ LFORTRAN_API void _lfortran_i64sys_clock(
         *max = 0;
     }
 #endif
+}
+
+LFORTRAN_API double _lfortran_time()
+{
+    struct timeval tv;
+    if (gettimeofday(&tv, NULL) != 0) {
+        /* Error occurred, return -1 */
+        return -1.0;
+    }
+    return (double)tv.tv_sec + (double)tv.tv_usec / 1000000.0;
 }
 
 LFORTRAN_API void _lfortran_sp_rand_num(float *x) {

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -10,7 +10,7 @@
 #include <limits.h>
 #include <ctype.h>
 
-#if defined(MSC_VER) || defined(MACH_)
+#if defined(_MSC_VER)
 #  include <winsock2.h>
 #endif
 
@@ -1193,7 +1193,7 @@ LFORTRAN_API void _lfortran_i64sys_clock(
 
 LFORTRAN_API double _lfortran_time()
 {
-#if defined(MSC_VER) || defined(MACH_)
+#if defined(_MSC_VER)
     FILETIME ft;
     ULARGE_INTEGER uli;
     GetSystemTimeAsFileTime(&ft);

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -10,6 +10,10 @@
 #include <limits.h>
 #include <ctype.h>
 
+#if defined(MSC_VER) || defined(MACH_)
+#  include <winsock2.h>
+#endif
+
 #include <libasr/runtime/lfortran_intrinsics.h>
 #include <libasr/config.h>
 
@@ -1189,9 +1193,18 @@ LFORTRAN_API void _lfortran_i64sys_clock(
 
 LFORTRAN_API double _lfortran_time()
 {
+#if defined(MSC_VER) || defined(MACH_)
+    FILETIME ft;
+    ULARGE_INTEGER uli;
+    GetSystemTimeAsFileTime(&ft);
+    uli.LowPart = ft.dwLowDateTime;
+    uli.HighPart = ft.dwHighDateTime;
+    return (double)uli.QuadPart / 10000000.0 - 11644473600.0;
+#else
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
     return (double)ts.tv_sec + (double)ts.tv_nsec / 1000000000.0;
+#endif
 }
 
 LFORTRAN_API void _lfortran_sp_rand_num(float *x) {

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -9,7 +9,6 @@
 #include <float.h>
 #include <limits.h>
 #include <ctype.h>
-#include <sys/time.h>
 
 #include <libasr/runtime/lfortran_intrinsics.h>
 #include <libasr/config.h>
@@ -1190,12 +1189,9 @@ LFORTRAN_API void _lfortran_i64sys_clock(
 
 LFORTRAN_API double _lfortran_time()
 {
-    struct timeval tv;
-    if (gettimeofday(&tv, NULL) != 0) {
-        /* Error occurred, return -1 */
-        return -1.0;
-    }
-    return (double)tv.tv_sec + (double)tv.tv_usec / 1000000.0;
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec / 1000000000.0;
 }
 
 LFORTRAN_API void _lfortran_sp_rand_num(float *x) {

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -208,6 +208,7 @@ LFORTRAN_API void _lfortran_i32sys_clock(
         int32_t *count, int32_t *rate, int32_t *max);
 LFORTRAN_API void _lfortran_i64sys_clock(
         uint64_t *count, int64_t *rate, int64_t *max);
+LFORTRAN_API double _lfortran_time();
 LFORTRAN_API void _lfortran_sp_rand_num(float *x);
 LFORTRAN_API void _lfortran_dp_rand_num(double *x);
 LFORTRAN_API int64_t _lpython_open(char *path, char *flags);

--- a/src/runtime/time.py
+++ b/src/runtime/time.py
@@ -1,0 +1,8 @@
+from lpython import f64, ccall
+
+def time() -> f64:
+    return _lfortran_time()
+
+@ccall
+def _lfortran_time() -> f64:
+    pass


### PR DESCRIPTION
For timing the benchmarks, we currently use the bash ```time``` command. But that only provides the time in millisecond. Python's time.time() method outputs time in a much higher precision.

I have implemented the ```time.time()``` method here using ```Unix Time``` after understanding [timemodule.c](https://github.com/python/cpython/blob/main/Modules/timemodule.c)

Here is an example:
```Python
import time

def fibonacci(n : i32) -> i32:
    if n <= 1:
        return n
    return fibonacci(n-1) + fibonacci(n-2)

def main():
    print("Current time : ", time.time())
    start_time : f64 = time.time()
    a : i32 = fibonacci(35)
    print("Answer: ", a)
    print("Time taken : ", time.time()-start_time)

main()
```
```console
(base) sarthak@pop-os:~/lpython$ python examples/timetest.py
Current time :  1680876878.893159
Answer:  9227465
Time taken :  2.6417429447174072
(base) sarthak@pop-os:~/lpython$ lpython examples/timetest.py
Current time :  1.68087688629948306e+09          // Decimal : 1680876886.29948306
Answer:  9227465
Time taken :  7.29780197143554688e-02            // Decimal : 0.0729780197143554688
```
I will add tests after a review.