### PR TITLE
Added support for assert through SymbolicCompare

### DIFF
--- a/integration_tests/symbolics_01.py
+++ b/integration_tests/symbolics_01.py
@@ -6,6 +6,7 @@ def main0():
     y: S = Symbol('y')
     x = pi
     z: S = x + y
+    print(z)
     assert(z == pi + y)
     assert(z != S(2)*pi + y)
 

--- a/integration_tests/symbolics_01.py
+++ b/integration_tests/symbolics_01.py
@@ -6,6 +6,7 @@ def main0():
     y: S = Symbol('y')
     x = pi
     z: S = x + y
-    print(z)
+    assert(z == pi + y)
+    assert(z != S(2)*pi + y)
 
 main0()

--- a/integration_tests/symbolics_02.py
+++ b/integration_tests/symbolics_02.py
@@ -8,27 +8,33 @@ def test_symbolic_operations():
     # Addition
     z: S = x + y
     assert(z == x + y)
+    print(z)
     
     # Subtraction
     w: S = x - y
     assert(w == x - y)
+    print(w)
     
     # Multiplication
     u: S = x * y
     assert(u == x * y)
-    
+    print(u)
+
     # Division
     v: S = x / y
     assert(v == x / y)
-    
+    print(v)
+
     # Power
     p: S = x ** y
     assert(p == x ** y)
-    
+    print(p)
+
     # Casting
     a: S = S(100)
     b: S = S(-100)
     c: S = a + b
     assert(c == S(0))
+    print(c)
 
 test_symbolic_operations()

--- a/integration_tests/symbolics_02.py
+++ b/integration_tests/symbolics_02.py
@@ -7,28 +7,28 @@ def test_symbolic_operations():
     
     # Addition
     z: S = x + y
-    print(z)  # Expected: x + y
+    assert(z == x + y)
     
     # Subtraction
     w: S = x - y
-    print(w)  # Expected: x - y
+    assert(w == x - y)
     
     # Multiplication
     u: S = x * y
-    print(u)  # Expected: x*y
+    assert(u == x * y)
     
     # Division
     v: S = x / y
-    print(v)  # Expected: x/y
+    assert(v == x / y)
     
     # Power
     p: S = x ** y
-    print(p)  # Expected: x**y
+    assert(p == x ** y)
     
     # Casting
     a: S = S(100)
     b: S = S(-100)
     c: S = a + b
-    print(c)  # Expected: 0
+    assert(c == S(0))
 
 test_symbolic_operations()

--- a/integration_tests/symbolics_03.py
+++ b/integration_tests/symbolics_03.py
@@ -6,13 +6,16 @@ def test_operator_chaining():
     x: S = Symbol('x')
     y: S = Symbol('y')
     z: S = Symbol('z')
-    Pi: S = Symbol('pi')
 
     a: S = x * w
-    b: S = a + Pi
+    b: S = a + pi
     c: S = b / z
     d: S = c ** w
 
+    assert(a == S(2)*x)
+    assert(b == pi + S(2)*x)
+    assert(c == (pi + S(2)*x)/z)
+    assert(d == (pi + S(2)*x)**S(2)/z**S(2))
     print(a)  # Expected: 2*x
     print(b)  # Expected: pi + 2*x
     print(c)  # Expected: (pi + 2*x)/z

--- a/integration_tests/symbolics_04.py
+++ b/integration_tests/symbolics_04.py
@@ -13,6 +13,7 @@ def test_chained_operations():
     result: S = (w ** S(2) - pi) + S(3)
     
     # Print Statements
+    assert(result == S(3) + (a -b)**S(2)*(x + y)**S(2)/(z + pi)**S(2) - pi)
     print(result)
     # Expected: 3 + (a - b)**2*(x + y)**2/(z + pi)**2 - pi
     
@@ -29,13 +30,11 @@ def test_chained_operations():
     result = (z + e) * (a - b)
     
     # Print Statements
+    assert(result == (a - b)*(e + ((S(5) + pi)*(S(-10) + (e + c*d)/f))**(S(2)/(d + f))))
     print(result)
     # Expected: (a - b)*(e + ((5 + pi)*(-10 + (e + c*d)/f))**(2/(d + f)))
-    print(x)
-    # Expected: (e + c*d)/f
-    print(y)
-    # Expected: (5 + pi)*(-10 + (e + c*d)/f)
-    print(z)
-    # Expected: ((5 + pi)*(-10 + (e + c*d)/f))**(2/(d + f))
+    assert(x == (e + c*d)/f)
+    assert(y == (S(5) + pi)*(S(-10) + (e + c*d)/f))
+    assert(z == ((S(5) + pi)*(S(-10) + (e + c*d)/f))**(S(2)/(d + f)))
 
 test_chained_operations()

