### PR TITLE
Support pass in dataclass

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -578,6 +578,7 @@ RUN(NAME structs_24          LABELS cpython llvm c)
 RUN(NAME structs_25          LABELS cpython llvm c)
 RUN(NAME structs_26          LABELS cpython llvm c)
 RUN(NAME structs_27          LABELS cpython llvm c)
+RUN(NAME structs_28          LABELS cpython llvm c)
 
 RUN(NAME symbolics_01        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_02        LABELS cpython_sym c_sym)

--- a/integration_tests/structs_28.py
+++ b/integration_tests/structs_28.py
@@ -1,0 +1,15 @@
+from lpython import dataclass, i32
+
+@dataclass
+class Pattern:
+    _foo : str
+    pass
+    _n: i32
+
+def main0():
+    p: Pattern = Pattern("some string", 5)
+    assert p._foo == "some string"
+    assert p._n == 5
+    print(p)
+
+main0()

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -2885,6 +2885,10 @@ public:
             if ( AST::is_a<AST::FunctionDef_t>(*x.m_body[i]) ) {
                 throw SemanticError("Struct member functions are not supported", x.m_body[i]->base.loc);
             }
+            if (AST::is_a<AST::Pass_t>(*x.m_body[i])) {
+                continue;
+            }
+
             LCOMPILERS_ASSERT(AST::is_a<AST::AnnAssign_t>(*x.m_body[i]));
             AST::AnnAssign_t* ann_assign = AST::down_cast<AST::AnnAssign_t>(x.m_body[i]);
             LCOMPILERS_ASSERT(AST::is_a<AST::Name_t>(*ann_assign->m_target));

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -2874,18 +2874,14 @@ public:
                 if (AST::is_a<AST::ConstantStr_t>(*expr->m_value)) {
                     // It is a doc string. Skip doc strings for now.
                     continue;
-                } else {
-                    throw SemanticError("Only doc strings allowed as expressions inside class", expr->base.base.loc);
                 }
-            }
-            if( AST::is_a<AST::ClassDef_t>(*x.m_body[i]) ) {
+                throw SemanticError("Only doc strings allowed as expressions inside class", expr->base.base.loc);
+            } else if( AST::is_a<AST::ClassDef_t>(*x.m_body[i]) ) {
                 visit_ClassDef(*AST::down_cast<AST::ClassDef_t>(x.m_body[i]));
                 continue;
-            }
-            if ( AST::is_a<AST::FunctionDef_t>(*x.m_body[i]) ) {
+            } else if ( AST::is_a<AST::FunctionDef_t>(*x.m_body[i]) ) {
                 throw SemanticError("Struct member functions are not supported", x.m_body[i]->base.loc);
-            }
-            if (AST::is_a<AST::Pass_t>(*x.m_body[i])) {
+            } else if (AST::is_a<AST::Pass_t>(*x.m_body[i])) {
                 continue;
             }
 

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -2883,11 +2883,13 @@ public:
                 throw SemanticError("Struct member functions are not supported", x.m_body[i]->base.loc);
             } else if (AST::is_a<AST::Pass_t>(*x.m_body[i])) {
                 continue;
+            } else if (!AST::is_a<AST::AnnAssign_t>(*x.m_body[i])) {
+                throw SemanticError("AnnAssign expected inside struct", x.m_body[i]->base.loc);
             }
-
-            LCOMPILERS_ASSERT(AST::is_a<AST::AnnAssign_t>(*x.m_body[i]));
             AST::AnnAssign_t* ann_assign = AST::down_cast<AST::AnnAssign_t>(x.m_body[i]);
-            LCOMPILERS_ASSERT(AST::is_a<AST::Name_t>(*ann_assign->m_target));
+            if (!AST::is_a<AST::Name_t>(*ann_assign->m_target)) {
+                throw SemanticError("Only Name supported as target in AnnAssign inside struct", x.m_body[i]->base.loc);
+            }
             AST::Name_t *n = AST::down_cast<AST::Name_t>(ann_assign->m_target);
             std::string var_name = n->m_id;
             ASR::expr_t* init_expr = nullptr;


### PR DESCRIPTION
fixes https://github.com/lcompilers/lpython/issues/1988

This PR also replaces the `LCOMPILERS_ASSERT` for `AnnAssign` with a `SemanticError`.