### PR TITLE
Accept shape in ``c_p_pointer`` if target is an array

### DIFF
--- a/integration_tests/bindc_02.py
+++ b/integration_tests/bindc_02.py
@@ -1,8 +1,8 @@
 from lpython import c_p_pointer, CPtr, pointer, i16, Pointer, empty_c_void_p
-from numpy import empty, int16
+from numpy import empty, int16, array
 
 queries: CPtr = empty_c_void_p()
-x: Pointer[i16[:]] = c_p_pointer(queries, i16[:])
+x: Pointer[i16[:]] = c_p_pointer(queries, i16[:], array([1]))
 print(queries, x)
 
 def f():
@@ -17,7 +17,7 @@ def f():
     assert yptr1[0] == i16(1)
     assert yptr1[1] == i16(2)
 
-    yptr1 = c_p_pointer(yq, i16[:])
+    yptr1 = c_p_pointer(yq, i16[:], array([2]))
 
     print(yq, yptr1)
 

--- a/integration_tests/bindc_03.py
+++ b/integration_tests/bindc_03.py
@@ -2,6 +2,7 @@ from lpython import (c_p_pointer, CPtr, pointer, i32,
                     Pointer, ccall, p_c_pointer, dataclass,
                     ccallable, empty_c_void_p, cptr_to_u64,
                     u64_to_cptr, u64)
+from numpy import array
 
 @dataclass
 class ArrayWrapped:
@@ -22,7 +23,7 @@ def get_array(size: i32) -> CPtr:
 def f(q_void: CPtr) -> None:
     i: i32
     el: i32
-    q: Pointer[i32[:]] = c_p_pointer(q_void, i32[:])
+    q: Pointer[i32[:]] = c_p_pointer(q_void, i32[:], array([10]))
     for i in range(10):
         q2: CPtr
         p_c_pointer(pointer(q[i]), q2)
@@ -35,7 +36,7 @@ def f(q_void: CPtr) -> None:
 def h(q_void: CPtr) -> None:
     i: i32
     el: i32
-    q: Pointer[i32[:]] = c_p_pointer(q_void, i32[:])
+    q: Pointer[i32[:]] = c_p_pointer(q_void, i32[:], array([10]))
     for i in range(10):
         # TODO: Use q[i] directly in the assert.
         el = q[i]

--- a/integration_tests/bindc_07.py
+++ b/integration_tests/bindc_07.py
@@ -1,5 +1,5 @@
 from lpython import CPtr, i64, sizeof, i32, i16, i8, ccall, c_p_pointer, empty_c_void_p, Pointer, pointer
-from numpy import empty, int64
+from numpy import empty, int64, array
 
 @ccall
 def _lfortran_malloc(size: i32) -> CPtr:
@@ -13,12 +13,12 @@ def allocate_memory(size: i32) -> tuple[CPtr, CPtr, CPtr, CPtr]:
     return array1, array2, array3, array4
 
 def sum_arrays(array1: CPtr, array2: CPtr, array3: CPtr, array4: CPtr, size: i32):
-    iarray1: Pointer[i8[size]] = c_p_pointer(array1, i8[size])
-    iarray2: Pointer[i16[size]] = c_p_pointer(array2, i16[size])
-    iarray3: Pointer[i32[size]] = c_p_pointer(array3, i32[size])
-    iarray4: Pointer[i64[size]] = c_p_pointer(array4, i64[size])
+    iarray1: Pointer[i8[:]] = c_p_pointer(array1, i8[:], array([size]))
+    iarray2: Pointer[i16[:]] = c_p_pointer(array2, i16[:], array([size]))
+    iarray3: Pointer[i32[:]] = c_p_pointer(array3, i32[:], array([size]))
+    iarray4: Pointer[i64[:]] = c_p_pointer(array4, i64[:], array([size]))
     sum_array_cptr: CPtr = _lfortran_malloc(size * i32(sizeof(i64)))
-    sum_array: Pointer[i64[size]] = c_p_pointer(sum_array_cptr, i64[size])
+    sum_array: Pointer[i64[:]] = c_p_pointer(sum_array_cptr, i64[:], array([size]))
     i: i32
 
     for i in range(size):