--- a/integration_tests/symbolics_04.py
+++ b/integration_tests/symbolics_04.py
@@ -15,7 +15,6 @@ def test_chained_operations():
     # Print Statements
     assert(result == S(3) + (a -b)**S(2)*(x + y)**S(2)/(z + pi)**S(2) - pi)
     print(result)
-    # Expected: 3 + (a - b)**2*(x + y)**2/(z + pi)**2 - pi
     
     # Additional Variables
     c: S = Symbol('c')
@@ -32,9 +31,11 @@ def test_chained_operations():
     # Print Statements
     assert(result == (a - b)*(e + ((S(5) + pi)*(S(-10) + (e + c*d)/f))**(S(2)/(d + f))))
     print(result)
-    # Expected: (a - b)*(e + ((5 + pi)*(-10 + (e + c*d)/f))**(2/(d + f)))
     assert(x == (e + c*d)/f)
+    print(x)
     assert(y == (S(5) + pi)*(S(-10) + (e + c*d)/f))
+    print(y)
     assert(z == ((S(5) + pi)*(S(-10) + (e + c*d)/f))**(S(2)/(d + f)))
+    print(z)
 
 test_chained_operations()

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -290,6 +290,7 @@ expr
     | StringChr(expr arg, ttype type, expr? value)
 
     | CPtrCompare(expr left, cmpop op, expr right, ttype type, expr? value)
+    | SymbolicCompare(expr left, cmpop op, expr right, ttype type, expr? value)
 
     | DictConstant(expr* keys, expr* values, ttype type)
     | DictLen(expr arg, ttype type, expr? value)

--- a/src/libasr/codegen/asr_to_c.cpp
+++ b/src/libasr/codegen/asr_to_c.cpp
@@ -1064,15 +1064,19 @@ R"(    // Initialise Numpy
         std::string indent(indentation_level*indentation_spaces, ' ');
         std::string out = indent;
         bracket_open++;
+        visit_expr(*x.m_test);
+        if (ASR::is_a<ASR::SymbolicCompare_t>(*x.m_test)){
+            out = symengine_src;
+            symengine_src = "";
+            out += indent;
+        }
         if (x.m_msg) {
             out += "ASSERT_MSG(";
-            visit_expr(*x.m_test);
             out += src + ", ";
             visit_expr(*x.m_msg);
             out += src + ");\n";
         } else {
             out += "ASSERT(";
-            visit_expr(*x.m_test);
             out += src + ");\n";
         }
         bracket_open--;

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -89,7 +89,6 @@ public:
     std::vector<std::string> queue;
     int queue_front = -1;
     std::string& symengine_src;
-    std::unordered_set<std::string> variables_to_free;
 
     SymEngineQueue(std::string& symengine_src) : symengine_src(symengine_src) {}
 
@@ -103,13 +102,11 @@ public:
             symengine_src = indent + "basic " + var + ";\n";
             symengine_src += indent + "basic_new_stack(" + var + ");\n";
         }
-        variables_to_free.insert(queue[queue_front]);
         return queue[queue_front++];
     }
 
     void pop() {
         LCOMPILERS_ASSERT(queue_front != -1 && queue_front < static_cast<int>(queue.size()));
-        variables_to_free.insert(queue[queue_front]);
         queue_front++;
     }
 };
@@ -786,10 +783,6 @@ R"(#include <stdio.h>
                     + ";\n";
             }
 
-            for (const auto& var : symengine_queue.variables_to_free) {
-                current_body += indent + "basic_free_stack(" + var + ");\n";
-            }
-            symengine_queue.variables_to_free.clear();
             if (decl.size() > 0 || current_body.size() > 0) {
                 sub += "{\n" + decl + current_body + "}\n";
             } else {

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <memory>
 #include <set>
+#include <unordered_set>
 
 #include <libasr/asr.h>
 #include <libasr/containers.h>
@@ -88,6 +89,7 @@ public:
     std::vector<std::string> queue;
     int queue_front = -1;
     std::string& symengine_src;
+    std::unordered_set<std::string> variables_to_free;
 
     SymEngineQueue(std::string& symengine_src) : symengine_src(symengine_src) {}
 
@@ -97,14 +99,17 @@ public:
         if(queue_front == -1 || queue_front >= static_cast<int>(queue.size())) {
             var = "queue" + std::to_string(queue.size());
             queue.push_back(var);
+            if(queue_front == -1) queue_front++;
             symengine_src = indent + "basic " + var + ";\n";
             symengine_src += indent + "basic_new_stack(" + var + ");\n";
         }
+        variables_to_free.insert(queue[queue_front]);
         return queue[queue_front++];
     }
 
     void pop() {
         LCOMPILERS_ASSERT(queue_front != -1 && queue_front < static_cast<int>(queue.size()));
+        variables_to_free.insert(queue[queue_front]);
         queue_front++;
     }
 };
