### PR TITLE
Add list index overloads

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -447,6 +447,7 @@ RUN(NAME test_list_11        LABELS cpython llvm c)
 RUN(NAME test_list_section   LABELS cpython llvm c NOFAST)
 RUN(NAME test_list_count     LABELS cpython llvm)
 RUN(NAME test_list_index     LABELS cpython llvm)
+RUN(NAME test_list_index2    LABELS cpython llvm)
 RUN(NAME test_list_repeat    LABELS cpython llvm NOFAST)
 RUN(NAME test_list_reverse   LABELS cpython llvm)
 RUN(NAME test_list_pop       LABELS cpython llvm NOFAST) # TODO: Remove NOFAST from here.

--- a/integration_tests/test_list_index2.py
+++ b/integration_tests/test_list_index2.py
@@ -1,0 +1,55 @@
+from lpython import i32, f64
+
+def test_list_index2():
+    # test optional start and end parameters
+    i: i32
+    x: list[i32] = []
+    y: list[str] = []
+    z: list[tuple[i32, str, f64]] = []
+
+    x = [1, 2, 3, 2]
+    assert x.index(2, 0) == 1
+    assert x.index(2, 1) == 1
+    assert x.index(2, 2) == 3
+    assert x.index(2, 1, 4) == 1
+    assert x.index(2, 2, 4) == 3
+
+    x = []
+    for i in range(-5, 0):
+        x.append(i)
+        assert x.index(i, 0) == len(x) - 1
+        assert x.index(i, 0, len(x)) == len(x) - 1
+        x.append(i)
+        assert x.index(i, 0) == len(x) - 2
+        assert x.index(i, 0, len(x)) == len(x) - 2
+        assert x.index(i, len(x) - 1) == len(x) - 1
+        assert x.index(i, len(x) - 1, len(x)) == len(x) - 1
+        x.remove(i)
+        assert x.index(i, 0) == len(x) - 1
+        assert x.index(i, 0, len(x)) == len(x) - 1
+
+    assert x == [-5, -4, -3, -2, -1]
+
+    # str
+    y = ['a', 'abc', 'a', 'b', 'abc']
+    assert y.index('a', 0) == 0
+    assert y.index('a', 0, 1) == 0
+    assert y.index('a', 1) == 2
+    assert y.index('a', 1, 3) == 2
+    assert y.index('abc', 0) == 1
+    assert y.index('abc', 1) == 1
+    assert y.index('abc', 2) == 4
+
+    # tuple, float
+    z = [(1, 'a', 2.01), (-1, 'b', 2.0), (1, 'a', 2.02)]
+    assert z.index((1, 'a', 2.01), 0) == 0
+    assert z.index((1, 'a', 2.01), 0, 1) == 0
+    z.insert(0, (1, 'a', 2.0))
+    assert z.index((1, 'a', 2.0), 0) == 0
+    assert z.index((-1, 'b', 2.0), 1) == 2
+    z.insert(0, (1, 'a', 2.0))
+    assert z.index((-1, 'b', 2.0), 1) == 3
+    assert z.index((-1, 'b', 2.0), 1, 4) == 3
+    assert z.index((-1, 'b', 2.0), 1, 5) == 3
+
+test_list_index2()

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -271,9 +271,11 @@ namespace LCompilers {
 
             llvm::Value* find_item_position(llvm::Value* list,
                 llvm::Value* item, ASR::ttype_t* item_type,
-                llvm::Module& module);
+                llvm::Module& module, llvm::Value* start=nullptr,
+                llvm::Value* end=nullptr);
 
             llvm::Value* index(llvm::Value* list, llvm::Value* item,
+                                llvm::Value* start, llvm::Value* end,
                                 ASR::ttype_t* item_type, llvm::Module& module);
 
             llvm::Value* count(llvm::Value* list, llvm::Value* item,

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -1002,17 +1002,6 @@ static inline ASR::expr_t *eval_list_index(Allocator &/*al*/,
 static inline ASR::asr_t* create_ListIndex(Allocator& al, const Location& loc,
     Vec<ASR::expr_t*>& args,
     const std::function<void (const std::string &, const Location &)> err) {
-    // if (args.size() != 2) {
-    //     // Support start and end arguments by overloading ListIndex
-    //     // intrinsic. We need 3 overload IDs,
-    //     // 0 - only list and element
-    //     // 1 - list, element and start
-    //     // 2 - list, element, start and end
-    //     // list, element and end case is not possible as list.index
-    //     // doesn't accept keyword arguments
-    //     err("For now index() takes exactly one argument", loc);
-    // }
-
     int64_t overload_id = 0;
     ASR::expr_t* list_expr = args[0];
     ASR::ttype_t *type = ASRUtils::expr_type(list_expr);

--- a/tests/errors/test_list_index.py
+++ b/tests/errors/test_list_index.py
@@ -4,6 +4,6 @@ def test_list_index_error():
     a: list[i32]
     a = [1, 2, 3]
     # a.index(1.0)  # type mismatch
-    print(a.index(0)) # no error?
+    print(a.index(0))
 
 test_list_index_error()

--- a/tests/errors/test_list_index2.py
+++ b/tests/errors/test_list_index2.py
@@ -1,0 +1,8 @@
+from lpython import i32
+
+def test_list_index2_error():
+    a: list[i32]
+    a = [1, 2, 3]
+    print(a.index(1, 1))
+
+test_list_index2_error()

--- a/tests/errors/test_list_index3.py
+++ b/tests/errors/test_list_index3.py
@@ -1,0 +1,8 @@
+from lpython import i32
+
+def test_list_index3_error():
+    a: list[i32]
+    a = [1, 2, 3]
+    print(a.index(1, 1, 2))
+
+test_list_index3_error()

--- a/tests/reference/runtime-test_list_index-0483808.json
+++ b/tests/reference/runtime-test_list_index-0483808.json
@@ -2,7 +2,7 @@
     "basename": "runtime-test_list_index-0483808",
     "cmd": "lpython {infile}",
     "infile": "tests/errors/test_list_index.py",
-    "infile_hash": "991dc5eddf2579b7c6b3bc31bb07656cec73bdf91c3196a761985682",
+    "infile_hash": "cded5d4f016ab4642b0ad1e30239da53272d823fe7d01c999c2811a1",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,

--- a/tests/reference/runtime-test_list_index2-1249233.json
+++ b/tests/reference/runtime-test_list_index2-1249233.json
@@ -1,0 +1,13 @@
+{
+    "basename": "runtime-test_list_index2-1249233",
+    "cmd": "lpython {infile}",
+    "infile": "tests/errors/test_list_index2.py",
+    "infile_hash": "f7f556f1c048a88ee6eb9eae3ce3a337da17b3705b602085ff62ac4f",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "runtime-test_list_index2-1249233.stderr",
+    "stderr_hash": "fc647b30c89710c23d7efec0fe4390894c725680b5d8c4b4c939a5bf",
+    "returncode": 1
+}

--- a/tests/reference/runtime-test_list_index2-1249233.stderr
+++ b/tests/reference/runtime-test_list_index2-1249233.stderr
@@ -1,0 +1,1 @@
+ValueError: The list does not contain the element: 1

--- a/tests/reference/runtime-test_list_index3-647a94a.json
+++ b/tests/reference/runtime-test_list_index3-647a94a.json
@@ -1,0 +1,13 @@
+{
+    "basename": "runtime-test_list_index3-647a94a",
+    "cmd": "lpython {infile}",
+    "infile": "tests/errors/test_list_index3.py",
+    "infile_hash": "2e560614ee9a755d3a001cee48f968f2ff90bea9f00ab22b441667b2",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "runtime-test_list_index3-647a94a.stderr",
+    "stderr_hash": "fc647b30c89710c23d7efec0fe4390894c725680b5d8c4b4c939a5bf",
+    "returncode": 1
+}

--- a/tests/reference/runtime-test_list_index3-647a94a.stderr
+++ b/tests/reference/runtime-test_list_index3-647a94a.stderr
@@ -1,0 +1,1 @@
+ValueError: The list does not contain the element: 1

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -782,6 +782,14 @@ filename = "errors/test_list_index.py"
 run = true
 
 [[test]]
+filename = "errors/test_list_index2.py"
+run = true
+
+[[test]]
+filename = "errors/test_list_index3.py"
+run = true
+
+[[test]]
 filename = "errors/test_list1.py"
 asr = true
 


### PR DESCRIPTION
Add support for optional parameters `start` and `end` in `list.index(x[, start[, end]])`.