### PR TITLE
Rename the @jit decorator to @lpython

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -542,4 +542,4 @@ RUN(NAME intrinsics_01     LABELS cpython llvm) # any
 COMPILE(NAME import_order_01     LABELS cpython llvm c) # any
 
 # Jit
-RUN(NAME test_jit_01       LABELS cpython)
+RUN(NAME test_lpython_decorator       LABELS cpython)

--- a/integration_tests/test_lpython_decorator.py
+++ b/integration_tests/test_lpython_decorator.py
@@ -1,7 +1,7 @@
 from numpy import array
-from lpython import i32, f64, jit
+from lpython import i32, f64, lpython
 
-@jit
+@lpython
 def fast_sum(n: i32, x: f64[:]) -> f64:
     s: f64 = 0.0
     i: i32

--- a/src/runtime/lpython/lpython.py
+++ b/src/runtime/lpython/lpython.py
@@ -525,7 +525,16 @@ def ccallable(f):
 def ccallback(f):
     return f
 
-class jit:
+class lpython:
+    """
+    The @lpython decorator compiles a given function using LPython.
+
+    The decorator should be used from CPython mode, i.e., when the module is
+    being run using CPython. When possible, it is recommended to use LPython
+    for the main program, and use the @cpython decorator from the LPython mode
+    to access CPython features that are not supported by LPython.
+    """
+
     def __init__(self, function):
         def get_rtlib_dir():
             current_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Added inital docstring explaining the motivation. The term `jit` is not the right term for this decorator because we are not using JIT (=Just In Time) compilation, but rather AOT (=Ahead of Time) compilation, at runtime from CPython. The term `lpython` is better, as it conveys that we are using LPython to compile the function (ahead of time). It is also consistent with the `@cpython` decorator.