### PR TITLE
Introducing type() as an intrinsic function

### DIFF
--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -330,6 +330,7 @@ expr
     | PointerAssociated(expr ptr, expr? tgt, ttype type, expr? value)
 
     | IntrinsicFunctionSqrt(expr arg, ttype type, expr? value)
+    | TypeConstant(ttype type)
 
 
 -- `len` in Character:

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1969,6 +1969,17 @@ public:
         list_api->reverse(plist, asr_el_type, *module);
     }
 
+    void generate_Type(ASR::expr_t* m_arg) {
+        this->visit_expr_wrapper(m_arg, true);
+        llvm::Value* item = tmp;
+
+        // Get the LLVM type of the value
+        llvm::Type* llvmType = item->getType();
+
+        // Create an LLVM expression for the type
+        tmp = builder->CreateBitCast(tmp, llvmType);
+    }
+
     void visit_IntrinsicFunction(const ASR::IntrinsicFunction_t& x) {
         switch (static_cast<ASRUtils::IntrinsicFunctions>(x.m_intrinsic_id)) {
             case ASRUtils::IntrinsicFunctions::ListIndex: {
@@ -2030,6 +2041,19 @@ public:
             }
             case ASRUtils::IntrinsicFunctions::ListReverse: {
                 generate_ListReverse(x.m_args[0]);
+                break;
+            }
+            case ASRUtils::IntrinsicFunctions::Type: {
+                switch (x.m_overload_id) {
+                    case 0: {
+                        ASR::expr_t* m_arg = x.m_args[0];
+                        generate_Type(m_arg);
+                        break;
+                    }
+                    default: {
+                        throw CodeGenError("Type() only accepts one argument", x.base.base.loc);
+                    }
+                }
                 break;
             }
             default: {


### PR DESCRIPTION
**My goal through this pr is to implement the inbuilt type function in python as an intrinsic function** (for 1 argument only ... It can take up 2 as well as 3 arguments but those cases can be addressed after this pr through overloading).

```
(lf) anutosh491@spbhat68:~/lpython/lpython$ cat examples/expr2.py 
def main0():
    print(type('hi'))

main0()

# Not implemented yet in LPython:
#if __name__ == "__main__":
#    main()
(lf) anutosh491@spbhat68:~/lpython/lpython$ python examples/expr2.py 
<class 'str'>
```
My code doesn't give out the desired output as of now because I am not sure about a few things . I get the following 
```
(lf) anutosh491@spbhat68:~/lpython/lpython$ lpython examples/expr2.py 
1682743304
```