--- a/integration_tests/bindc_08.py
+++ b/integration_tests/bindc_08.py
@@ -1,7 +1,7 @@
 # file: main.py
 from lpython import CPtr, i32, dataclass, c_p_pointer, Pointer, empty_c_void_p, p_c_pointer
 
-from numpy import empty
+from numpy import empty, array
 
 @dataclass
 class Foo:
@@ -9,7 +9,7 @@ class Foo:
      y: i32
 
 def init(foos_ptr: CPtr) -> None:
-    foos: Pointer[Foo[1]] = c_p_pointer(foos_ptr, Foo[1])
+    foos: Pointer[Foo[:]] = c_p_pointer(foos_ptr, Foo[:], array([1]))
     foos[0] = Foo(3, 2)
 
 def main() -> None:

--- a/integration_tests/expr_16.py
+++ b/integration_tests/expr_16.py
@@ -1,11 +1,12 @@
 from lpython import f64, Pointer, c_p_pointer, ccall, i32, CPtr, sizeof
+from numpy import array
 
 @ccall
 def _lfortran_malloc(size: i32) -> CPtr:
     pass
 
 def foo(xs_ptr: CPtr, length: i32) -> None:
-    xs: Pointer[f64[length]] = c_p_pointer(xs_ptr, f64[length])
+    xs: Pointer[f64[:]] = c_p_pointer(xs_ptr, f64[:], array([length]))
     xs[0] = 3.0
     xs[1] = 4.0
 
@@ -13,7 +14,7 @@ def main() -> None:
     length: i32 = 32
     xs_ptr: CPtr = _lfortran_malloc(length * i32(sizeof(f64)))
     foo(xs_ptr, length)
-    t: Pointer[f64[:]] = c_p_pointer(xs_ptr, f64[:])
+    t: Pointer[f64[:]] = c_p_pointer(xs_ptr, f64[:], array([32]))
     print(t[0], t[1])
     assert t[0] == 3.0
     assert t[1] == 4.0

--- a/integration_tests/structs_13.py
+++ b/integration_tests/structs_13.py
@@ -1,4 +1,5 @@
 from lpython import i32, i16, i64, CPtr, dataclass, ccall, Pointer, c_p_pointer, sizeof
+from numpy import array
 
 @dataclass
 class A:
@@ -23,7 +24,7 @@ def add_Aptr_members(Ax: i32, Ay: i16) -> i32:
 def test_A_member_passing():
     array_cptr: CPtr = cmalloc(sizeof(A) * i64(10))
     assert not bool(is_null(array_cptr)), "Failed to allocate array on memory"
-    array_ptr: Pointer[A[:]] = c_p_pointer(array_cptr, A[:])
+    array_ptr: Pointer[A[:]] = c_p_pointer(array_cptr, A[:], array([10]))
     i: i32; sum_A_members: i32
     for i in range(10):
         array_ptr[i] = A(i, i16(i + 1))

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -1009,6 +1009,12 @@ public:
             symbol_owner);
     }
 
