### PR TITLE
Add `list.reverse` intrinsic function

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1929,6 +1929,18 @@ public:
         tmp = list_api->index(plist, item, asr_el_type, *module);
     }
 
+    void generate_ListReverse(ASR::expr_t* m_arg) {
+        ASR::ttype_t* asr_el_type = ASRUtils::get_contained_type(ASRUtils::expr_type(m_arg));
+        int64_t ptr_loads_copy = ptr_loads;
+        ptr_loads = 0;
+        this->visit_expr(*m_arg);
+        llvm::Value* plist = tmp;
+
+        ptr_loads = !LLVM::is_llvm_struct(asr_el_type);
+        ptr_loads = ptr_loads_copy;
+        list_api->reverse(plist, *module);
+    }
+
     void visit_IntrinsicFunction(const ASR::IntrinsicFunction_t& x) {
         switch (static_cast<ASRUtils::IntrinsicFunctions>(x.m_intrinsic_id)) {
             case ASRUtils::IntrinsicFunctions::ListIndex: {
@@ -1945,6 +1957,10 @@ public:
                     }
                 }
                 break ;
+            }
+            case ASRUtils::IntrinsicFunctions::ListReverse: {
+                generate_ListReverse(x.m_args[0]);
+                break;
             }
             default: {
                 throw CodeGenError( ASRUtils::IntrinsicFunctionRegistry::

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2626,6 +2626,63 @@ namespace LCompilers {
         shift_end_point_by_one(list);
     }
 
+    void LLVMList::reverse(llvm::Value* list, llvm::Module& module) {
+
+        /* Equivalent in C++:
+         *
+         * int i = 0;
+         * int j = end_point - 1;
+         * 
+         * tmp;
+         *
+         * while(j > i) {
+         *      tmp = list[i];
+         *      list[i] = list[j];
+         *      list[j] = tmp;
+         *      i = i + 1;
+         *      j = j - 1;
+         *  }
+         */
+
+        llvm::Value* end_point = LLVM::CreateLoad(*builder,
+                                        get_pointer_to_current_end_point(list));
+
+        llvm::Type* pos_type = llvm::Type::getInt32Ty(context);
+        llvm::AllocaInst *i = builder->CreateAlloca(pos_type, nullptr);
+        LLVM::CreateStore(*builder, llvm::ConstantInt::get(
+                                    context, llvm::APInt(32, 0)), i);       // i = 0
+        llvm::AllocaInst *j = builder->CreateAlloca(pos_type, nullptr);
+        llvm::Value* tmp = nullptr;
+        tmp = builder->CreateSub(
+                    LLVM::CreateLoad(*builder, end_point),
+                    llvm::ConstantInt::get(context, llvm::APInt(32, 1)));
+        LLVM::CreateStore(*builder, tmp, j);        // j = end_point - 1
+
+        llvm::BasicBlock *loophead = llvm::BasicBlock::Create(context, "loop.head");
+        llvm::BasicBlock *loopbody = llvm::BasicBlock::Create(context, "loop.body");
+        llvm::BasicBlock *loopend = llvm::BasicBlock::Create(context, "loop.end");
+
+        // head
+        llvm_utils->start_new_block(loophead);
+        {
+            llvm::Value *cond = builder->CreateICmpSGT(j, LLVM::CreateLoad(*builder, i));
+            builder->CreateCondBr(cond, loopbody, loopend);
+        }
+
+        // body
+        llvm_utils->start_new_block(loopbody);
+        {
+            tmp = read_item(list, i, false, module, false);    // tmp = list[i]
+            write_item(list, i, LLVM::CreateLoad(*builder,
+                        read_item(list, j, false, module, false)), false, module);    // list[i] = list[j]
+            write_item(list, i, tmp, false, module);           // list[j] = tmp
+        }
+        builder->CreateBr(loophead);
+
+        // end
+        llvm_utils->start_new_block(loopend);
+    }
+
     llvm::Value* LLVMList::find_item_position(llvm::Value* list,
         llvm::Value* item, ASR::ttype_t* item_type, llvm::Module& module) {
         llvm::Type* pos_type = llvm::Type::getInt32Ty(context);

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -258,6 +258,8 @@ namespace LCompilers {
 
             void list_clear(llvm::Value* list);
 
+            void reverse(llvm::Value* list, llvm::Module& module);
+
             llvm::Value* find_item_position(llvm::Value* list,
                 llvm::Value* item, ASR::ttype_t* item_type,
                 llvm::Module& module);

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -53,6 +53,7 @@ enum class IntrinsicFunctions : int64_t {
     Abs,
     Any,
     ListIndex,
+    ListReverse,
     // ...
 };
 
@@ -590,6 +591,34 @@ static inline ASR::asr_t* create_ListIndex(Allocator& al, const Location& loc,
 
 } // namespace ListIndex
 
+namespace ListReverse {
+
+static inline ASR::expr_t *eval_list_reverse(Allocator &/*al*/,
+    const Location &/*loc*/, Vec<ASR::expr_t*>& /*args*/) {
+    // TODO: To be implemented for ListConstant expression
+    return nullptr;
+}
+
+static inline ASR::asr_t* create_ListReverse(Allocator& al, const Location& loc,
+    Vec<ASR::expr_t*>& args,
+    const std::function<void (const std::string &, const Location &)> err) {
+    if (args.size() != 1) {
+        err("list.reverse() takes no arguments", loc);
+    }
+
+    Vec<ASR::expr_t*> arg_values;
+    arg_values.reserve(al, args.size());
+    for( size_t i = 0; i < args.size(); i++ ) {
+        arg_values.push_back(al, ASRUtils::expr_value(args[i]));
+    }
+    ASR::expr_t* compile_time_value = eval_list_reverse(al, loc, arg_values);
+    return ASR::make_IntrinsicFunction_t(al, loc,
+            static_cast<int64_t>(ASRUtils::IntrinsicFunctions::ListReverse),
+            args.p, args.size(), 0, nullptr, compile_time_value);
+}
+
+} // namespace ListReverse
+
 namespace Any {
 
 static inline ASR::expr_t *eval_Any(Allocator & /*al*/,
@@ -921,7 +950,9 @@ namespace IntrinsicFunctionRegistry {
         {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::Abs),
             "abs"},
         {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::ListIndex),
-            "list.index"}
+            "list.index"},
+        {static_cast<int64_t>(ASRUtils::IntrinsicFunctions::ListReverse),
+            "list.reverse"}
     };
 
     static const std::map<std::string,
@@ -940,6 +971,7 @@ namespace IntrinsicFunctionRegistry {
                 {"abs", {&Abs::create_Abs, &Abs::eval_Abs}},
                 {"any", {&Any::create_Any, &Any::eval_Any}},
                 {"list.index", {&ListIndex::create_ListIndex, &ListIndex::eval_list_index}},
+                {"list.reverse", {&ListReverse::create_ListReverse, &ListReverse::eval_list_reverse}},
     };
 
     static inline bool is_intrinsic_function(const std::string& name) {
@@ -1019,6 +1051,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(Abs)
         INTRINSIC_NAME_CASE(Any)
         INTRINSIC_NAME_CASE(ListIndex)
+        INTRINSIC_NAME_CASE(ListReverse)
         default : {
             throw LCompilersException("pickle: intrinsic_id not implemented");
         }

--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -24,6 +24,7 @@ struct AttributeHandler {
             {"list@remove", &eval_list_remove},
             {"list@count", &eval_list_count},
             {"list@index", &eval_list_index},
+            {"list@reverse", &eval_list_reverse},
             {"list@clear", &eval_list_clear},
             {"list@insert", &eval_list_insert},
             {"list@pop", &eval_list_pop},
@@ -161,6 +162,20 @@ struct AttributeHandler {
         }
         ASRUtils::create_intrinsic_function create_function =
             ASRUtils::IntrinsicFunctionRegistry::get_create_function("list.index");
+        return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
+                                { throw SemanticError(msg, loc); });
+    }
+
+    static ASR::asr_t* eval_list_reverse(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &/*diag*/) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicFunctionRegistry::get_create_function("list.reverse");
         return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
                                 { throw SemanticError(msg, loc); });
     }


### PR DESCRIPTION
Currently gives an `Internal Compiler Error` at
```
File ".../lpython/src/libasr/asr_utils.h", line 39
    return ASR::down_cast<ASR::stmt_t>(f);
AssertFailed: is_a<T>(*f)
```