### PR TITLE
Handle the case where start is greater than end in `list.index()`

### DIFF
--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2787,7 +2787,10 @@ namespace LCompilers {
 
         llvm::Value* cond = builder->CreateICmpEQ(
                               LLVM::CreateLoad(*builder, i), end_point);
-        llvm_utils->create_if_else(cond, [&]() {
+        llvm::Value* start_greater_than_end = builder->CreateICmpSGE(
+                                                LLVM::CreateLoad(*builder, i), end_point);
+        llvm::Value* condition = builder->CreateOr(cond, start_greater_than_end);
+        llvm_utils->create_if_else(condition, [&]() {
             std::string message = "The list does not contain the element: ";
             llvm::Value *fmt_ptr = builder->CreateGlobalStringPtr("ValueError: %s%d\n");
             llvm::Value *fmt_ptr2 = builder->CreateGlobalStringPtr(message);

--- a/tests/errors/test_list_index4.py
+++ b/tests/errors/test_list_index4.py
@@ -1,0 +1,8 @@
+from lpython import i32
+
+def test_list_index4_error():
+    a: list[i32]
+    a = [1, 2, 3]
+    print(lst.index(2,2,1))
+
+test_list_index4_error()

--- a/tests/errors/test_list_index4.py
+++ b/tests/errors/test_list_index4.py
@@ -3,6 +3,6 @@ from lpython import i32
 def test_list_index4_error():
     a: list[i32]
     a = [1, 2, 3]
-    print(lst.index(2,2,1))
+    print(a.index(2,2,1))
 
 test_list_index4_error()

--- a/tests/reference/runtime-test_list_index4-c31dfdb.json
+++ b/tests/reference/runtime-test_list_index4-c31dfdb.json
@@ -1,0 +1,13 @@
+{
+    "basename": "runtime-test_list_index4-c31dfdb",
+    "cmd": "lpython {infile}",
+    "infile": "tests/errors/test_list_index4.py",
+    "infile_hash": "2f332b34ab594a273fb45c7c7a714557906de03f79132a0cd2a0f966",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "runtime-test_list_index4-c31dfdb.stderr",
+    "stderr_hash": "42ba013b21768d8d2577e2e3218f747a82706ca0b625ae33458452df",
+    "returncode": 2
+}

--- a/tests/reference/runtime-test_list_index4-c31dfdb.json
+++ b/tests/reference/runtime-test_list_index4-c31dfdb.json
@@ -2,12 +2,12 @@
     "basename": "runtime-test_list_index4-c31dfdb",
     "cmd": "lpython {infile}",
     "infile": "tests/errors/test_list_index4.py",
-    "infile_hash": "2f332b34ab594a273fb45c7c7a714557906de03f79132a0cd2a0f966",
+    "infile_hash": "4513031129335b8c83686936c12f6b24516c14a79ad5c3b9a9d98113",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "runtime-test_list_index4-c31dfdb.stderr",
-    "stderr_hash": "42ba013b21768d8d2577e2e3218f747a82706ca0b625ae33458452df",
-    "returncode": 2
+    "stderr_hash": "3e3eee1ba7f96c1edaeed1c7b93f54b397dbe3b08d20c9b720c291a5",
+    "returncode": 1
 }

--- a/tests/reference/runtime-test_list_index4-c31dfdb.stderr
+++ b/tests/reference/runtime-test_list_index4-c31dfdb.stderr
@@ -1,0 +1,5 @@
+[0;31;1msemantic error[0;0m[0;1m: NameError: 'lst' is not defined[0;0m
+ [0;34;1m-->[0;0m tests/errors/test_list_index4.py:6:11
+  [0;34;1m|[0;0m
+[0;34;1m6 |[0;0m     print(lst.index(2,2,1))
+  [0;34;1m|[0;0m           [0;31;1m^^^ [0;0m

--- a/tests/reference/runtime-test_list_index4-c31dfdb.stderr
+++ b/tests/reference/runtime-test_list_index4-c31dfdb.stderr
@@ -1,5 +1,1 @@
-[0;31;1msemantic error[0;0m[0;1m: NameError: 'lst' is not defined[0;0m
- [0;34;1m-->[0;0m tests/errors/test_list_index4.py:6:11
-  [0;34;1m|[0;0m
-[0;34;1m6 |[0;0m     print(lst.index(2,2,1))
-  [0;34;1m|[0;0m           [0;31;1m^^^ [0;0m
+ValueError: The list does not contain the element: 2

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -790,6 +790,10 @@ filename = "errors/test_list_index3.py"
 run = true
 
 [[test]]
+filename = "errors/test_list_index4.py"
+run = true
+
+[[test]]
 filename = "errors/test_list1.py"
 asr = true
 


### PR DESCRIPTION
A rather unlikely edge case -
```
def f():
    lst :list[i32] = [1, 2, 3]
    print(lst.index(2,2,1))

f()
```
On master :

```
(lp) C:\Users\kunni\lpython>python try.py
Traceback (most recent call last):
  File "C:\Users\kunni\lpython\try.py", line 5, in <module>
    f()
  File "C:\Users\kunni\lpython\try.py", line 3, in f
    print(lst.index(2,2,1))
ValueError: 2 is not in list

(lp) C:\Users\kunni\lpython>src\bin\lpython try.py
2
```
On branch :
```
(lp) C:\Users\kunni\lpython>src\bin\lpython try.py
ValueError: The list does not contain the element: 2
```