### PR TITLE
Make sizeof() work for external symbols

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6567,13 +6567,14 @@ public:
                 ASR::ttype_t* arg_type = nullptr;
                 if( ASR::is_a<ASR::Var_t>(*args[0].m_value) ) {
                     ASR::Var_t* arg_Var = ASR::down_cast<ASR::Var_t>(args[0].m_value);
-                    if( ASR::is_a<ASR::Variable_t>(*arg_Var->m_v) ) {
-                        arg_type = ASR::down_cast<ASR::Variable_t>(arg_Var->m_v)->m_type;
-                    } else if( ASR::is_a<ASR::StructType_t>(*arg_Var->m_v) ) {
+                    ASR::symbol_t *arg_Var2 = ASRUtils::symbol_get_past_external(arg_Var->m_v);
+                    if( ASR::is_a<ASR::Variable_t>(*arg_Var2) ) {
+                        arg_type = ASR::down_cast<ASR::Variable_t>(arg_Var2)->m_type;
+                    } else if( ASR::is_a<ASR::StructType_t>(*arg_Var2) ) {
                         arg_type = ASRUtils::TYPE(ASR::make_Struct_t(al, x.base.base.loc,
-                                        arg_Var->m_v, nullptr, 0));
+                                        arg_Var2, nullptr, 0));
                     } else {
-                        throw SemanticError("Symbol " + std::to_string(arg_Var->m_v->type) +
+                        throw SemanticError("Symbol " + std::to_string(arg_Var2->type) +
                                             " is not yet supported in sizeof.",
                                             x.base.base.loc);
                     }


### PR DESCRIPTION
Fixes #1728.