### PR TITLE
Fix zero slice step

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -3469,7 +3469,8 @@ public:
                     throw SemanticError("slice indices must be integers or None", tmp->loc);
                 }
                 ASR::expr_t* val = ASRUtils::expr_value(ASRUtils::EXPR(tmp_step));
-                if (val != nullptr && ASR::down_cast<ASR::IntegerConstant_t>(val)->m_n == 0) {
+                int64_t const_value = 1;
+                if (ASRUtils::is_value_constant(val, const_value) && const_value == 0) {
                     throw SemanticError("slice step cannot be zero", tmp_step->loc);
                 }
                 ai.m_step = ASRUtils::EXPR(tmp);

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -3464,8 +3464,13 @@ public:
             }
             if (sl->m_step != nullptr) {
                 this->visit_expr(*sl->m_step);
+                ASR::asr_t *tmp_step = tmp;
                 if (!ASRUtils::is_integer(*ASRUtils::expr_type(ASRUtils::EXPR(tmp)))) {
                     throw SemanticError("slice indices must be integers or None", tmp->loc);
+                }
+                ASR::expr_t* val = ASRUtils::expr_value(ASRUtils::EXPR(tmp_step));
+                if (val != nullptr && ASR::down_cast<ASR::IntegerConstant_t>(val)->m_n == 0) {
+                    throw SemanticError("slice step cannot be zero", tmp_step->loc);
                 }
                 ai.m_step = ASRUtils::EXPR(tmp);
             }

--- a/tests/errors/test_list_slicing.py
+++ b/tests/errors/test_list_slicing.py
@@ -1,0 +1,8 @@
+from lpython import i32
+
+def test_slice_step_list():
+    l: list[i32]
+    l = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    print(l[0:10:0])
+
+test_slice_step_list()

--- a/tests/errors/test_str_slicing4.py
+++ b/tests/errors/test_str_slicing4.py
@@ -1,0 +1,6 @@
+def test_slice_step_str():
+    s: str
+    s = "abcd"
+    print(s[0:1:0])
+
+test_slice_step_str()

--- a/tests/reference/asr-test_list_slicing-984fbf0.json
+++ b/tests/reference/asr-test_list_slicing-984fbf0.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_list_slicing-984fbf0",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_list_slicing.py",
+    "infile_hash": "7dfe8cfa4697e4ce8bf18e24c5b11b969e8329febc711d83d2fba746",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_list_slicing-984fbf0.stderr",
+    "stderr_hash": "6763533f9c1730429d50f58b653595bfeef48c4d19943c36d037d023",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_list_slicing-984fbf0.stderr
+++ b/tests/reference/asr-test_list_slicing-984fbf0.stderr
@@ -1,0 +1,5 @@
+semantic error: slice step cannot be zero
+ --> tests/errors/test_list_slicing.py:6:18
+  |
+6 |     print(l[0:10:0])
+  |                  ^ 

--- a/tests/reference/asr-test_str_slicing4-a0c7a69.json
+++ b/tests/reference/asr-test_str_slicing4-a0c7a69.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_str_slicing4-a0c7a69",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_str_slicing4.py",
+    "infile_hash": "7bd3e8d21550f50244ee88e383dbd42cde33f03c516cfcaaeaaadd71",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_str_slicing4-a0c7a69.stderr",
+    "stderr_hash": "a5dd047df86649936606a0b134d10e76c6aacb224319be4aefd64bfe",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_str_slicing4-a0c7a69.stderr
+++ b/tests/reference/asr-test_str_slicing4-a0c7a69.stderr
@@ -1,0 +1,5 @@
+semantic error: slice step cannot be zero
+ --> tests/errors/test_str_slicing4.py:4:17
+  |
+4 |     print(s[0:1:0])
+  |                 ^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -714,6 +714,14 @@ filename = "errors/test_str_slicing3.py"
 asr = true
 
 [[test]]
+filename = "errors/test_str_slicing4.py"
+asr = true
+
+[[test]]
+filename = "errors/test_list_slicing.py"
+asr = true
+
+[[test]]
 filename = "errors/test_annassign_type_mismatch.py"
 asr = true
 


### PR DESCRIPTION
Fixes #1833.
I have added the check for any slice step. This holds for strings and lists.
Are there places where zero step is allowed? (I don't think so.)