### PR TITLE
WASM: Unescape string

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -295,7 +295,7 @@ RUN(NAME exit_02b    FAIL    LABELS cpython llvm c wasm wasm_x86 wasm_x64)
 RUN(NAME exit_02c    FAIL    LABELS cpython llvm c)
 
 # Test all four backends
-RUN(NAME print_01            LABELS cpython llvm c wasm) # wasm not yet supports sep and end keywords
+RUN(NAME print_01            LABELS cpython llvm c wasm wasm_x86 wasm_x64)
 RUN(NAME print_03            LABELS x86 c wasm wasm_x86 wasm_x64) # simple test case specifically for x86, wasm_x86 and wasm_x64
 RUN(NAME print_04            LABELS cpython llvm c)
 RUN(NAME print_06            LABELS cpython llvm c)

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -2084,8 +2084,9 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
     }
 
     void visit_StringConstant(const ASR::StringConstant_t &x) {
-        emit_string(x.m_s);
-        m_wa.emit_i32_const(m_string_to_iov_loc_map[x.m_s]);
+        std::string s = unescape_string(m_al, x.m_s);
+        emit_string(s);
+        m_wa.emit_i32_const(m_string_to_iov_loc_map[s]);
     }
 
     void visit_ArrayConstant(const ASR::ArrayConstant_t &x) {


### PR DESCRIPTION
Expected:
```bash
$ lpython integration_tests/print_01.py                          
Hello World!
a,b
a-+-+-b-+-+-c
d=e=f+
x*
y*
z!!1:2
LCompilers LPython
```
Main branch:
```bash
$ lpython integration_tests/print_01.py --backend wasm -o tmp.out
$ wasmtime tmp.out                                               
Hello World!
a,b
a-+-+-b-+-+-c
d=e=f+\nx*\ny*\nz!!1:2
LCompilers LPython
```

PR branch:
```bash
$ lpython integration_tests/print_01.py --backend wasm -o tmp.out     
$ wasmtime tmp.out
Hello World!
a,b
a-+-+-b-+-+-c
d=e=f+
x*
y*
z!!1:2
LCompilers LPython
```
