### PR TITLE
Revert "Replace helper `floor()` function with `//` operator "

### DIFF
--- a/src/runtime/math.py
+++ b/src/runtime/math.py
@@ -5,6 +5,8 @@ pi: f64 = 3.141592653589793238462643383279502884197
 e: f64 = 2.718281828459045235360287471352662497757
 tau: f64 = 6.283185307179586
 
+# TODO: Change floor used inside functions implemented here to
+# floordiv operator (//) once the multiple import issue is fixed
 
 @overload
 def modf(x: f64) -> tuple[f64, f64]:
@@ -228,7 +230,7 @@ def comb(n: i32, k: i32) -> i32:
 
     if n < k or n < 0:
         return 0
-    return i32(factorial(n)//(factorial(k)*factorial(n-k)))
+    return i32(floor(factorial(n)/(factorial(k)*factorial(n-k))))
 
 
 def perm(n: i32, k: i32) -> i32:
@@ -239,7 +241,7 @@ def perm(n: i32, k: i32) -> i32:
 
     if n < k or n < 0:
         return 0
-    return i32(factorial(n)//factorial(n-k))
+    return i32(floor(factorial(n)/factorial(n-k)))
 
 
 def isqrt(n: i32) -> i32:
@@ -254,7 +256,7 @@ def isqrt(n: i32) -> i32:
     low = 0
     high = n+1
     while low + 1 < high:
-        mid = i32((low + high)//2)
+        mid = i32(floor((low + high)/2))
         if mid*mid <= n:
             low = mid
         else:
@@ -462,7 +464,7 @@ def mod(a: i32, b: i32) -> i32:
     """
     Returns a%b
     """
-    return a - i32(a//b)*b
+    return a - i32(floor(a/b))*b
 
 
 def gcd(a: i32, b: i32) -> i32:
@@ -500,7 +502,7 @@ def lcm(a: i32, b: i32) -> i32:
         b_ = -b_
     if a_*b_ == 0:
         return 0
-    return i32((a_*b_)//gcd(a_, b_))
+    return i32(floor((a_*b_)/gcd(a_, b_)))
 
 
 def copysign(x: f64, y: f64) -> f64:


### PR DESCRIPTION
Reverts lcompilers/lpython#1806

Fixes #1875.