### PR TITLE
Support character iteration over strings

### DIFF
--- a/integration_tests/test_list_11.py
+++ b/integration_tests/test_list_11.py
@@ -11,6 +11,13 @@ def test_issue_1882():
     for i in [1, 2, 3]:
         assert i + 1 == x[i - 1]
 
+def test_iterate_over_string():
+    s: str
+    i: i32 = 0
+    temp: str = "abcd"
+    for s in "abcd":
+        assert s == temp[i]
+        i+=1
 
 def main0():
     x: list[i32] = return_empty_list_of_tuples()
@@ -18,5 +25,6 @@ def main0():
 
     assert len(x) == 0
     test_issue_1882()
+    test_iterate_over_string()
 
 main0()

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5371,7 +5371,7 @@ public:
                 throw SemanticError("Only Name is supported for Subscript",
                     sbt->base.base.loc);
             }
-        } else if (AST::is_a<AST::List_t>(*x.m_iter)) {
+        } else if (AST::is_a<AST::List_t>(*x.m_iter) || AST::is_a<AST::ConstantStr_t>(*x.m_iter) ) {
             visit_expr(*x.m_iter);
             ASR::expr_t *target = ASRUtils::EXPR(tmp);
             ASR::ttype_t *loop_src_var_ttype = ASRUtils::expr_type(target);


### PR DESCRIPTION
```
def f():
    s: str
    for s in "abcd":
        print(s)
f()

```
On main:
```
semantic error: Only function call `range(..)` supported as for loop iteration for now
 --> try.py:5:5 - 6:16
  |
5 |        for s in "abcd":
  |        ^^^^^^^^^^^^^^^^...
...
  |
6 |            print(s)
```

On branch :
```
(lp) C:\Users\kunni\lpython>src\bin\lpython try.py
a
b
c
d
```