### PR TITLE
C: Use `const` in place of `#define` for declaring constants

### DIFF
--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -306,11 +306,7 @@ R"(#include <stdio.h>
             ASR::symbol_t* var_sym = x.m_symtab->get_symbol(item);
             if (ASR::is_a<ASR::Variable_t>(*var_sym)) {
                 ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(var_sym);
-                std::string d = self().convert_variable_decl(*v);
-                if( !ASR::is_a<ASR::Const_t>(*v->m_type) ||
-                    v->m_intent == ASRUtils::intent_return_var ) {
-                    d += ";\n";
-                }
+                std::string d = self().convert_variable_decl(*v) + ";\n";
                 decl += check_tmp_buffer() + d;
             }
         }
@@ -354,11 +350,7 @@ R"(#include <stdio.h>
             ASR::symbol_t* var_sym = block->m_symtab->get_symbol(item);
             if (ASR::is_a<ASR::Variable_t>(*var_sym)) {
                 ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(var_sym);
-                std::string d = indent + self().convert_variable_decl(*v);
-                if( !ASR::is_a<ASR::Const_t>(*v->m_type) ||
-                    v->m_intent == ASRUtils::intent_return_var ) {
-                    d += ";\n";
-                }
+                std::string d = indent + self().convert_variable_decl(*v) + ";\n";
                 decl += check_tmp_buffer() + d;
             }
         }
@@ -673,11 +665,7 @@ R"(#include <stdio.h>
                     ASR::Variable_t *v = ASR::down_cast<ASR::Variable_t>(var_sym);
                     if (v->m_intent == ASRUtils::intent_local ||
                         v->m_intent == ASRUtils::intent_return_var) {
-                        std::string d = indent + self().convert_variable_decl(*v);
-                        if( !ASR::is_a<ASR::Const_t>(*v->m_type) ||
-                            v->m_intent == ASRUtils::intent_return_var ) {
-                            d += ";\n";
-                        }
+                        std::string d = indent + self().convert_variable_decl(*v) + ";\n";
                         if (ASR::is_a<ASR::SymbolicExpression_t>(*v->m_type)) {
                             std::string v_m_name = v->m_name;
                             d += indent + "basic_new_stack(" + v_m_name + ");\n";

--- a/tests/reference/c-test_import_02-d2c54c4.json
+++ b/tests/reference/c-test_import_02-d2c54c4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-test_import_02-d2c54c4.stdout",
-    "stdout_hash": "2697ed4e9d1c123a8c2fe3802d8f8458108393593df377117da85593",
+    "stdout_hash": "fe5d15e377a72c397cba67c89607695c9b77a2d5681aaab85a5c9654",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-test_import_02-d2c54c4.stdout
+++ b/tests/reference/c-test_import_02-d2c54c4.stdout
@@ -13,7 +13,7 @@ struct dimension_descriptor
 };
 
 // Implementations
-#define μ   1.45136923488338110e+00
+const double μ =   1.45136923488338110e+00;
 int32_t add(int32_t x, int32_t y)
 {
     int32_t _lpython_return_variable;
@@ -21,7 +21,7 @@ int32_t add(int32_t x, int32_t y)
     return _lpython_return_variable;
 }
 
-#define e   2.71828182845904509e+00
+const double e =   2.71828182845904509e+00;
 int32_t multiply(int32_t x, int32_t y)
 {
     int32_t _lpython_return_variable;


### PR DESCRIPTION
fixes https://github.com/lcompilers/lpython/issues/1956