### PR TITLE
Give an error message if function parameter is declared twice

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -3937,6 +3937,16 @@ public:
                 v = ASR::down_cast<ASR::symbol_t>(_tmp);
 
             }
+            if (current_scope->get_scope().find(arg_s) !=
+                    current_scope->get_scope().end()) {
+                ASR::symbol_t *orig_decl = current_scope->get_symbol(arg_s);
+                throw SemanticError(diag::Diagnostic(
+                    "Parameter is already declared",
+                    diag::Level::Error, diag::Stage::Semantic, {
+                        diag::Label("original declaration", {orig_decl->base.loc}, false),
+                        diag::Label("redeclaration", {v->base.loc}),
+                    }));
+            }
             current_scope->add_symbol(arg_s, v);
             args.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc,
                 v)));

--- a/tests/errors/func_06.py
+++ b/tests/errors/func_06.py
@@ -1,0 +1,7 @@
+def init_X(m:i32, n: i32, b: CPtr, m: i32) -> None:
+    B: Pointer[i16[m*n]] = c_p_pointer(b, i16[m*n])
+    i: i32
+    j: i32
+    for i in range(m):
+        for j in range(n):
+            B[i * n + j] = i16((i + j) % m)

--- a/tests/reference/asr-func_06-62e738c.json
+++ b/tests/reference/asr-func_06-62e738c.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-func_06-62e738c",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/func_06.py",
+    "infile_hash": "2b8a5fa5d38ad35eeec67177ab8848255901548fe929c964a9eefef1",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-func_06-62e738c.stderr",
+    "stderr_hash": "a97e6d8f812ec9e81cb4b0565dc2fd30f3bd194ccab41770962f6e32",
+    "returncode": 2
+}

--- a/tests/reference/asr-func_06-62e738c.stderr
+++ b/tests/reference/asr-func_06-62e738c.stderr
@@ -1,0 +1,8 @@
+semantic error: Parameter is already declared
+ --> tests/errors/func_06.py:1:12
+  |
+1 | def init_X(m:i32, n: i32, b: CPtr, m: i32) -> None:
+  |            ~~~~~ original declaration
+  |
+1 | def init_X(m:i32, n: i32, b: CPtr, m: i32) -> None:
+  |                                    ^^^^^^ redeclaration

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1098,6 +1098,10 @@ asr = true
 filename = "errors/func_05.py"
 asr = true
 
+[[test]]
+filename = "errors/func_06.py"
+asr = true
+
 # tests/runtime_errors
 [[test]]
 filename = "runtime_errors/test_list_01.py"


### PR DESCRIPTION
fixes https://github.com/lcompilers/lpython/issues/1849