+    void visit_ArrayConstant(const ArrayConstant_t& x) {
+        require(ASR::is_a<ASR::Array_t>(*x.m_type),
+            "Type of ArrayConstant must be an array");
+        BaseWalkVisitor<VerifyVisitor>::visit_ArrayConstant(x);
+    }
+
     void visit_Array(const Array_t& x) {
         visit_ttype(*x.m_type);
         require(x.n_dims != 0, "Array type cannot have 0 dimensions.")
@@ -1021,6 +1027,14 @@ public:
     void visit_Pointer(const Pointer_t &x) {
         require(!ASR::is_a<ASR::Allocatable_t>(*x.m_type),
             "Pointer type conflicts with Allocatable type");
+        if( ASR::is_a<ASR::Array_t>(*x.m_type) ) {
+            ASR::Array_t* array_t = ASR::down_cast<ASR::Array_t>(x.m_type);
+            for (size_t i = 0; i < array_t->n_dims; i++) {
+                require(array_t->m_dims[i].m_start == nullptr &&
+                        array_t->m_dims[i].m_length == nullptr,
+                        "Array type in pointer must have deferred shape");
+            }
+        }
         visit_ttype(*x.m_type);
     }
 

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -2557,39 +2557,63 @@ public:
 
     #define fill_shape_and_lower_bound_for_CPtrToPointer() ASR::dimension_t* target_dims = nullptr; \
         int target_n_dims = ASRUtils::extract_dimensions_from_ttype(target_type, target_dims); \
-        ASR::expr_t* target_shape = nullptr; \
         ASR::expr_t* lower_bounds = nullptr; \
         if( target_n_dims > 0 ) { \
-            Vec<ASR::expr_t*> sizes, lbs; \
-            sizes.reserve(al, target_n_dims); \
-            lbs.reserve(al, target_n_dims); \
-            bool success = true; \
-            for( int i = 0; i < target_n_dims; i++ ) { \
-                if( target_dims->m_length == nullptr ) { \
-                    success = false; \
-                    break; \
+            ASR::dimension_t* alloc_asr_type_dims = nullptr; \
+            int alloc_asr_type_n_dims = ASRUtils::extract_dimensions_from_ttype( \
+                asr_alloc_type, alloc_asr_type_dims); \
+            for( int i = 0; i < alloc_asr_type_n_dims; i++ ) { \
+                if( alloc_asr_type_dims[i].m_length != nullptr || \
+                    alloc_asr_type_dims[i].m_start != nullptr ) { \
+                    throw SemanticError("Target type specified in " \
+                        "c_p_pointer must have deferred shape.", \
+                        loc); \
                 } \
-                sizes.push_back(al, target_dims->m_length); \
+            } \
+            if( target_shape == nullptr ) { \
+                throw SemanticError("shape argument not specified in c_f_pointer " \
+                                    "even though pptr is an array.", \
+                                    loc); \
+            } \
+            int shape_rank = ASRUtils::extract_n_dims_from_ttype( \
+                ASRUtils::expr_type(target_shape)); \
+            if( shape_rank != 1 ) { \
+                throw SemanticError("shape array passed to c_p_pointer " \
+                                    "must be of rank 1 but given rank is " + \
+                                    std::to_string(shape_rank), loc); \
+            } \
+            Vec<ASR::expr_t*> lbs; \
+            lbs.reserve(al, target_n_dims); \
+            for( int i = 0; i < target_n_dims; i++ ) { \
                 lbs.push_back(al, ASRUtils::EXPR(ASR::make_IntegerConstant_t( \
                     al, loc, 0, ASRUtils::TYPE( \
                         ASR::make_Integer_t(al, loc, 4))))); \
             } \
-            if( success ) { \
-                target_shape = ASRUtils::EXPR(ASR::make_ArrayConstant_t(al, \
-                    loc, sizes.p, sizes.size(), ASRUtils::expr_type(target_dims[0].m_length), \
-                    ASR::arraystorageType::RowMajor)); \
-                lower_bounds = ASRUtils::EXPR(ASR::make_ArrayConstant_t(al, \
-                    loc, lbs.p, lbs.size(), ASRUtils::expr_type(lbs[0]), \
-                    ASR::arraystorageType::RowMajor)); \
-            } \
+            Vec<ASR::dimension_t> dims; \
+            dims.reserve(al, 1); \
+            ASR::dimension_t dim; \
+            dim.loc = loc; \
+            dim.m_length = nullptr; \
+            dim.m_start = nullptr; \
+            dims.push_back(al, dim); \
+            ASR::ttype_t* type = ASRUtils::make_Array_t_util(al, loc, \
+                ASRUtils::expr_type(lbs[0]), dims.p, dims.size()); \
+            lower_bounds = ASRUtils::EXPR(ASR::make_ArrayConstant_t(al, \
+                loc, lbs.p, lbs.size(), type, \
+                ASR::arraystorageType::RowMajor)); \
         } \
 
     ASR::asr_t* create_CPtrToPointerFromArgs(AST::expr_t* ast_cptr, AST::expr_t* ast_pptr,
-        AST::expr_t* ast_type_expr, const Location& loc) {
+        AST::expr_t* ast_type_expr, AST::expr_t* ast_target_shape, const Location& loc) {
         this->visit_expr(*ast_cptr);
         ASR::expr_t* cptr = ASRUtils::EXPR(tmp);
         this->visit_expr(*ast_pptr);
         ASR::expr_t* pptr = ASRUtils::EXPR(tmp);
+        ASR::expr_t* target_shape = nullptr;
+        if( ast_target_shape ) {
+            this->visit_expr(*ast_target_shape);
+            target_shape = ASRUtils::EXPR(tmp);
+        }
         bool is_allocatable = false;
         ASR::ttype_t* asr_alloc_type = ast_expr_to_asr_type(ast_type_expr->base.loc, *ast_type_expr, is_allocatable);
         ASR::ttype_t* target_type = ASRUtils::type_get_past_pointer(ASRUtils::expr_type(pptr));
@@ -2691,8 +2715,13 @@ public:
                 AST::Call_t* c_p_pointer_call = AST::down_cast<AST::Call_t>(x.m_value);
                 AST::expr_t* cptr = c_p_pointer_call->m_args[0];
                 AST::expr_t* pptr = assign_ast_target;
+                AST::expr_t* pptr_shape = nullptr;
+                if( c_p_pointer_call->n_args == 3 &&
+                    c_p_pointer_call->m_args[2] != nullptr ) {
+                    pptr_shape = c_p_pointer_call->m_args[2];
+                }
                 tmp = create_CPtrToPointerFromArgs(cptr, pptr, c_p_pointer_call->m_args[1],
-                                                   x.base.base.loc);
+                        pptr_shape, x.base.base.loc);
                 // if( current_body ) {
                 //     current_body->push_back(al, ASRUtils::STMT(tmp));
                 // }
@@ -4758,8 +4787,12 @@ public:
             AST::Call_t* c_p_pointer_call = AST::down_cast<AST::Call_t>(x.m_value);
             AST::expr_t* cptr = c_p_pointer_call->m_args[0];
             AST::expr_t* pptr = x.m_targets[0];
+            AST::expr_t* target_shape = nullptr;
+            if( c_p_pointer_call->n_args == 3 ) {
+                target_shape = c_p_pointer_call->m_args[2];
+            }
             tmp = create_CPtrToPointerFromArgs(cptr, pptr, c_p_pointer_call->m_args[1],
-                                               x.base.base.loc);
+                                               target_shape, x.base.base.loc);
             is_c_p_pointer_call = is_c_p_pointer_call;
             return ;
         }
@@ -6292,16 +6325,23 @@ public:
 
 
     ASR::asr_t* create_CPtrToPointer(const AST::Call_t& x) {
-        if( x.n_args != 2 ) {
-            throw SemanticError("c_p_pointer accepts two positional arguments, "
-                                "first a variable of c_ptr type and second "
-                                " the target type of the first variable.",
+        if( x.n_args != 2 && x.n_args != 3 ) {
+            throw SemanticError("c_p_pointer accepts maximum three positional arguments, "
+                                "first a variable of c_ptr type, second "
+                                "the target type of the first variable and "
+                                "third optionally the shape of the target variable "
+                                "if target variable is an array",
                                 x.base.base.loc);
         }
         visit_expr(*x.m_args[0]);
         ASR::expr_t* cptr = ASRUtils::EXPR(tmp);
         visit_expr(*x.m_args[1]);
         ASR::expr_t* pptr = ASRUtils::EXPR(tmp);
+        ASR::expr_t* target_shape = nullptr;
+        if( x.n_args == 3 ) {
+            visit_expr(*x.m_args[2]);
+            target_shape = ASRUtils::EXPR(tmp);
+        }
         bool is_allocatable = false;
         ASR::ttype_t* asr_alloc_type = ast_expr_to_asr_type(x.m_args[1]->base.loc, *x.m_args[1], is_allocatable);
         ASR::ttype_t* target_type = ASRUtils::type_get_past_pointer(ASRUtils::expr_type(pptr));
@@ -7147,8 +7187,9 @@ public:
                 return;
             } else if( call_name == "pointer" ) {
                 parse_args(x, args);
-                ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Pointer_t(al, x.base.base.loc,
-                                            ASRUtils::expr_type(args[0].m_value)));
+                ASR::ttype_t* type_ = ASRUtils::duplicate_type_with_empty_dims(
+                    al, ASRUtils::expr_type(args[0].m_value));
+                ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_Pointer_t(al, x.base.base.loc, type_));
                 tmp = ASR::make_GetPointer_t(al, x.base.base.loc, args[0].m_value, type, nullptr);
                 return ;
             } else if( call_name == "array" ) {
@@ -7165,6 +7206,14 @@ public:
                     ASR::ListConstant_t* list = ASR::down_cast<ASR::ListConstant_t>(arg);
                     ASR::expr_t **m_args = list->m_args;
                     size_t n_args = list->n_args;
+                    Vec<ASR::dimension_t> dims;
+                    dims.reserve(al, 1);
+                    ASR::dimension_t dim;
+                    dim.loc = x.base.base.loc;
+                    dim.m_length = nullptr;
+                    dim.m_start = nullptr;
+                    dims.push_back(al, dim);
+                    type = ASRUtils::make_Array_t_util(al, x.base.base.loc, type, dims.p, dims.size());
                     tmp = ASR::make_ArrayConstant_t(al, x.base.base.loc, m_args, n_args, type, ASR::arraystorageType::RowMajor);
                 } else {
                     throw SemanticError("array accepts only list for now, got " +

--- a/src/runtime/lpython/lpython.py
+++ b/src/runtime/lpython/lpython.py
@@ -560,9 +560,13 @@ class PointerToStruct:
             value = value.value
         self.ctypes_ptr.contents.__setattr__(name, value)
 
-def c_p_pointer(cptr, targettype):
+def c_p_pointer(cptr, targettype, targetshape=None):
     targettype_ptr = convert_type_to_ctype(targettype)
     if isinstance(targettype, Array):
+        if targetshape is None:
+            raise ValueError("target shape must be "
+                             "provided if target type is an array.")
+        # TODO: Add support for multi-dimensional shape of target variable
         if py_is_dataclass(targettype._type):
             return ctypes.cast(cptr.value, ctypes.py_object).value
         newa = ctypes.cast(cptr, targettype_ptr)

--- a/tests/errors/bindc_03.py
+++ b/tests/errors/bindc_03.py
@@ -1,24 +1,10 @@
 
 from lpython import c_p_pointer, CPtr, i32, Pointer, i16
+from numpy import array
 
 def fill_A(k: i32, n: i32, b: CPtr) -> None:
-    nk: i32 = n * k
-    A: Pointer[i16[nk]] = c_p_pointer(b, i16[k * n])
+    A: Pointer[i16[:]] = c_p_pointer(b, i16[n * k], array([k * n]))
     i: i32; j: i32
     for j in range(k):
         for i in range(n):
             A[j*n+i] = i16((i+j))
-
-def fill_B(k: i32, n: i32, b: CPtr) -> None:
-    B: Pointer[i16[n * k]] = c_p_pointer(b, i16[k * n])
-    i: i32; j: i32
-    for j in range(k):
-        for i in range(n):
-            B[j*n+i] = i16((i+j))
-
-def fill_C(k: i32, n: i32, b: CPtr) -> None:
-    C: Pointer[i16[n]] = c_p_pointer(b, i16[n * k])
-    i: i32; j: i32
-    for j in range(k):
-        for i in range(n):
-            C[j*n+i] = i16((i+j))

--- a/tests/errors/bindc_04.py
+++ b/tests/errors/bindc_04.py
@@ -1,0 +1,24 @@
+from lpython import CPtr, i32, Pointer, i16
+from numpy import empty, int32
+
+def fill_A(k: i32, n: i32) -> None:
+    A: i16[n*k] = empty(n*k, dtype=int32)
+    i: i32; j: i32
+    for j in range(k):
+        for i in range(n):
+            A[j*n+i] = i16((i+j))
+
+def fill_B(k: i32, n: i32) -> None:
+    B: i16[k*n] = empty(k*n, dtype=int32)
+    i: i32; j: i32
+    for j in range(k):
+        for i in range(n):
+            B[j*n+i] = i16((i+j))
+
+def fill_C(k: i32, n: i32, b: CPtr) -> None:
+    nk: i32 = n * k
+    C: i16[nk] = empty(nk, dtype=int32)
+    i: i32; j: i32
+    for j in range(k):
+        for i in range(n):
+            C[j*n+i] = i16((i+j))

--- a/tests/errors/func_06.py
+++ b/tests/errors/func_06.py
@@ -1,5 +1,5 @@
 def init_X(m:i32, n: i32, b: CPtr, m: i32) -> None:
-    B: Pointer[i16[m*n]] = c_p_pointer(b, i16[m*n])
+    B: Pointer[i16[m*n]] = c_p_pointer(b, i16[m*n], array([m*n]))
     i: i32
     j: i32
     for i in range(m):

--- a/tests/reference/asr-bindc_02-bc1a7ea.json
+++ b/tests/reference/asr-bindc_02-bc1a7ea.json
@@ -2,11 +2,11 @@
     "basename": "asr-bindc_02-bc1a7ea",
     "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/bindc_02.py",
-    "infile_hash": "f01761bc86ab282ba20778efe62f227b36929c0232cf5343588b5a85",
+    "infile_hash": "a29f0f269c494419077ca8725e7c2d2dc7a5b4964d5c909347f1caa4",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-bindc_02-bc1a7ea.stdout",
-    "stdout_hash": "675347588ab9699bcbef6f6b7a36d2cbd85cfbf25170519093a3c889",
+    "stdout_hash": "a84c81209f918df8b469a9249361ac3b7237cf0967e8dc0800279ff9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-bindc_02-bc1a7ea.stdout
+++ b/tests/reference/asr-bindc_02-bc1a7ea.stdout
@@ -35,8 +35,24 @@
                                     [(CPtrToPointer
                                         (Var 204 queries)
                                         (Var 204 x)
-                                        ()
-                                        ()
+                                        (ArrayConstant
+                                            [(IntegerConstant 1 (Integer 4))]
+                                            (Array
+                                                (Integer 4)
+                                                [(()
+                                                ())]
+                                            )
+                                            RowMajor
+                                        )
+                                        (ArrayConstant
+                                            [(IntegerConstant 0 (Integer 4))]
+                                            (Array
+                                                (Integer 4)
+                                                [(()
+                                                ())]
+                                            )
+                                            RowMajor
+                                        )
                                     )
                                     (Print
                                         ()
@@ -189,8 +205,8 @@
                                             (Pointer
                                                 (Array
                                                     (Integer 2)
-                                                    [((IntegerConstant 0 (Integer 4))
-                                                    (IntegerConstant 2 (Integer 4)))]
+                                                    [(()
+                                                    ())]
                                                 )
                                             )
                                             ()
@@ -204,8 +220,8 @@
                                             (Pointer
                                                 (Array
                                                     (Integer 2)
-                                                    [((IntegerConstant 0 (Integer 4))
-                                                    (IntegerConstant 2 (Integer 4)))]
+                                                    [(()
+                                                    ())]
                                                 )
                                             )
                                             ()
@@ -286,8 +302,24 @@
                                     (CPtrToPointer
                                         (Var 201 yq)
                                         (Var 201 yptr1)
-                                        ()
-                                        ()
+                                        (ArrayConstant
+                                            [(IntegerConstant 2 (Integer 4))]
+                                            (Array
+                                                (Integer 4)
+                                                [(()
+                                                ())]
+                                            )
+                                            RowMajor
+                                        )
+                                        (ArrayConstant
+                                            [(IntegerConstant 0 (Integer 4))]
+                                            (Array
+                                                (Integer 4)
+                                                [(()
+                                                ())]
+                                            )
+                                            RowMajor
+                                        )
                                     )
                                     (Print
                                         ()

--- a/tests/reference/asr-bindc_03-95dbba7.json
+++ b/tests/reference/asr-bindc_03-95dbba7.json
@@ -2,12 +2,12 @@
     "basename": "asr-bindc_03-95dbba7",
     "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/errors/bindc_03.py",
-    "infile_hash": "966305cef9890644f613e81f7405e694af6fa13e1b06f0e3e08782bb",
+    "infile_hash": "68e9bc4105ff94df854ee89163425cdc8fd26bcb5615938f6993985c",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-bindc_03-95dbba7.stderr",
-    "stderr_hash": "bd49feaada7484eafec316056295c58526a05d426d1a28f1bb5d8b93",
+    "stderr_hash": "c883db0632bbc273091e912f2e87f9530b662185953c2869bc96ed8f",
     "returncode": 2
 }

--- a/tests/reference/asr-bindc_03-95dbba7.stderr
+++ b/tests/reference/asr-bindc_03-95dbba7.stderr
@@ -1,5 +1,5 @@
-semantic error: Only those local variables which can be reduced to compile time constant should be used in dimensions of an array.
- --> tests/errors/bindc_03.py:6:20
+semantic error: Target type specified in c_p_pointer must have deferred shape.
+ --> tests/errors/bindc_03.py:6:5
   |
-6 |     A: Pointer[i16[nk]] = c_p_pointer(b, i16[k * n])
-  |                    ^^ 
+6 |     A: Pointer[i16[:]] = c_p_pointer(b, i16[n * k], array([k * n]))
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-bindc_04-06bd800.json
+++ b/tests/reference/asr-bindc_04-06bd800.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-bindc_04-06bd800",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/bindc_04.py",
+    "infile_hash": "cf66037fcd7e8cfdd63dc5800b73e5c398afda99cf83ed51a6e70c51",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-bindc_04-06bd800.stderr",
+    "stderr_hash": "3468ddf2bd723ff316c68d930a74ca8cad2dc3b4458bee1028752848",
+    "returncode": 2
+}

--- a/tests/reference/asr-bindc_04-06bd800.stderr
+++ b/tests/reference/asr-bindc_04-06bd800.stderr
@@ -1,0 +1,5 @@
+semantic error: Only those local variables which can be reduced to compile time constant should be used in dimensions of an array.
+  --> tests/errors/bindc_04.py:20:12
+   |
+20 |     C: i16[nk] = empty(nk, dtype=int32)
+   |            ^^ 

--- a/tests/reference/asr-func_06-62e738c.json
+++ b/tests/reference/asr-func_06-62e738c.json
@@ -2,7 +2,7 @@
     "basename": "asr-func_06-62e738c",
     "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/errors/func_06.py",
-    "infile_hash": "2b8a5fa5d38ad35eeec67177ab8848255901548fe929c964a9eefef1",
+    "infile_hash": "eed0fcf15f1964c916df4aa9bc4fab78f74f87243a42549a99234b7b",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,

--- a/tests/reference/asr-test_numpy_04-ecbb614.json
+++ b/tests/reference/asr-test_numpy_04-ecbb614.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_04-ecbb614.stdout",
-    "stdout_hash": "0ed6c5b385b2ea5a829073d375bbdb87b6c06bdc27c6e16d94f10f7d",
+    "stdout_hash": "497129100c171b5c0b1e958275aabc6d9b53e0c06d80f6568ad2d5e9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_04-ecbb614.stdout
+++ b/tests/reference/asr-test_numpy_04-ecbb614.stdout
@@ -163,7 +163,11 @@
                                                 3.000000
                                                 (Real 8)
                                             )]
-                                            (Real 8)
+                                            (Array
+                                                (Real 8)
+                                                [(()
+                                                ())]
+                                            )
                                             RowMajor
                                         )
                                         ()
@@ -347,7 +351,11 @@
                                             [(IntegerConstant 1 (Integer 4))
                                             (IntegerConstant 2 (Integer 4))
                                             (IntegerConstant 3 (Integer 4))]
-                                            (Integer 4)
+                                            (Array
+                                                (Integer 4)
+                                                [(()
+                                                ())]
+                                            )
                                             RowMajor
                                         )
                                         ()

