### PR TITLE
Changes for supporting global array pointers in LLVM

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1589,6 +1589,12 @@ static inline bool is_fixed_size_array(ASR::dimension_t* m_dims, size_t n_dims) 
     return true;
 }
 
+static inline bool is_fixed_size_array(ASR::ttype_t* type) {
+    ASR::dimension_t* m_dims = nullptr;
+    size_t n_dims = ASRUtils::extract_dimensions_from_ttype(type, m_dims);
+    return ASRUtils::is_fixed_size_array(m_dims, n_dims);
+}
+
 static inline int64_t get_fixed_size_of_array(ASR::dimension_t* m_dims, size_t n_dims) {
     if( n_dims == 0 ) {
         return 0;
@@ -2348,6 +2354,12 @@ static inline bool is_dimension_empty(ASR::dimension_t* dims, size_t n) {
         }
     }
     return false;
+}
+
+static inline bool is_data_only_array(ASR::ttype_t* type, ASR::abiType abi) {
+    ASR::dimension_t* m_dims = nullptr;
+    size_t n_dims = ASRUtils::extract_dimensions_from_ttype(type, m_dims);
+    return (abi == ASR::abiType::BindC || !ASRUtils::is_dimension_empty(m_dims, n_dims));
 }
 
 static inline void insert_module_dependency(ASR::symbol_t* a,

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -1,3 +1,6 @@
+#ifndef LFORTRAN_PASS_INTRINSIC_FUNCTION_REGISTRY_H
+#define LFORTRAN_PASS_INTRINSIC_FUNCTION_REGISTRY_H
+
 #include <libasr/asr.h>
 #include <libasr/containers.h>
 #include <libasr/asr_utils.h>
@@ -513,3 +516,5 @@ inline std::string get_intrinsic_name(int x) {
 } // namespace ASRUtils
 
 } // namespace LCompilers
+
+#endif // LFORTRAN_PASS_INTRINSIC_FUNCTION_REGISTRY_H


### PR DESCRIPTION
Corresponding LFortran PR - https://github.com/lfortran/lfortran/pull/1540