### PR TITLE
Register more Intrinsic Trig Functions

### DIFF
--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -2177,6 +2177,9 @@ R"(#include <stdio.h>
             SET_INTRINSIC_NAME(Asin, "asin");
             SET_INTRINSIC_NAME(Acos, "acos");
             SET_INTRINSIC_NAME(Atan, "atan");
+            SET_INTRINSIC_NAME(Sinh, "sinh");
+            SET_INTRINSIC_NAME(Cosh, "cosh");
+            SET_INTRINSIC_NAME(Tanh, "tanh");
             SET_INTRINSIC_NAME(Abs, "abs");
             default : {
                 throw LCompilersException("IntrinsicFunction: `"

--- a/src/libasr/codegen/asr_to_julia.cpp
+++ b/src/libasr/codegen/asr_to_julia.cpp
@@ -1892,6 +1892,9 @@ public:
             SET_INTRINSIC_NAME(Asin, "asin");
             SET_INTRINSIC_NAME(Acos, "acos");
             SET_INTRINSIC_NAME(Atan, "atan");
+            SET_INTRINSIC_NAME(Sinh, "sinh");
+            SET_INTRINSIC_NAME(Cosh, "cosh");
+            SET_INTRINSIC_NAME(Tanh, "tanh");
             SET_INTRINSIC_NAME(Abs, "abs");
             default : {
                 throw LCompilersException("IntrinsicFunction: `"

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -45,6 +45,9 @@ enum class IntrinsicFunctions : int64_t {
     Asin,
     Acos,
     Atan,
+    Sinh,
+    Cosh,
+    Tanh,
     Gamma,
     LogGamma,
     Abs,
@@ -348,6 +351,9 @@ create_trig(Tan, tan, tan)
 create_trig(Asin, asin, asin)
 create_trig(Acos, acos, acos)
 create_trig(Atan, atan, atan)
+create_trig(Sinh, sinh, sinh)
+create_trig(Cosh, cosh, cosh)
+create_trig(Tanh, tanh, tanh)
 
 namespace Abs {
 
@@ -878,6 +884,12 @@ namespace IntrinsicFunctionRegistry {
             &Acos::instantiate_Acos},
         {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::Atan),
             &Atan::instantiate_Atan},
+        {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::Sinh),
+            &Sinh::instantiate_Sinh},
+        {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::Cosh),
+            &Cosh::instantiate_Cosh},
+        {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::Tanh),
+            &Tanh::instantiate_Tanh},
         {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::Abs),
             &Abs::instantiate_Abs},
         {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::Any),
@@ -900,6 +912,12 @@ namespace IntrinsicFunctionRegistry {
             "acos"},
         {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::Atan),
             "atan"},
+        {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::Sinh),
+            "sinh"},
+        {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::Cosh),
+            "cosh"},
+        {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::Tanh),
+            "tanh"},
         {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::Abs),
             "abs"},
         {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::ListIndex),
@@ -916,6 +934,9 @@ namespace IntrinsicFunctionRegistry {
                 {"asin", {&Asin::create_Asin, &Asin::eval_Asin}},
                 {"acos", {&Acos::create_Acos, &Acos::eval_Acos}},
                 {"atan", {&Atan::create_Atan, &Atan::eval_Atan}},
+                {"sinh", {&Sinh::create_Sinh, &Sinh::eval_Sinh}},
+                {"cosh", {&Cosh::create_Cosh, &Cosh::eval_Cosh}},
+                {"tanh", {&Tanh::create_Tanh, &Tanh::eval_Tanh}},
                 {"abs", {&Abs::create_Abs, &Abs::eval_Abs}},
                 {"any", {&Any::create_Any, &Any::eval_Any}},
                 {"list.index", {&ListIndex::create_ListIndex, &ListIndex::eval_list_index}},
@@ -990,6 +1011,9 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(Asin)
         INTRINSIC_NAME_CASE(Acos)
         INTRINSIC_NAME_CASE(Atan)
+        INTRINSIC_NAME_CASE(Sinh)
+        INTRINSIC_NAME_CASE(Cosh)
+        INTRINSIC_NAME_CASE(Tanh)
         INTRINSIC_NAME_CASE(Gamma)
         INTRINSIC_NAME_CASE(LogGamma)
         INTRINSIC_NAME_CASE(Abs)

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6691,7 +6691,7 @@ public:
 
         if (!s) {
             std::set<std::string> not_cpython_builtin = {
-                "sin", "cos", "gamma", "tan", "asin", "acos", "atan"
+                "sin", "cos", "gamma", "tan", "asin", "acos", "atan", "sinh", "cosh", "tanh"
             };
             if (ASRUtils::IntrinsicFunctionRegistry::is_intrinsic_function(call_name)
              && not_cpython_builtin.find(call_name) == not_cpython_builtin.end()) {


### PR DESCRIPTION
`Sinh`, `Cosh`, `Tanh` are intrinsic built in [functions ](https://www.tutorialspoint.com/fortran/fortran_intrinsic_functions.htm#:~:text=Fortran%20-%20Intrinsic%20Functions%201%20Numeric%20Functions%202,7%20Kind%20Functions%208%20Logical%20Functions%20More%20items)in Fortran. They can be directly added in Lfortran as well.

Example - **Sinh** results 
```
import cmath
import math
def f():
    print(math.sin(1.5))
    print(cmath.sinh(complex(1,2)))
f()
(lp) C:\Users\kunni\lpython>python try.py
0.9974949866040544
(-0.4890562590412937+1.4031192506220405j)

(lp) C:\Users\kunni\lpython>src\bin\lpython try.py
9.97494986604054446e-01
(-0.489056,1.403119)
```
