### PR TITLE
CI: Consolidate cpython_py and cpython

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -288,8 +288,7 @@ jobs:
             ctest
             ./run_tests.py -s
             cd integration_tests
-            ./run_tests.py -b llvm
-            ./run_tests.py -b c
+            ./run_tests.py -b llvm c
 
   cpython_interop:
     name: Test CPython Interop (@pythoncall)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -331,7 +331,7 @@ jobs:
         shell: bash -l {0}
         run: |
             cd integration_tests
-            ./run_tests.py -b cpython_py c_py
+            ./run_tests.py -b cpython c_py
 
   sympy:
     name: Run SymPy tests

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -164,7 +164,7 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_ENABLE_CPYTHON RUN
             if (${fail})
                 set_tests_properties(${name} PROPERTIES WILL_FAIL TRUE)
             endif()
-        elseif((KIND STREQUAL "cpython") OR (KIND STREQUAL "cpython_py") OR (KIND STREQUAL "cpython_sym"))
+        elseif((KIND STREQUAL "cpython") OR (KIND STREQUAL "cpython_sym"))
             # CPython test
             if (extra_files)
                 set(PY_MOD "${name}_mod")
@@ -291,7 +291,7 @@ macro(RUN)
     if ((NOT DISABLE_FAST) AND (NOT RUN_NOFAST))
         set(RUN_EXTRA_ARGS ${RUN_EXTRA_ARGS} --fast)
         set(RUN_NAME "${RUN_NAME}_FAST")
-        list(REMOVE_ITEM RUN_LABELS cpython cpython_sym cpython_py) # remove cpython, cpython_sym, cpython_py from --fast test
+        list(REMOVE_ITEM RUN_LABELS cpython cpython_sym) # remove cpython, cpython_sym, from --fast test
         RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_ENABLE_CPYTHON RUN_EXTRAFILES RUN_EXTRA_ARGS)
     endif()
 endmacro(RUN)
@@ -529,8 +529,8 @@ RUN(NAME bindc_05   LABELS llvm c
         EXTRAFILES bindc_05b.c)
 RUN(NAME bindc_06   LABELS llvm c
         EXTRAFILES bindc_06b.c)
-RUN(NAME bindpy_01           LABELS cpython_py c_py ENABLE_CPYTHON NOFAST EXTRAFILES bindpy_01_module.py)
-RUN(NAME bindpy_02           LABELS cpython_py c_py LINK_NUMPY EXTRAFILES bindpy_02_module.py)
+RUN(NAME bindpy_01           LABELS cpython c_py ENABLE_CPYTHON NOFAST EXTRAFILES bindpy_01_module.py)
+RUN(NAME bindpy_02           LABELS cpython c_py LINK_NUMPY EXTRAFILES bindpy_02_module.py)
 RUN(NAME test_generics_01    LABELS cpython llvm c NOFAST)
 RUN(NAME test_cmath          LABELS cpython llvm c NOFAST)
 RUN(NAME test_complex_01        LABELS cpython llvm c wasm wasm_x64)

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -6,7 +6,7 @@ import os
 
 # Initialization
 DEFAULT_THREADS_TO_USE = 8 # default no of threads is 8
-SUPPORTED_BACKENDS = ['llvm', 'c', 'wasm', 'cpython', 'x86', 'wasm_x86', 'wasm_x64', 'c_py', 'cpython_py', 'c_sym', 'cpython_sym']
+SUPPORTED_BACKENDS = ['llvm', 'c', 'wasm', 'cpython', 'x86', 'wasm_x86', 'wasm_x64', 'c_py', 'c_sym', 'cpython_sym']
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 LPYTHON_PATH = f"{BASE_DIR}/../src/bin"
 

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -41,7 +41,7 @@ def get_args():
     parser.add_argument("-j", "-n", "--no_of_threads", type=int,
                 help="Parallel testing on given number of threads")
     parser.add_argument("-b", "--backends", nargs="*", default=["llvm", "cpython"],
-                type=str, help="Test the requested backends (%s)" % \
+                type=str, help="Test the requested backends (%s), default: llvm, cpython" % \
                         ", ".join(SUPPORTED_BACKENDS))
     parser.add_argument("-nf", "--no_fast", action='store_true',
                 help="Disable --fast testing of integration tests")


### PR DESCRIPTION
The two tests seem to be the same. The `c_py` requires Python to be
installed which otherwise is not required. But the `cpython_py` just
requires Python to be installed, which it is anyway for the `cpython`
backend, so the two labels are effectively the same. So we make them the
same.