@@ -781,6 +786,10 @@ R"(#include <stdio.h>
                     + ";\n";
             }
 
+            for (const auto& var : symengine_queue.variables_to_free) {
+                current_body += indent + "basic_free_stack(" + var + ");\n";
+            }
+            symengine_queue.variables_to_free.clear();
             if (decl.size() > 0 || current_body.size() > 0) {
                 sub += "{\n" + decl + current_body + "}\n";
             } else {
@@ -1950,6 +1959,40 @@ PyMODINIT_FUNC PyInit_lpython_module_)" + fn_name + R"((void) {
 
     void visit_CPtrCompare(const ASR::CPtrCompare_t &x) {
         handle_Compare(x);
+    }
+
+    void visit_SymbolicCompare(const ASR::SymbolicCompare_t &x) {
+        CHECK_FAST_C_CPP(compiler_options, x)
+        self().visit_expr(*x.m_left);
+        std::string left_src = symengine_src;
+        if(ASR::is_a<ASR::Var_t>(*x.m_left)){
+            symengine_queue.pop();
+        }
+        std::string left = std::move(src);
+
+        self().visit_expr(*x.m_right);
+        std::string right_src = symengine_src;
+        if(ASR::is_a<ASR::Var_t>(*x.m_right)){
+            symengine_queue.pop();
+        }
+        std::string right = std::move(src);
+        std::string op_str = ASRUtils::cmpop_to_str(x.m_op);
+        switch (x.m_op) {
+            case (ASR::cmpopType::Eq) : {
+                src = "basic_eq(" + left + ", " + right + ") " + op_str + " 1";
+                break;
+            }
+            case (ASR::cmpopType::NotEq) : {
+                src = "basic_neq(" + left + ", " + right + ") " + op_str + " 0";
+                break;
+            }
+            default : {
+                throw LCompilersException("Symbolic comparison operator: '"
+                    + op_str
+                    + "' is not implemented");
+            }
+        }
+        symengine_src = left_src + right_src;
     }
 
     template<typename T>

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6227,6 +6227,8 @@ public:
                                 x.base.base.loc);
             }
             tmp = ASR::make_CPtrCompare_t(al, x.base.base.loc, left, asr_op, right, type, value);
+        } else if (ASR::is_a<ASR::SymbolicExpression_t>(*dest_type)) {
+            tmp = ASR::make_SymbolicCompare_t(al, x.base.base.loc, left, asr_op, right, type, value);
         } else {
             throw SemanticError("Compare not supported for type: " + ASRUtils::type_to_str_python(dest_type),
                                 x.base.base.loc);


### PR DESCRIPTION
The Pr adds support for the following 
1) Freeing the basic variables declared throughout the C generated code . For eg
```
(lf) anutosh491@spbhat68:~/lpython/lpython$ cat examples/expr2.py 
from sympy import Symbol, pi
from lpython import S

def main0():
    x: S = Symbol('x')
    y: S = Symbol('y')
    print(pi + S(100))

main0()

// Implementations
void main0()
{
    basic x;
    basic_new_stack(x);
    basic y;
    basic_new_stack(y);
    symbol_set(x, "x");
    symbol_set(y, "y");
    basic queue2;
    basic_new_stack(queue2);
    basic queue3;
    basic_new_stack(queue3);
    basic_const_pi(queue3);
    basic queue4;
    basic_new_stack(queue4);
    integer_set_si(queue4, 100);
    basic_add(queue2, queue3, queue4);
    printf("%s\n", basic_str(queue2));
    basic_free_stack(queue4);
    basic_free_stack(queue3);
    basic_free_stack(queue2);
    basic_free_stack(y);
    basic_free_stack(x);
}
```

2) Support `equal to` and `not equal to` operators through `assert`
```
from sympy import Symbol, pi
from lpython import S

def test_operator_chaining():
    w: S = S(2)
    x: S = Symbol('x')
    y: S = Symbol('y')
    z: S = Symbol('z')

    a: S = x * w
    b: S = a + pi
    c: S = b / z
    d: S = c ** w

    assert(a == S(2)*x)
    assert(b == pi + S(2)*x)
    assert(c == (pi + S(2)*x)/z)
    assert(d == (pi + S(2)*x)**S(2)/z**S(2))
```
All test files have been updated to use assert