### PR TITLE
ASR: Support UnaryOp in attr bit_length()

### DIFF
--- a/integration_tests/test_bit_length.py
+++ b/integration_tests/test_bit_length.py
@@ -24,8 +24,25 @@ def ff3():
     x = -i16(one << i16(13))
     assert i32(x.bit_length()) == 14
 
+def ff4():
+    print((-100).bit_length())
+    print((-4).bit_length())
+
+    assert (-100).bit_length() == 7
+    assert (-4).bit_length() == 3
+
+def ff5():
+    a: i32
+    a = 100
+    print((-a).bit_length())
+    print((-(-(-(-a)))).bit_length())
+
+    assert (-a).bit_length() == 7
+    assert (-(-(-(-a)))).bit_length() == 7
 
 ff()
 ff1()
 ff2()
 ff3()
+ff4()
+ff5()

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -1604,7 +1604,7 @@ R"(#include <stdio.h>
         self().visit_expr(*x.m_arg);
         int expr_precedence = last_expr_precedence;
         last_expr_precedence = 3;
-        if (expr_precedence <= last_expr_precedence) {
+        if (expr_precedence < last_expr_precedence) {
             src = "-" + src;
         } else {
             src = "-(" + src + ")";

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6531,6 +6531,17 @@ public:
                 }
                 tmp = make_call_helper(al, st, current_scope, args, call_name, x.base.base.loc);
                 return;
+            } else if (AST::is_a<AST::UnaryOp_t>(*at->m_value)) {
+                AST::UnaryOp_t* uop = AST::down_cast<AST::UnaryOp_t>(at->m_value);
+                visit_UnaryOp(*uop);
+                Vec<ASR::expr_t*> eles;
+                eles.reserve(al, x.n_args);
+                for (size_t i=0; i<x.n_args; i++) {
+                    eles.push_back(al, args[i].m_value);
+                }
+                ASR::expr_t* expr = ASR::down_cast<ASR::expr_t>(tmp);
+                handle_attribute(expr, at->m_attr, x.base.base.loc, eles);
+                return;
             } else if (AST::is_a<AST::ConstantInt_t>(*at->m_value)) {
                 if (std::string(at->m_attr) == std::string("bit_length")) {
                     //bit_length() attribute:


### PR DESCRIPTION
fixes https://github.com/lcompilers/lpython/issues/1749.