### PR TITLE
TEST: Update test to test input param modification

### DIFF
--- a/tests/errors/func_04.py
+++ b/tests/errors/func_04.py
@@ -1,4 +1,4 @@
 from lpython import i32
 
 def f(l: list[i32]):
-    l[5] = 5
+    l.append(5)

--- a/tests/reference/asr-func_04-eef2656.json
+++ b/tests/reference/asr-func_04-eef2656.json
@@ -2,12 +2,12 @@
     "basename": "asr-func_04-eef2656",
     "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/errors/func_04.py",
-    "infile_hash": "763216ad3cb1090dc322e63706d4f92be4e806b1fc2df6f160d02fd0",
+    "infile_hash": "f8a6eed44ebd1dee435e6db842a874c41b8ba2b13d88d16944a4d265",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-func_04-eef2656.stderr",
-    "stderr_hash": "c0ef482d68b30b03615927ecd02a30b14ff4d24b5673b7399671ee79",
+    "stderr_hash": "d1e5bb4b5356e57124ff34eea9e5b96ecc44d3bc8a1da4b0a7db5b4a",
     "returncode": 2
 }

--- a/tests/reference/asr-func_04-eef2656.stderr
+++ b/tests/reference/asr-func_04-eef2656.stderr
@@ -1,5 +1,5 @@
-semantic error: Assignment to an input function parameter `l` is not allowed
+semantic error: Modifying input function parameter `l` is not allowed
  --> tests/errors/func_04.py:4:5
   |
-4 |     l[5] = 5
-  |     ^ 
+4 |     l.append(5)
+  |     ^^^^^^^^^^^ 


### PR DESCRIPTION
Two tests `tests/errors/func_03.py` and `tests/errors/func_04.py` added in https://github.com/lcompilers/lpython/pull/1852 are similar/same. This updates one of the test to test param modification (Initially one of the test was param modification, I think I lost its changes during one of the rebase I performed).