### PR TITLE
RTL: fix an issue with abs()

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -794,24 +794,33 @@ LFORTRAN_API char* _lfortran_int_to_str8(int64_t num)
 LFORTRAN_API int32_t _lpython_bit_length1(int8_t num)
 {
     int32_t res = 0;
-    num = abs(num);
-    for(; num; num >>= 1, res++);
+    num = abs((int)num);
+    while (num > 0) {
+        num = num >> 1;
+        res++;
+    }
     return res;
 }
 
 LFORTRAN_API int32_t _lpython_bit_length2(int16_t num)
 {
     int32_t res = 0;
-    num = abs(num);
-    for(; num; num >>= 1, res++);
+    num = abs((int)num);
+    while (num > 0) {
+        num = num >> 1;
+        res++;
+    }
     return res;
 }
 
 LFORTRAN_API int32_t _lpython_bit_length4(int32_t num)
 {
     int32_t res = 0;
-    num = abs(num);
-    for(; num; num >>= 1, res++);
+    num = abs((int)num);
+    while (num > 0) {
+        num = num >> 1;
+        res++;
+    }
     return res;
 }
 
@@ -819,7 +828,10 @@ LFORTRAN_API int32_t _lpython_bit_length8(int64_t num)
 {
     int32_t res = 0;
     num = llabs(num);
-    for(; num; num >>= 1, res++);
+    while (num > 0) {
+        num = num >> 1;
+        res++;
+    }
     return res;
 }
 
@@ -1114,7 +1126,7 @@ LFORTRAN_API int32_t _lfortran_ishft32(int32_t i, int32_t shift) {
     if(shift > 0) {
         return i << shift;
     } else if(shift < 0) {
-        return i >> abs(shift);
+        return i >> abs((int)shift);
     } else {
         return i;
     }


### PR DESCRIPTION
Previously the abs() was somehow returning a negative number, because we called it with an int8_t argument, but it was expecting "int" argument.

The other bug was that "num" in the for loop stayed at -1 forever. We fixed that by using the condition "num > 0". We also switched to a while loop which make it more readable.

Fixes #1825.