### PR TITLE
Fix ExternalSymbol location

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -445,7 +445,7 @@ ASR::symbol_t* import_from_module(Allocator &al, ASR::Module_t *m, SymbolTable *
         name.from_str(al, new_sym_name);
         char *cname = name.c_str(al);
         ASR::asr_t *fn = ASR::make_ExternalSymbol_t(
-            al, mfn->base.base.loc,
+            al, loc,
             /* a_symtab */ current_scope,
             /* a_name */ cname,
             (ASR::symbol_t*)mfn,
@@ -461,7 +461,7 @@ ASR::symbol_t* import_from_module(Allocator &al, ASR::Module_t *m, SymbolTable *
         name.from_str(al, new_sym_name);
         char *cname = name.c_str(al);
         ASR::asr_t *est = ASR::make_ExternalSymbol_t(
-            al, st->base.base.loc,
+            al, loc,
             /* a_symtab */ current_scope,
             /* a_name */ cname,
             (ASR::symbol_t*)st,
@@ -475,7 +475,7 @@ ASR::symbol_t* import_from_module(Allocator &al, ASR::Module_t *m, SymbolTable *
         name.from_str(al, new_sym_name);
         char *cname = name.c_str(al);
         ASR::asr_t *est = ASR::make_ExternalSymbol_t(
-            al, et->base.base.loc,
+            al, loc,
             /* a_symtab */ current_scope,
             /* a_name */ cname,
             (ASR::symbol_t*)et,
@@ -491,7 +491,7 @@ ASR::symbol_t* import_from_module(Allocator &al, ASR::Module_t *m, SymbolTable *
         name.from_str(al, new_sym_name);
         char *cname = name.c_str(al);
         ASR::asr_t *v = ASR::make_ExternalSymbol_t(
-            al, mv->base.base.loc,
+            al, loc,
             /* a_symtab */ current_scope,
             /* a_name */ cname,
             (ASR::symbol_t*)mv,
@@ -505,7 +505,7 @@ ASR::symbol_t* import_from_module(Allocator &al, ASR::Module_t *m, SymbolTable *
         name.from_str(al, new_sym_name);
         char *cname = name.c_str(al);
         ASR::asr_t *v = ASR::make_ExternalSymbol_t(
-            al, gt->base.base.loc,
+            al, loc,
             /* a_symtab */ current_scope,
             /* a_name */ cname,
             (ASR::symbol_t*)gt,
@@ -4253,14 +4253,14 @@ public:
             }
             std::string new_sym_name = ASRUtils::get_mangled_name(m, remote_sym);
             ASR::symbol_t *t = import_from_module(al, m, current_scope, msym,
-                                remote_sym, new_sym_name, x.base.base.loc, true);
+                                remote_sym, new_sym_name, x.m_names[i].loc, true);
             if (current_scope->get_scope().find(new_sym_name) != current_scope->get_scope().end()) {
                 ASR::symbol_t *old_sym = current_scope->get_scope().find(new_sym_name)->second;
                 diag.add(diag::Diagnostic(
                     "The symbol '" + new_sym_name + "' imported from " + std::string(m->m_name) +" will shadow the existing symbol '" + new_sym_name + "'",
                     diag::Level::Warning, diag::Stage::Semantic, {
-                        diag::Label("new symbol", {x.m_names[i].loc}),
-                        diag::Label("old symbol implementation", {old_sym->base.loc}),
+                        diag::Label("old symbol", {old_sym->base.loc}),
+                        diag::Label("new symbol", {t->base.loc}),
                     })
                 );
                 current_scope->overwrite_symbol(new_sym_name, t);

--- a/tests/reference/asr-modules_02-ec92e6f.json
+++ b/tests/reference/asr-modules_02-ec92e6f.json
@@ -8,6 +8,6 @@
     "stdout": "asr-modules_02-ec92e6f.stdout",
     "stdout_hash": "2b9767d477601b562ca13e1d770d84bafad8f2647fb778d52fc20d0d",
     "stderr": "asr-modules_02-ec92e6f.stderr",
-    "stderr_hash": "910bed77716460a8f8712eac5e5818c55b7744f45a4a36aa257f3527",
+    "stderr_hash": "132af04271d3bfd523848990e734bfa3c0aed6e4b85ec4eb87e66720",
     "returncode": 0
 }

--- a/tests/reference/asr-modules_02-ec92e6f.stderr
+++ b/tests/reference/asr-modules_02-ec92e6f.stderr
@@ -1,14 +1,8 @@
 warning: The symbol 'f' imported from modules_02b will shadow the existing symbol 'f'
- --> tests/../integration_tests/modules_02.py:1:28
+ --> tests/../integration_tests/modules_02.py:1:25
+  |
+1 | from modules_02b import f, f
+  |                         ^ old symbol
   |
 1 | from modules_02b import f, f
   |                            ^ new symbol
-
- --> tests/../integration_tests/modules_02b.py:3:1 - 5:16
-  |
-3 |    def f():
-  |    ^^^^^^^^...
-...
-  |
-5 |        print("f()")
-  | ...^^^^^^^^^^^^^^^^ old symbol implementation

--- a/tests/reference/asr_json-modules_02-70a491a.json
+++ b/tests/reference/asr_json-modules_02-70a491a.json
@@ -6,8 +6,8 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_json-modules_02-70a491a.stdout",
-    "stdout_hash": "baae33b908a2ae0da9c7dd50b6307a768b0360e514987d70d3e37dc4",
+    "stdout_hash": "a2e97444a1e8cb6a623037d104f24628adeea2d3af9cae5d680a5423",
     "stderr": "asr_json-modules_02-70a491a.stderr",
-    "stderr_hash": "67b8bf471b878cb687ed200fe5d207b6b4acb9d1e1096a930576fba9",
+    "stderr_hash": "074c73dfbd40f5246b5f400ebe4b1597683344d0c6353cbffc6f32c8",
     "returncode": 0
 }

--- a/tests/reference/asr_json-modules_02-70a491a.stderr
+++ b/tests/reference/asr_json-modules_02-70a491a.stderr
@@ -1,14 +1,8 @@
 [0;33;1mwarning[0;0m[0;1m: The symbol 'f' imported from modules_02b will shadow the existing symbol 'f'[0;0m
- [0;34;1m-->[0;0m tests/../integration_tests/modules_02.py:1:28
+ [0;34;1m-->[0;0m tests/../integration_tests/modules_02.py:1:25
+  [0;34;1m|[0;0m
+[0;34;1m1 |[0;0m from modules_02b import f, f
+  [0;34;1m|[0;0m                         [0;33;1m^ old symbol[0;0m
   [0;34;1m|[0;0m
 [0;34;1m1 |[0;0m from modules_02b import f, f
   [0;34;1m|[0;0m                            [0;33;1m^ new symbol[0;0m
-
- [0;34;1m-->[0;0m tests/../integration_tests/modules_02b.py:3:1 - 5:16
-  [0;34;1m|[0;0m
-[0;34;1m3 |[0;0m    def f():
-  [0;34;1m|[0;0m    [0;33;1m^^^^^^^^...[0;0m
-...
-  [0;34;1m|[0;0m
-[0;34;1m5 |[0;0m        print("f()")
-  [0;34;1m|[0;0m [0;33;1m...^^^^^^^^^^^^^^^^ old symbol implementation[0;0m

--- a/tests/reference/asr_json-modules_02-70a491a.stdout
+++ b/tests/reference/asr_json-modules_02-70a491a.stdout
@@ -100,14 +100,14 @@
                                         "access": "Public"
                                     },
                                     "loc": {
-                                        "first": 157,
-                                        "last": 189,
-                                        "first_filename": "tests/../integration_tests/modules_02b.py",
-                                        "first_line": 3,
-                                        "first_column": 1,
-                                        "last_filename": "tests/../integration_tests/modules_02b.py",
-                                        "last_line": 5,
-                                        "last_column": 16
+                                        "first": 27,
+                                        "last": 27,
+                                        "first_filename": "tests/../integration_tests/modules_02.py",
+                                        "first_line": 1,
+                                        "first_column": 28,
+                                        "last_filename": "tests/../integration_tests/modules_02.py",
+                                        "last_line": 1,
+                                        "last_column": 28
                                     }
                                 },
                                 "main0": {
@@ -822,14 +822,14 @@
                                         "access": "Public"
                                     },
                                     "loc": {
-                                        "first": 191,
-                                        "last": 215,
-                                        "first_filename": "tests/../integration_tests/modules_02c.py",
+                                        "first": 154,
+                                        "last": 154,
+                                        "first_filename": "tests/../integration_tests/modules_02b.py",
                                         "first_line": 1,
-                                        "first_column": 1,
-                                        "last_filename": "tests/../integration_tests/modules_02c.py",
-                                        "last_line": 2,
-                                        "last_column": 16
+                                        "first_column": 25,
+                                        "last_filename": "tests/../integration_tests/modules_02b.py",
+                                        "last_line": 1,
+                                        "last_column": 25
                                     }
                                 }
                             }


### PR DESCRIPTION
Improve shadowing warning messages.

Now they look like this:
```console
$ lpython integration_tests/modules_02.py 
warning: The symbol 'f' imported from modules_02b will shadow the existing symbol 'f'
 --> integration_tests/modules_02.py:1:25
  |
1 | from modules_02b import f, f
  |                         ^ old symbol
  |
1 | from modules_02b import f, f
  |                            ^ new symbol
```
and
```console
$ lpython --show-c mat_vec_device.py -I../.. -I. -Iemulation > x
warning: The symbol 'SM_REG3' imported from gchl_defs will shadow the existing symbol 'SM_REG3'
  --> mat_vec_device.py:25:25
   |
25 |                         SM_REG3, VR16_G0, VR16_G1, VR16_G2, VR16_G3, VR16_G4, VR16_G5, VR16_G6, VR16_G7,
   |                         ^^^^^^^ old symbol
   |
29 |                         SM_REG0, SM_REG1, SM_REG2, SM_REG3, SM_0XFFFF, SM_0X0001, SM_0X1111, SM_0X0101,
   |                                                    ^^^^^^^ new symbol
```