### PR TITLE
CI: Install and use lpython as a package

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -225,6 +225,8 @@ jobs:
       - name: PIP install required packages
         shell: bash -l {0}
         run: |
+            # Package lpynn has lpython_emulation as dependency
+            # Hence, it should by default install lpython_emulation
             python -m pip install lpynn numpy
 
       - name: PIP show installed packages
@@ -235,7 +237,6 @@ jobs:
       - name: Test PIP Packages with Python
         shell: bash -l {0}
         run: |
-            export PYTHONPATH=./src/runtime/lpython
             python integration_tests/test_pip_import_01.py
 
       - name: Test PIP Packages with LPython

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -227,7 +227,7 @@ jobs:
         run: |
             # Package lpynn has lpython_emulation as dependency
             # Hence, it should by default install lpython_emulation
-            python -m pip install lpynn numpy
+            python -m pip install lpython_emulation==0.0.1.8 lpynn==0.0.1.3 numpy==1.24.3
 
       - name: PIP show installed packages
         shell: bash -l {0}

--- a/integration_tests/test_pip_import_01.py
+++ b/integration_tests/test_pip_import_01.py
@@ -1,4 +1,5 @@
-from lpynn.perceptron import init_perceptron, print_perceptron, normalize_input_vectors, Perceptron, train_dataset
+from lpynn.perceptron import init_perceptron, print_perceptron, Perceptron, train_dataset
+from lpynn.utils import normalize_input_vectors
 from lpython import i32, f64
 
 def main0():


### PR DESCRIPTION
Using `pip install lpython_emulation`, we can now install and import `lpython` as a package. This PR updates the CI to use `lpython` installed via `pip` (previously we used `lpython` from the runtime library).