--- a/tests/reference/asr-test_pointer_types-1bf0d01.json
+++ b/tests/reference/asr-test_pointer_types-1bf0d01.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_pointer_types-1bf0d01.stderr",
-    "stderr_hash": "4f3b9512978dfb5d22367aa7b2e4fd20768de78530bf4d83a52fa881",
+    "stderr_hash": "3fcd692a6b79b6b3f22fc7a2957df19219fc817446aa6d46f47d049f",
     "returncode": 2
 }

--- a/tests/reference/asr-test_pointer_types-1bf0d01.stderr
+++ b/tests/reference/asr-test_pointer_types-1bf0d01.stderr
@@ -1,4 +1,4 @@
-semantic error: Casting not supported for different pointer types. Received target pointer type, Pointer[i16[:]] and value pointer type, Pointer[i32[3]]
+semantic error: Casting not supported for different pointer types. Received target pointer type, Pointer[i16[:]] and value pointer type, Pointer[i32[:]]
  --> tests/errors/test_pointer_types.py:8:5
   |
 8 |     yptr1 = pointer(y)

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1080,6 +1080,10 @@ filename = "errors/bindc_03.py"
 asr = true
 
 [[test]]
+filename = "errors/bindc_04.py"
+asr = true
+
+[[test]]
 filename = "errors/cptr_01.py"
 asr = true
 


### PR DESCRIPTION
Also, all types under `Pointer` should be of deferred shape. The same rule as Fortran.