### PR TITLE
Never inline intrinsic functions

### DIFF
--- a/src/libasr/pass/inline_function_calls.cpp
+++ b/src/libasr/pass/inline_function_calls.cpp
@@ -153,12 +153,6 @@ public:
                 ASR::ExternalSymbol_t* called_sym_ext = ASR::down_cast<ASR::ExternalSymbol_t>(x.m_name);
                 ASR::symbol_t* f_sym = ASRUtils::symbol_get_past_external(called_sym_ext->m_external);
                 ASR::Function_t* f = ASR::down_cast<ASR::Function_t>(f_sym);
-
-                // Never inline intrinsic functions
-                if( ASRUtils::is_intrinsic_function2(f) ) {
-                    return ;
-                }
-
                 ASR::symbol_t* called_sym = x.m_name;
 
                 // TODO: Handle later
@@ -217,6 +211,12 @@ public:
             return ;
         }
 
+        // Never inline intrinsic functions
+        if( ASRUtils::is_intrinsic_function2(func) ||
+            startswith(func->m_name,"_lfortran_") ) {
+            return ;
+        }
+        
         if( !is_fast && !ASRUtils::get_FunctionType(func)->m_inline ) {
             return ;
         }

--- a/src/libasr/pass/inline_function_calls.cpp
+++ b/src/libasr/pass/inline_function_calls.cpp
@@ -153,6 +153,12 @@ public:
                 ASR::ExternalSymbol_t* called_sym_ext = ASR::down_cast<ASR::ExternalSymbol_t>(x.m_name);
                 ASR::symbol_t* f_sym = ASRUtils::symbol_get_past_external(called_sym_ext->m_external);
                 ASR::Function_t* f = ASR::down_cast<ASR::Function_t>(f_sym);
+
+                // Never inline intrinsic functions
+                if( ASRUtils::is_intrinsic_function2(f) ) {
+                    return ;
+                }
+
                 ASR::symbol_t* called_sym = x.m_name;
 
                 // TODO: Handle later
@@ -211,12 +217,6 @@ public:
             return ;
         }
 
-        // Never inline intrinsic functions
-        if( ASRUtils::is_intrinsic_function2(func) ||
-            startswith(func->m_name,"_lfortran_") ) {
-            return ;
-        }
-        
         if( !is_fast && !ASRUtils::get_FunctionType(func)->m_inline ) {
             return ;
         }
@@ -344,6 +344,11 @@ public:
             } else {
                 success = false;
             }
+        }
+
+        // Never Inline BindC Function
+        if(ASRUtils::get_FunctionType(func)->m_abi == ASR::abiType::BindC){
+            return;
         }
 
         if( success ) {


### PR DESCRIPTION
Fixes #1698 
```Python
import time
import random
import math

print(time.time())
print(random.randrange(10,20))
print(random.random())
print(math.atanh(0.90))
```
Main:
```console
(lp) sarthak@pop-os:~/lpython$ lpython --fast examples/time.py
0.00000000000000000e+00
0
9.53282412436823800e-130
9.53282412436823800e-130
```
On branch:
```console
(lp) sarthak@pop-os:~/lpython_new/lpython$ src/bin/lpython --fast examples/hi.py
1.68139046414960361e+09
13
3.94382926819093038e-01
1.47221948958322035e+00
```