### PR TITLE
PythonCall: Support array of other simple types

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -534,6 +534,7 @@ RUN(NAME bindc_06   LABELS llvm c
 RUN(NAME bindpy_01           LABELS cpython c_py ENABLE_CPYTHON NOFAST EXTRAFILES bindpy_01_module.py)
 RUN(NAME bindpy_02           LABELS cpython c_py LINK_NUMPY EXTRAFILES bindpy_02_module.py)
 RUN(NAME bindpy_03           LABELS cpython c_py LINK_NUMPY NOFAST EXTRAFILES bindpy_03_module.py)
+RUN(NAME bindpy_04           LABELS cpython c_py LINK_NUMPY NOFAST EXTRAFILES bindpy_04_module.py)
 RUN(NAME test_generics_01    LABELS cpython llvm c NOFAST)
 RUN(NAME test_cmath          LABELS cpython llvm c NOFAST)
 RUN(NAME test_complex_01        LABELS cpython llvm c wasm wasm_x64)

--- a/integration_tests/bindpy_04.py
+++ b/integration_tests/bindpy_04.py
@@ -1,0 +1,150 @@
+from lpython import i1, i32, u32, f64, c64, pythoncall, Const, TypeVar
+from numpy import empty, uint32, complex64
+
+n = TypeVar("n")
+m = TypeVar("m")
+
+# Defining the pythoncall decorator functions
+@pythoncall(module = "bindpy_04_module")
+def get_uint_array_sum(n: i32, a: u32[:], b: u32[:]) -> u32[n]:
+    pass
+
+@pythoncall(module = "bindpy_04_module")
+def get_bool_array_or(n: i32, a: i1[:], b: i1[:]) -> i1[n]:
+    pass
+
+@pythoncall(module = "bindpy_04_module")
+def get_complex_array_product(n: i32, a: c64[:], b: c64[:]) -> c64[n]:
+    pass
+
+@pythoncall(module = "bindpy_04_module")
+def get_2D_uint_array_sum(n: i32, m: i32, a: u32[:,:], b: u32[:,:]) -> u32[n,m]:
+    pass
+
+@pythoncall(module = "bindpy_04_module")
+def get_2D_bool_array_and(n: i32, m: i32, a: i1[:,:], b: i1[:,:]) -> i1[n,m]:
+    pass
+
+@pythoncall(module = "bindpy_04_module")
+def get_2D_complex_array_sum(n: i32, m: i32, a: c64[:,:], b: c64[:,:]) -> c64[n,m]:
+    pass
+
+# Unsigned Integers
+def test_array_uints():
+    n: Const[i32] = 5
+    a: u32[n] = empty([n], dtype=uint32)
+    b: u32[n] = empty([n], dtype=uint32)
+
+    i: i32
+    for i in range(n):
+        a[i] = u32(i + 10)
+        b[i] = u32(i + 20)
+
+    c: u32[n] = get_uint_array_sum(n, a, b)
+    print(c)
+    for i in range(n):
+        assert c[i] == u32(i * 2 + 30)
+
+def test_2D_array_uints():
+    n: Const[i32] = 3
+    m: Const[i32] = 4
+    a: u32[n, m] = empty([n, m], dtype=uint32)
+    b: u32[n, m] = empty([n, m], dtype=uint32)
+
+    i: i32
+    j: i32
+    for i in range(n):
+        for j in range(m):
+            a[i, j] = u32(i * 10 + j)
+            b[i, j] = u32(i * 20 + j)
+
+    c: u32[n, m] = get_2D_uint_array_sum(n, m, a, b)
+    print(c)
+    for i in range(n):
+        for j in range(m):
+            assert c[i, j] == u32(i * 30 + 2*j)
+
+# Boolean
+def test_array_bools():
+    n: Const[i32] = 5
+    a: i1[n] = empty([n], dtype=bool)
+    b: i1[n] = empty([n], dtype=bool)
+
+    i: i32
+    for i in range(n):
+        a[i] = bool(i % 2 == 0)
+        b[i] = bool(i % 3 == 0)
+
+    c: i1[n] = get_bool_array_or(n, a, b)
+    print(c)
+    for i in range(n):
+        assert c[i] == bool((i % 2 == 0) or (i % 3 == 0))
+
+def test_2D_array_bools():
+    n: Const[i32] = 3
+    m: Const[i32] = 4
+    a: i1[n, m] = empty([n, m], dtype=bool)
+    b: i1[n, m] = empty([n, m], dtype=bool)
+
+    i: i32
+    j: i32
+    for i in range(n):
+        for j in range(m):
+            a[i, j] = bool(i % 2 == 0)
+            b[i, j] = bool(j % 2 == 0)
+
+    c: i1[n, m] = get_2D_bool_array_and(n, m, a, b)
+    print(c)
+    for i in range(n):
+        for j in range(m):
+            assert c[i, j] == bool((i % 2 == 0) and (j % 2 == 0))
+
+# Complex
+def test_array_complexes():
+    n: Const[i32] = 5
+    a: c64[n] = empty([n], dtype=complex64)
+    b: c64[n] = empty([n], dtype=complex64)
+
+    i: i32
+    for i in range(n):
+        a[i] = c64(complex(i, i + 10))
+        b[i] = c64(complex(i + 1, i + 11))
+
+    c: c64[n] = get_complex_array_product(n, a, b)
+    print(c)
+    for i in range(n):
+        p: f64 = f64(i)
+        q: f64 = f64(i + 10)
+        r: f64 = f64(i + 1)
+        s: f64 = f64(i + 11)
+        assert abs(c[i] - c64(complex((p*r - q*s), (p*s + q*r)))) <= 1e-5
+
+def test_2D_array_complexes():
+    n: Const[i32] = 3
+    m: Const[i32] = 4
+    a: c64[n, m] = empty([n, m], dtype=complex64)
+    b: c64[n, m] = empty([n, m], dtype=complex64)
+
+    i: i32
+    j: i32
+    for i in range(n):
+        for j in range(m):
+            a[i, j] = c64(complex(i, 10*j))
+            b[i, j] = c64(complex(i + 1, 10 * (j + 1)))
+
+    c: c64[n, m] = get_2D_complex_array_sum(n, m, a, b)
+    print(c)
+    for i in range(n):
+        for j in range(m):
+            assert abs(c[i, j] - c64(complex(2*i + 1, 20*j + 10))) <= 1e-5
+
+def main0():
+    test_array_uints()
+    test_array_bools()
+    test_array_complexes()
+
+    test_2D_array_uints()
+    test_2D_array_bools()
+    test_2D_array_complexes()
+
+main0()

--- a/integration_tests/bindpy_04_module.py
+++ b/integration_tests/bindpy_04_module.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+def get_uint_array_sum(n, a, b):
+    return np.add(a, b)
+
+def get_bool_array_or(n, a, b):
+    return np.logical_or(a, b)
+
+def get_complex_array_product(n, a, b):
+    print(a, b)
+    print(np.multiply(a, b))
+    return np.multiply(a, b)
+
+def get_2D_uint_array_sum(n, m, a, b):
+    return np.add(a, b)
+
+def get_2D_bool_array_and(n, m, a, b):
+    return np.logical_and(a, b)
+
+def get_2D_complex_array_sum(n, m, a, b):
+    return np.add(a, b)

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1049,7 +1049,7 @@ static inline std::string get_type_code(const ASR::ttype_t *t, bool use_undersco
             break;
         }
         case ASR::ttypeType::Logical: {
-            res = "bool";
+            res = "i1";
             break;
         }
         case ASR::ttypeType::Character: {

--- a/src/libasr/codegen/asr_to_c.cpp
+++ b/src/libasr/codegen/asr_to_c.cpp
@@ -394,9 +394,8 @@ public:
                 std::string v_m_name = v.m_name;
                 sub = format_type_c("", type_name, v_m_name, use_ref, dummy);
             } else if (ASRUtils::is_logical(*v_m_type)) {
-                bool is_fixed_size = true;
-                dims = convert_dims_c(n_dims, m_dims, v_m_type, is_fixed_size);
-                sub = format_type_c(dims, "bool", v.m_name, use_ref, dummy);
+                convert_variable_decl_util(v, is_array, declare_as_constant, use_ref, dummy,
+                    force_declare, force_declare_name, n_dims, m_dims, v_m_type, dims, sub);
             } else if (ASRUtils::is_character(*v_m_type)) {
                 bool is_fixed_size = true;
                 dims = convert_dims_c(n_dims, m_dims, v_m_type, is_fixed_size);

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -124,7 +124,7 @@ public:
     std::string from_std_vector_helper;
 
     std::unique_ptr<CCPPDSUtils> c_ds_api;
-    std::unique_ptr<CUtils::BindPyUtilFunctions> bind_py_utils_functions;
+    std::unique_ptr<BindPyUtils::BindPyUtilFunctions> bind_py_utils_functions;
     std::string const_name;
     size_t const_vars_count;
     size_t loop_end_count;
@@ -151,7 +151,7 @@ public:
         gen_stdstring{gen_stdstring}, gen_stdcomplex{gen_stdcomplex},
         is_c{is_c}, global_scope{nullptr}, lower_bound{default_lower_bound},
         template_number{0}, c_ds_api{std::make_unique<CCPPDSUtils>(is_c, platform)},
-        bind_py_utils_functions{std::make_unique<CUtils::BindPyUtilFunctions>()},
+        bind_py_utils_functions{std::make_unique<BindPyUtils::BindPyUtilFunctions>()},
         const_name{"constname"},
         const_vars_count{0}, loop_end_count{0}, bracket_open{0},
         is_string_concat_present{false} {
@@ -514,11 +514,11 @@ R"(#include <stdio.h>
             std::string indent = "\n    ";
             if (ASRUtils::is_array(arg->m_type)) {
                 arg_conv += indent + bind_py_utils_functions->get_conv_dims_to_1D_arr() + "(" + arg_name + "->n_dims, " + arg_name + "->dims, __new_dims);";
-                std::string func_call = CUtils::get_py_obj_type_conv_func_from_ttype_t(arg->m_type);
+                std::string func_call = BindPyUtils::get_py_obj_type_conv_func_from_ttype_t(arg->m_type);
                 arg_conv += indent + "pValue = " + func_call + "(" + arg_name + "->n_dims, __new_dims, "
-                    + CUtils::get_numpy_c_obj_type_conv_func_from_ttype_t(arg->m_type) + ", " + arg_name + "->data);";
+                    + BindPyUtils::get_numpy_c_obj_type_conv_func_from_ttype_t(arg->m_type) + ", " + arg_name + "->data);";
             } else {
-                arg_conv += indent + "pValue = " + CUtils::get_py_obj_type_conv_func_from_ttype_t(arg->m_type)
+                arg_conv += indent + "pValue = " + BindPyUtils::get_py_obj_type_conv_func_from_ttype_t(arg->m_type)
                     + "(" + arg_name + ");";
             }
             arg_conv += R"(
@@ -540,7 +540,7 @@ R"(#include <stdio.h>
         ASR::Variable_t* r_v = ASRUtils::EXPR2VAR(x.m_return_var);
         std::string indent = "\n    ";
         std::string ret_var_decl = indent + CUtils::get_c_type_from_ttype_t(r_v->m_type) + " _lpython_return_variable;";
-        std::string py_val_cnvrt = CUtils::get_py_obj_return_type_conv_func_from_ttype_t(r_v->m_type,
+        std::string py_val_cnvrt = BindPyUtils::get_py_obj_return_type_conv_func_from_ttype_t(r_v->m_type,
             array_types_decls, c_ds_api, bind_py_utils_functions);
         std::string ret_assign = indent + "_lpython_return_variable = " + py_val_cnvrt + "(pValue);";
         std::string clear_pValue = indent + "Py_DECREF(pValue);";

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -422,18 +422,23 @@ R"(#include <stdio.h>
                     sub = "char* ";
                 }
             } else if (ASRUtils::is_complex(*return_var->m_type)) {
-                bool is_float = ASR::down_cast<ASR::Complex_t>(return_var->m_type)->m_kind == 4;
-                if (is_float) {
-                    if (gen_stdcomplex) {
-                        sub = "std::complex<float> ";
-                    } else {
-                        sub = "float complex ";
-                    }
+                int kind = ASRUtils::extract_kind_from_ttype_t(return_var->m_type);
+                if (is_array) {
+                    sub = "struct c" + std::to_string(kind * 8) + "* ";
                 } else {
-                    if (gen_stdcomplex) {
-                        sub = "std::complex<double> ";
+                    bool is_float = kind == 4;
+                    if (is_float) {
+                        if (gen_stdcomplex) {
+                            sub = "std::complex<float> ";
+                        } else {
+                            sub = "float complex ";
+                        }
                     } else {
-                        sub = "double complex ";
+                        if (gen_stdcomplex) {
+                            sub = "std::complex<double> ";
+                        } else {
+                            sub = "double complex ";
+                        }
                     }
                 }
             } else if (ASR::is_a<ASR::SymbolicExpression_t>(*return_var->m_type)) {

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -540,7 +540,7 @@ R"(#include <stdio.h>
         ASR::Variable_t* r_v = ASRUtils::EXPR2VAR(x.m_return_var);
         std::string indent = "\n    ";
         std::string ret_var_decl = indent + CUtils::get_c_type_from_ttype_t(r_v->m_type) + " _lpython_return_variable;";
-        std::string py_val_cnvrt = BindPyUtils::get_py_obj_return_type_conv_func_from_ttype_t(r_v->m_type,
+        std::string py_val_cnvrt = BindPyUtils::get_py_obj_ret_type_conv_fn_from_ttype(r_v->m_type,
             array_types_decls, c_ds_api, bind_py_utils_functions);
         std::string ret_assign = indent + "_lpython_return_variable = " + py_val_cnvrt + "(pValue);";
         std::string clear_pValue = indent + "Py_DECREF(pValue);";

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -410,7 +410,11 @@ R"(#include <stdio.h>
                     }
                 }
             } else if (ASRUtils::is_logical(*return_var->m_type)) {
-                sub = "bool ";
+                if (is_array) {
+                    sub = "struct i1* ";
+                } else {
+                    sub = "bool ";
+                }
             } else if (ASRUtils::is_character(*return_var->m_type)) {
                 if (gen_stdstring) {
                     sub = "std::string ";

--- a/src/libasr/codegen/c_utils.h
+++ b/src/libasr/codegen/c_utils.h
@@ -1782,6 +1782,16 @@ namespace BindPyUtils {
                 type_src = "NPY_STRING";
                 break;
             }
+            case ASR::ttypeType::Complex: {
+                switch (kind)
+                {
+                    case 4: type_src = "NPY_COMPLEX64"; break;
+                    case 8: type_src = "NPY_COMPLEX128"; break;
+                    default:
+                        throw CodeGenError("get_numpy_c_obj_type_conv_func_from_ttype_t: Unsupported kind in complex type");
+                }
+                break;
+            }
             default: {
                 throw CodeGenError("get_numpy_c_obj_type_conv_func_from_ttype_t: Type " + ASRUtils::type_to_str_python(t) + " not supported yet.");
             }

--- a/src/libasr/codegen/c_utils.h
+++ b/src/libasr/codegen/c_utils.h
@@ -234,130 +234,6 @@ namespace CUtils {
             }
     };
 
-    class BindPyUtilFunctions {
-
-        private:
-
-            SymbolTable* global_scope;
-            std::map<std::string, std::string> util2func;
-
-            int indentation_level, indentation_spaces;
-
-        public:
-
-            std::string util_func_decls;
-            std::string util_funcs;
-
-            BindPyUtilFunctions() {
-                util2func.clear();
-                util_func_decls.clear();
-                util_funcs.clear();
-            }
-
-            void set_indentation(int indendation_level_, int indendation_space_) {
-                indentation_level = indendation_level_;
-                indentation_spaces = indendation_space_;
-            }
-
-            void set_global_scope(SymbolTable* global_scope_) {
-                global_scope = global_scope_;
-            }
-
-            std::string get_generated_code() {
-                return util_funcs;
-            }
-
-            std::string get_util_func_decls() {
-                return util_func_decls;
-            }
-
-            void conv_dims_to_1D_arr() {
-                if( util2func.find("conv_dims_to_1D_arr") != util2func.end() ) {
-                    return;
-                }
-                util_func_decls += "long __new_dims[32];\n";
-                std::string indent(indentation_level * indentation_spaces, ' ');
-                std::string tab(indentation_spaces, ' ');
-                util2func["conv_dims_to_1D_arr"] = global_scope->get_unique_name("conv_dims_to_1D_arr");
-                std::string conv_dims_to_1D_arr_func = util2func["conv_dims_to_1D_arr"];
-                std::string signature = "static inline void " + conv_dims_to_1D_arr_func + "(int n_dims, struct dimension_descriptor *dims, long* new_dims)";
-                util_func_decls += indent + signature + ";\n";
-                std::string body = indent + signature + " {\n";
-                body += indent + tab + "for (int i = 0; i < n_dims; i++) {\n";
-                body += indent + tab + tab + "new_dims[i] = dims[i].length;\n";
-                body += indent + tab + "}\n";
-                body += indent + "}\n\n";
-                util_funcs += body;
-            }
-
-            std::string get_conv_dims_to_1D_arr() {
-                conv_dims_to_1D_arr();
-                return util2func["conv_dims_to_1D_arr"];
-            }
-
-            void conv_py_arr_to_c(std::string return_type,
-                std::string element_type, std::string encoded_type) {
-                if( util2func.find("conv_py_arr_to_c_" + encoded_type) != util2func.end() ) {
-                    return;
-                }
-                std::string indent(indentation_level * indentation_spaces, ' ');
-                std::string tab(indentation_spaces, ' ');
-                util2func["conv_py_arr_to_c_" + encoded_type] = global_scope->get_unique_name("conv_py_arr_to_c_" + encoded_type);
-                std::string conv_py_arr_to_c_func = util2func["conv_py_arr_to_c_" + encoded_type];
-                std::string signature = "static inline " + return_type + " " + conv_py_arr_to_c_func + "(PyObject* pValue)";
-                util_func_decls += indent + signature + ";\n";
-                std::string body = indent + signature + " {\n";
-                body += indent + tab + "if (!PyArray_Check(pValue)) {\n";
-                body += indent + tab + tab + R"(fprintf(stderr, "Return value is not an array\n");)" + "\n";
-                body += indent + tab + "}\n";
-                body += indent + tab + "PyArrayObject *np_arr = (PyArrayObject *)pValue;\n";
-                body += indent + tab + return_type + " ret_var  = (" + return_type + ") malloc(sizeof(struct " + encoded_type + "));\n";
-                body += indent + tab + "ret_var->n_dims = PyArray_NDIM(np_arr);\n";
-                body += indent + tab + "long* m_dims = PyArray_SHAPE(np_arr);\n";
-                body += indent + tab + "for (long i = 0; i < ret_var->n_dims; i++) {\n";
-                body += indent + tab + tab + "ret_var->dims[i].length = m_dims[i];\n";
-                body += indent + tab + tab + "ret_var->dims[i].lower_bound = 0;\n";
-                body += indent + tab + "}\n";
-                body += indent + tab + "long arr_size = PyArray_SIZE(np_arr);\n";
-                body += indent + tab + element_type + "* data = (" + element_type + "*) PyArray_DATA(np_arr);\n";
-                body += indent + tab + "ret_var->data = (" + element_type + "*) malloc(arr_size * sizeof(" + element_type + "));\n";
-                body += indent + tab + "for (long i = 0; i < arr_size; i++) {\n";
-                body += indent + tab + tab + "ret_var->data[i] = data[i];\n";
-                body += indent + tab + "}\n";
-                body += indent + tab + "return ret_var;\n";
-                body += indent + "}\n\n";
-                util_funcs += body;
-            }
-
-            std::string get_conv_py_arr_to_c(std::string return_type,
-                std::string element_type, std::string encoded_type) {
-                conv_py_arr_to_c(return_type, element_type, encoded_type);
-                return util2func["conv_py_arr_to_c_" + encoded_type];
-            }
-
-            void conv_py_str_to_c() {
-                if( util2func.find("conv_py_str_to_c") != util2func.end() ) {
-                    return;
-                }
-                std::string indent(indentation_level * indentation_spaces, ' ');
-                std::string tab(indentation_spaces, ' ');
-                util2func["conv_py_str_to_c"] = global_scope->get_unique_name("conv_py_str_to_c");
-                std::string conv_py_arr_to_c_func = util2func["conv_py_str_to_c"];
-                std::string signature = "static inline char* " + conv_py_arr_to_c_func + "(PyObject* pValue)";
-                util_func_decls += indent + signature + ";\n";
-                std::string body = indent + signature + " {\n";
-                body += indent + tab + "char *s = (char*)PyUnicode_AsUTF8(pValue);\n";
-                body += indent + tab + "return _lfortran_str_copy(s, 1, 0);\n";
-                body += indent + "}\n\n";
-                util_funcs += body;
-            }
-
-            std::string get_conv_py_str_to_c() {
-                conv_py_str_to_c();
-                return util2func["conv_py_str_to_c"];
-            }
-    };
-
     static inline std::string get_tuple_type_code(ASR::Tuple_t *tup) {
         std::string result = "tuple_";
         for (size_t i = 0; i < tup->n_type; i++) {
@@ -459,143 +335,7 @@ namespace CUtils {
         }
         return type_src;
     }
-
-    static inline std::string get_numpy_c_obj_type_conv_func_from_ttype_t(ASR::ttype_t* t) {
-        t = ASRUtils::type_get_past_array(t);
-        int kind = ASRUtils::extract_kind_from_ttype_t(t);
-        std::string type_src = "";
-        switch( t->type ) {
-            case ASR::ttypeType::Integer: {
-                type_src = "NPY_INT" + std::to_string(kind * 8);
-                break;
-            }
-            case ASR::ttypeType::UnsignedInteger: {
-                type_src = "NPY_UINT" + std::to_string(kind * 8);
-                break;
-            }
-            case ASR::ttypeType::Logical: {
-                type_src = "NPY_BOOL";
-                break;
-            }
-            case ASR::ttypeType::Real: {
-                switch (kind)
-                {
-                    case 4: type_src = "NPY_FLOAT"; break;
-                    case 8: type_src = "NPY_DOUBLE"; break;
-                    default:
-                        throw CodeGenError("get_numpy_c_obj_type_conv_func_from_ttype_t: Unsupported kind in real type");
-                }
-                break;
-            }
-            case ASR::ttypeType::Character: {
-                type_src = "NPY_STRING";
-                break;
-            }
-            default: {
-                throw CodeGenError("get_numpy_c_obj_type_conv_func_from_ttype_t: Type " + ASRUtils::type_to_str_python(t) + " not supported yet.");
-            }
-        }
-        return type_src;
-    }
-
-    static inline std::string get_py_obj_type_conv_func_from_ttype_t(ASR::ttype_t* t) {
-        int kind = ASRUtils::extract_kind_from_ttype_t(t);
-        std::string type_src = "";
-        switch( t->type ) {
-            case ASR::ttypeType::Integer: {
-                switch (kind)
-                {
-                    case 4: type_src = "PyLong_FromLong"; break;
-                    case 8: type_src = "PyLong_FromLongLong"; break;
-                    default:
-                        throw CodeGenError("get_py_obj_type_conv_func: Unsupported kind in int type");
-                }
-                break;
-            }
-            case ASR::ttypeType::UnsignedInteger: {
-                switch (kind)
-                {
-                    case 4: type_src = "PyLong_FromUnsignedLong"; break;
-                    case 8: type_src = "PyLong_FromUnsignedLongLong"; break;
-                    default:
-                        throw CodeGenError("get_py_obj_type_conv_func: Unsupported kind in unsigned int type");
-                }
-                break;
-            }
-            case ASR::ttypeType::Logical: {
-                type_src = "PyBool_FromLong";
-                break;
-            }
-            case ASR::ttypeType::Real: {
-                type_src = "PyFloat_FromDouble";
-                break;
-            }
-            case ASR::ttypeType::Character: {
-                type_src = "PyUnicode_FromString";
-                break;
-            }
-            case ASR::ttypeType::Array: {
-                type_src = "PyArray_SimpleNewFromData";
-                break;
-            }
-            default: {
-                throw CodeGenError("get_py_obj_type_conv_func_from_ttype_t: Type " + ASRUtils::type_to_str_python(t) + " not supported yet.");
-            }
-        }
-        return type_src;
-    }
-
-    static inline std::string get_py_obj_return_type_conv_func_from_ttype_t(ASR::ttype_t* t,
-        std::string &array_types_decls, std::unique_ptr<CCPPDSUtils> &c_ds_api,
-        std::unique_ptr<CUtils::BindPyUtilFunctions> &bind_py_utils_functions) {
-        int kind = ASRUtils::extract_kind_from_ttype_t(t);
-        std::string type_src = "";
-        switch( t->type ) {
-            case ASR::ttypeType::Array: {
-                ASR::ttype_t* array_t = ASR::down_cast<ASR::Array_t>(t)->m_type;
-                std::string array_type_name = CUtils::get_c_type_from_ttype_t(array_t);
-                std::string array_encoded_type_name = ASRUtils::get_type_code(array_t, true, false);
-                std::string return_type = c_ds_api->get_array_type(array_type_name, array_encoded_type_name, array_types_decls, true);
-                type_src = bind_py_utils_functions->get_conv_py_arr_to_c(return_type, array_type_name,
-                    array_encoded_type_name);
-                break;
-            }
-            case ASR::ttypeType::Integer: {
-                switch (kind)
-                {
-                    case 4: type_src = "PyLong_AsLong"; break;
-                    case 8: type_src = "PyLong_AsLongLong"; break;
-                    default:
-                        throw CodeGenError("get_py_obj_return_type_conv_func_from_ttype_t: Unsupported kind in int type");
-                }
-                break;
-            }
-            case ASR::ttypeType::UnsignedInteger: {
-                switch (kind)
-                {
-                    case 4: type_src = "PyLong_AsUnsignedLong"; break;
-                    case 8: type_src = "PyLong_AsUnsignedLongLong"; break;
-                    default:
-                        throw CodeGenError("get_py_obj_return_type_conv_func_from_ttype_t: Unsupported kind in unsigned int type");
-                }
-                break;
-            }
-            case ASR::ttypeType::Real: {
-                type_src = "PyFloat_AsDouble";
-                break;
-            }
-            case ASR::ttypeType::Character: {
-                type_src = bind_py_utils_functions->get_conv_py_str_to_c();
-                break;
-            }
-            default: {
-                throw CodeGenError("get_py_obj_return_type_conv_func_from_ttype_t: Type " + ASRUtils::type_to_str_python(t) + " not supported yet.");
-            }
-        }
-        return type_src;
-    }
 } // namespace CUtils
-
 
 class CCPPDSUtils {
     private:
@@ -1885,6 +1625,267 @@ class CCPPDSUtils {
             compareTwoDS.clear();
         }
 };
+
+namespace BindPyUtils {
+    class BindPyUtilFunctions {
+
+        private:
+
+            SymbolTable* global_scope;
+            std::map<std::string, std::string> util2func;
+
+            int indentation_level, indentation_spaces;
+
+        public:
+
+            std::string util_func_decls;
+            std::string util_funcs;
+
+            BindPyUtilFunctions() {
+                util2func.clear();
+                util_func_decls.clear();
+                util_funcs.clear();
+            }
+
+            void set_indentation(int indendation_level_, int indendation_space_) {
+                indentation_level = indendation_level_;
+                indentation_spaces = indendation_space_;
+            }
+
+            void set_global_scope(SymbolTable* global_scope_) {
+                global_scope = global_scope_;
+            }
+
+            std::string get_generated_code() {
+                return util_funcs;
+            }
+
+            std::string get_util_func_decls() {
+                return util_func_decls;
+            }
+
+            void conv_dims_to_1D_arr() {
+                if( util2func.find("conv_dims_to_1D_arr") != util2func.end() ) {
+                    return;
+                }
+                util_func_decls += "long __new_dims[32];\n";
+                std::string indent(indentation_level * indentation_spaces, ' ');
+                std::string tab(indentation_spaces, ' ');
+                util2func["conv_dims_to_1D_arr"] = global_scope->get_unique_name("conv_dims_to_1D_arr");
+                std::string conv_dims_to_1D_arr_func = util2func["conv_dims_to_1D_arr"];
+                std::string signature = "static inline void " + conv_dims_to_1D_arr_func + "(int n_dims, struct dimension_descriptor *dims, long* new_dims)";
+                util_func_decls += indent + signature + ";\n";
+                std::string body = indent + signature + " {\n";
+                body += indent + tab + "for (int i = 0; i < n_dims; i++) {\n";
+                body += indent + tab + tab + "new_dims[i] = dims[i].length;\n";
+                body += indent + tab + "}\n";
+                body += indent + "}\n\n";
+                util_funcs += body;
+            }
+
+            std::string get_conv_dims_to_1D_arr() {
+                conv_dims_to_1D_arr();
+                return util2func["conv_dims_to_1D_arr"];
+            }
+
+            void conv_py_arr_to_c(std::string return_type,
+                std::string element_type, std::string encoded_type) {
+                if( util2func.find("conv_py_arr_to_c_" + encoded_type) != util2func.end() ) {
+                    return;
+                }
+                std::string indent(indentation_level * indentation_spaces, ' ');
+                std::string tab(indentation_spaces, ' ');
+                util2func["conv_py_arr_to_c_" + encoded_type] = global_scope->get_unique_name("conv_py_arr_to_c_" + encoded_type);
+                std::string conv_py_arr_to_c_func = util2func["conv_py_arr_to_c_" + encoded_type];
+                std::string signature = "static inline " + return_type + " " + conv_py_arr_to_c_func + "(PyObject* pValue)";
+                util_func_decls += indent + signature + ";\n";
+                std::string body = indent + signature + " {\n";
+                body += indent + tab + "if (!PyArray_Check(pValue)) {\n";
+                body += indent + tab + tab + R"(fprintf(stderr, "Return value is not an array\n");)" + "\n";
+                body += indent + tab + "}\n";
+                body += indent + tab + "PyArrayObject *np_arr = (PyArrayObject *)pValue;\n";
+                body += indent + tab + return_type + " ret_var  = (" + return_type + ") malloc(sizeof(struct " + encoded_type + "));\n";
+                body += indent + tab + "ret_var->n_dims = PyArray_NDIM(np_arr);\n";
+                body += indent + tab + "long* m_dims = PyArray_SHAPE(np_arr);\n";
+                body += indent + tab + "for (long i = 0; i < ret_var->n_dims; i++) {\n";
+                body += indent + tab + tab + "ret_var->dims[i].length = m_dims[i];\n";
+                body += indent + tab + tab + "ret_var->dims[i].lower_bound = 0;\n";
+                body += indent + tab + "}\n";
+                body += indent + tab + "long arr_size = PyArray_SIZE(np_arr);\n";
+                body += indent + tab + element_type + "* data = (" + element_type + "*) PyArray_DATA(np_arr);\n";
+                body += indent + tab + "ret_var->data = (" + element_type + "*) malloc(arr_size * sizeof(" + element_type + "));\n";
+                body += indent + tab + "for (long i = 0; i < arr_size; i++) {\n";
+                body += indent + tab + tab + "ret_var->data[i] = data[i];\n";
+                body += indent + tab + "}\n";
+                body += indent + tab + "return ret_var;\n";
+                body += indent + "}\n\n";
+                util_funcs += body;
+            }
+
+            std::string get_conv_py_arr_to_c(std::string return_type,
+                std::string element_type, std::string encoded_type) {
+                conv_py_arr_to_c(return_type, element_type, encoded_type);
+                return util2func["conv_py_arr_to_c_" + encoded_type];
+            }
+
+            void conv_py_str_to_c() {
+                if( util2func.find("conv_py_str_to_c") != util2func.end() ) {
+                    return;
+                }
+                std::string indent(indentation_level * indentation_spaces, ' ');
+                std::string tab(indentation_spaces, ' ');
+                util2func["conv_py_str_to_c"] = global_scope->get_unique_name("conv_py_str_to_c");
+                std::string conv_py_arr_to_c_func = util2func["conv_py_str_to_c"];
+                std::string signature = "static inline char* " + conv_py_arr_to_c_func + "(PyObject* pValue)";
+                util_func_decls += indent + signature + ";\n";
+                std::string body = indent + signature + " {\n";
+                body += indent + tab + "char *s = (char*)PyUnicode_AsUTF8(pValue);\n";
+                body += indent + tab + "return _lfortran_str_copy(s, 1, 0);\n";
+                body += indent + "}\n\n";
+                util_funcs += body;
+            }
+
+            std::string get_conv_py_str_to_c() {
+                conv_py_str_to_c();
+                return util2func["conv_py_str_to_c"];
+            }
+    };
+
+    static inline std::string get_numpy_c_obj_type_conv_func_from_ttype_t(ASR::ttype_t* t) {
+        t = ASRUtils::type_get_past_array(t);
+        int kind = ASRUtils::extract_kind_from_ttype_t(t);
+        std::string type_src = "";
+        switch( t->type ) {
+            case ASR::ttypeType::Integer: {
+                type_src = "NPY_INT" + std::to_string(kind * 8);
+                break;
+            }
+            case ASR::ttypeType::UnsignedInteger: {
+                type_src = "NPY_UINT" + std::to_string(kind * 8);
+                break;
+            }
+            case ASR::ttypeType::Logical: {
+                type_src = "NPY_BOOL";
+                break;
+            }
+            case ASR::ttypeType::Real: {
+                switch (kind)
+                {
+                    case 4: type_src = "NPY_FLOAT"; break;
+                    case 8: type_src = "NPY_DOUBLE"; break;
+                    default:
+                        throw CodeGenError("get_numpy_c_obj_type_conv_func_from_ttype_t: Unsupported kind in real type");
+                }
+                break;
+            }
+            case ASR::ttypeType::Character: {
+                type_src = "NPY_STRING";
+                break;
+            }
+            default: {
+                throw CodeGenError("get_numpy_c_obj_type_conv_func_from_ttype_t: Type " + ASRUtils::type_to_str_python(t) + " not supported yet.");
+            }
+        }
+        return type_src;
+    }
+
+    static inline std::string get_py_obj_type_conv_func_from_ttype_t(ASR::ttype_t* t) {
+        int kind = ASRUtils::extract_kind_from_ttype_t(t);
+        std::string type_src = "";
+        switch( t->type ) {
+            case ASR::ttypeType::Integer: {
+                switch (kind)
+                {
+                    case 4: type_src = "PyLong_FromLong"; break;
+                    case 8: type_src = "PyLong_FromLongLong"; break;
+                    default:
+                        throw CodeGenError("get_py_obj_type_conv_func: Unsupported kind in int type");
+                }
+                break;
+            }
+            case ASR::ttypeType::UnsignedInteger: {
+                switch (kind)
+                {
+                    case 4: type_src = "PyLong_FromUnsignedLong"; break;
+                    case 8: type_src = "PyLong_FromUnsignedLongLong"; break;
+                    default:
+                        throw CodeGenError("get_py_obj_type_conv_func: Unsupported kind in unsigned int type");
+                }
+                break;
+            }
+            case ASR::ttypeType::Logical: {
+                type_src = "PyBool_FromLong";
+                break;
+            }
+            case ASR::ttypeType::Real: {
+                type_src = "PyFloat_FromDouble";
+                break;
+            }
+            case ASR::ttypeType::Character: {
+                type_src = "PyUnicode_FromString";
+                break;
+            }
+            case ASR::ttypeType::Array: {
+                type_src = "PyArray_SimpleNewFromData";
+                break;
+            }
+            default: {
+                throw CodeGenError("get_py_obj_type_conv_func_from_ttype_t: Type " + ASRUtils::type_to_str_python(t) + " not supported yet.");
+            }
+        }
+        return type_src;
+    }
+
+    static inline std::string get_py_obj_return_type_conv_func_from_ttype_t(ASR::ttype_t* t,
+        std::string &array_types_decls, std::unique_ptr<CCPPDSUtils> &c_ds_api,
+        std::unique_ptr<BindPyUtilFunctions> &bind_py_utils_functions) {
+        int kind = ASRUtils::extract_kind_from_ttype_t(t);
+        std::string type_src = "";
+        switch( t->type ) {
+            case ASR::ttypeType::Array: {
+                ASR::ttype_t* array_t = ASR::down_cast<ASR::Array_t>(t)->m_type;
+                std::string array_type_name = CUtils::get_c_type_from_ttype_t(array_t);
+                std::string array_encoded_type_name = ASRUtils::get_type_code(array_t, true, false);
+                std::string return_type = c_ds_api->get_array_type(array_type_name, array_encoded_type_name, array_types_decls, true);
+                type_src = bind_py_utils_functions->get_conv_py_arr_to_c(return_type, array_type_name,
+                    array_encoded_type_name);
+                break;
+            }
+            case ASR::ttypeType::Integer: {
+                switch (kind)
+                {
+                    case 4: type_src = "PyLong_AsLong"; break;
+                    case 8: type_src = "PyLong_AsLongLong"; break;
+                    default:
+                        throw CodeGenError("get_py_obj_return_type_conv_func_from_ttype_t: Unsupported kind in int type");
+                }
+                break;
+            }
+            case ASR::ttypeType::UnsignedInteger: {
+                switch (kind)
+                {
+                    case 4: type_src = "PyLong_AsUnsignedLong"; break;
+                    case 8: type_src = "PyLong_AsUnsignedLongLong"; break;
+                    default:
+                        throw CodeGenError("get_py_obj_return_type_conv_func_from_ttype_t: Unsupported kind in unsigned int type");
+                }
+                break;
+            }
+            case ASR::ttypeType::Real: {
+                type_src = "PyFloat_AsDouble";
+                break;
+            }
+            case ASR::ttypeType::Character: {
+                type_src = bind_py_utils_functions->get_conv_py_str_to_c();
+                break;
+            }
+            default: {
+                throw CodeGenError("get_py_obj_return_type_conv_func_from_ttype_t: Type " + ASRUtils::type_to_str_python(t) + " not supported yet.");
+            }
+        }
+        return type_src;
+    }
+}
 
 } // namespace LCompilers
 

--- a/src/libasr/codegen/c_utils.h
+++ b/src/libasr/codegen/c_utils.h
@@ -1836,7 +1836,7 @@ namespace BindPyUtils {
         return type_src;
     }
 
-    static inline std::string get_py_obj_return_type_conv_func_from_ttype_t(ASR::ttype_t* t,
+    static inline std::string get_py_obj_ret_type_conv_fn_from_ttype(ASR::ttype_t* t,
         std::string &array_types_decls, std::unique_ptr<CCPPDSUtils> &c_ds_api,
         std::unique_ptr<BindPyUtilFunctions> &bind_py_utils_functions) {
         int kind = ASRUtils::extract_kind_from_ttype_t(t);
@@ -1857,7 +1857,7 @@ namespace BindPyUtils {
                     case 4: type_src = "PyLong_AsLong"; break;
                     case 8: type_src = "PyLong_AsLongLong"; break;
                     default:
-                        throw CodeGenError("get_py_obj_return_type_conv_func_from_ttype_t: Unsupported kind in int type");
+                        throw CodeGenError("get_py_obj_ret_type_conv_fn_from_ttype: Unsupported kind in int type");
                 }
                 break;
             }
@@ -1867,7 +1867,7 @@ namespace BindPyUtils {
                     case 4: type_src = "PyLong_AsUnsignedLong"; break;
                     case 8: type_src = "PyLong_AsUnsignedLongLong"; break;
                     default:
-                        throw CodeGenError("get_py_obj_return_type_conv_func_from_ttype_t: Unsupported kind in unsigned int type");
+                        throw CodeGenError("get_py_obj_ret_type_conv_fn_from_ttype: Unsupported kind in unsigned int type");
                 }
                 break;
             }
@@ -1880,7 +1880,7 @@ namespace BindPyUtils {
                 break;
             }
             default: {
-                throw CodeGenError("get_py_obj_return_type_conv_func_from_ttype_t: Type " + ASRUtils::type_to_str_python(t) + " not supported yet.");
+                throw CodeGenError("get_py_obj_ret_type_conv_fn_from_ttype: Type " + ASRUtils::type_to_str_python(t) + " not supported yet.");
             }
         }
         return type_src;

--- a/src/libasr/codegen/c_utils.h
+++ b/src/libasr/codegen/c_utils.h
@@ -282,7 +282,7 @@ namespace CUtils {
             }
             case ASR::ttypeType::Array: {
                 ASR::Array_t* array_t = ASR::down_cast<ASR::Array_t>(t);
-                type_src = get_c_type_from_ttype_t(array_t->m_type);
+                type_src = "struct " + ASRUtils::get_type_code(array_t->m_type) + "*";
                 break;
             }
             case ASR::ttypeType::Pointer: {

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1076,7 +1076,7 @@ public:
         } else if (var_annotation == "str") {
             type = ASRUtils::TYPE(ASR::make_Character_t(al, loc, 1, -2, nullptr));
             type = ASRUtils::make_Array_t_util(al, loc, type, dims.p, dims.size());
-        } else if (var_annotation == "bool") {
+        } else if (var_annotation == "bool" || var_annotation == "i1") {
             type = ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4));
             type = ASRUtils::make_Array_t_util(al, loc, type, dims.p, dims.size());
         } else if (var_annotation == "CPtr") {
@@ -4446,11 +4446,11 @@ public:
                     if (AST::is_a<AST::Name_t>(*x.m_targets[0])) {
                         std::string tvar_name = AST::down_cast<AST::Name_t>(x.m_targets[0])->m_id;
                         // Check if the type variable name is a reserved type keyword
-                        const char* type_list[14]
+                        const char* type_list[15]
                             = { "list", "set", "dict", "tuple",
                                 "i8", "i16", "i32", "i64", "f32",
-                                "f64", "c32", "c64", "str", "bool"};
-                        for (int i = 0; i < 14; i++) {
+                                "f64", "c32", "c64", "str", "bool", "i1"};
+                        for (int i = 0; i < 15; i++) {
                             if (strcmp(s2c(al, tvar_name), type_list[i]) == 0) {
                                 throw SemanticError(tvar_name + " is a reserved type, consider a different type variable name",
                                     x.base.base.loc);

--- a/src/runtime/lpython/lpython.py
+++ b/src/runtime/lpython/lpython.py
@@ -15,6 +15,7 @@ __slots__ = ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64",
 # data-types
 
 type_to_convert_func = {
+    "i1": bool,
     "i8": int,
     "i16": int,
     "i32": int,
@@ -75,6 +76,7 @@ class Array:
         self._type = type
         self._dims = dims
 
+i1 = Type("i1")
 i8 = Type("i8")
 i16 = Type("i16")
 i32 = Type("i32")


### PR DESCRIPTION
This PR adds support (and tests) for arrays of unsigned integers, bool, complex types for the `@pythoncall` decorator.