### PR TITLE
Added support for symbolic Expand & Differentiation

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -602,6 +602,7 @@ RUN(NAME symbolics_01        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_02        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_03        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_04        LABELS cpython_sym c_sym)
+RUN(NAME symbolics_05        LABELS cpython_sym c_sym)
 
 RUN(NAME sizeof_01           LABELS llvm c
         EXTRAFILES sizeof_01b.c)

--- a/integration_tests/symbolics_05.py
+++ b/integration_tests/symbolics_05.py
@@ -1,0 +1,26 @@
+from sympy import Symbol, expand, diff
+from lpython import S
+
+def test_operations():
+    x: S = Symbol('x')
+    y: S = Symbol('y')
+    z: S = Symbol('z')
+    
+    # test expand
+    a: S = (x + y)**S(2)
+    b: S = (x + y + z)**S(3)
+    assert(a.expand() == S(2)*x*y + x**S(2) + y**S(2))
+    assert(expand(b) == S(3)*x*y**S(2) + S(3)*x*z**S(2) + S(3)*x**S(2)*y + S(3)*x**S(2)*z +\
+    S(3)*y*z**S(2) + S(3)*y**S(2)*z + S(6)*x*y*z + x**S(3) + y**S(3) + z**S(3))
+    print(a.expand())
+    print(expand(b))
+
+    # test diff
+    c: S = (x + y)**S(2)
+    d: S = (x + y + z)**S(3)
+    assert(c.diff(x) == S(2)*(x + y))
+    assert(diff(d, x) == S(3)*(x + y + z)**S(2))
+    print(c.diff(x))
+    print(diff(d, x))
+
+test_operations()

--- a/integration_tests/symbolics_05.py
+++ b/integration_tests/symbolics_05.py
@@ -5,10 +5,10 @@ def test_operations():
     x: S = Symbol('x')
     y: S = Symbol('y')
     z: S = Symbol('z')
-    
-    # test expand
     a: S = (x + y)**S(2)
     b: S = (x + y + z)**S(3)
+
+    # test expand
     assert(a.expand() == S(2)*x*y + x**S(2) + y**S(2))
     assert(expand(b) == S(3)*x*y**S(2) + S(3)*x*z**S(2) + S(3)*x**S(2)*y + S(3)*x**S(2)*z +\
     S(3)*y*z**S(2) + S(3)*y**S(2)*z + S(6)*x*y*z + x**S(3) + y**S(3) + z**S(3))
@@ -16,11 +16,9 @@ def test_operations():
     print(expand(b))
 
     # test diff
-    c: S = (x + y)**S(2)
-    d: S = (x + y + z)**S(3)
-    assert(c.diff(x) == S(2)*(x + y))
-    assert(diff(d, x) == S(3)*(x + y + z)**S(2))
-    print(c.diff(x))
-    print(diff(d, x))
+    assert(a.diff(x) == S(2)*(x + y))
+    assert(diff(b, x) == S(3)*(x + y + z)**S(2))
+    print(a.diff(x))
+    print(diff(b, x))
 
 test_operations()

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -2755,6 +2755,10 @@ PyMODINIT_FUNC PyInit_lpython_module_)" + fn_name + R"((void) {
                 src = performSymbolicOperation("basic_pow", x);
                 return;
             }
+            case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicDiff)): {
+                src = performSymbolicOperation("basic_diff", x);
+                return;
+            }
             case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicPi)): {
                 headers.insert("symengine/cwrapper.h");
                 LCOMPILERS_ASSERT(x.n_args == 0);
@@ -2778,6 +2782,22 @@ PyMODINIT_FUNC PyInit_lpython_module_)" + fn_name + R"((void) {
                 this->visit_expr(*x.m_args[0]);
                 std::string target = symengine_queue.push();
                 symengine_src += indent + "integer_set_si(" + target + ", " + src + ");\n";
+                src = target;
+                return;
+            }
+            case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicExpand)): {
+                headers.insert("symengine/cwrapper.h");
+                LCOMPILERS_ASSERT(x.n_args == 1);
+                std::string target = symengine_queue.push();
+                std::string target_src = symengine_src;
+                this->visit_expr(*x.m_args[0]);
+                std::string arg1 = src;
+                std::string arg1_src = symengine_src;
+                if (ASR::is_a<ASR::Var_t>(*x.m_args[0])) {
+                    symengine_queue.pop();
+                }
+                symengine_src = target_src + arg1_src;
+                symengine_src += indent + "basic_expand(" + target + ", " + arg1 + ");\n";
                 src = target;
                 return;
             }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -694,6 +694,11 @@ public:
         return;
     }
 
+    void handle_symbolic_attribute(ASR::expr_t *s, std::string attr_name,
+                const Location &loc, Vec<ASR::expr_t*> &args) {
+        tmp = attr_handler.get_symbolic_attribute(s, attr_name, al, loc, args, diag);
+        return;
+    }
 
     void fill_expr_in_ttype_t(std::vector<ASR::expr_t*>& exprs, ASR::dimension_t* dims, size_t n_dims) {
         for( size_t i = 0; i < n_dims; i++ ) {
@@ -7113,6 +7118,11 @@ public:
                             handle_string_attributes(se, args, at->m_attr, loc);
                             return;
                         }
+                        ASR::ttype_t *type = ASRUtils::expr_type(se);
+                        if (ASR::is_a<ASR::SymbolicExpression_t>(*type)) {
+                            handle_symbolic_attribute(se, at->m_attr, loc, eles);
+                            return;
+                        }
                         handle_builtin_attribute(se, at->m_attr, loc, eles);
                         return;
                     }
@@ -7231,7 +7241,7 @@ public:
 
         if (!s) {
             std::set<std::string> not_cpython_builtin = {
-                "sin", "cos", "gamma", "tan", "asin", "acos", "atan", "sinh", "cosh", "tanh", "exp", "exp2", "expm1", "Symbol",
+                "sin", "cos", "gamma", "tan", "asin", "acos", "atan", "sinh", "cosh", "tanh", "exp", "exp2", "expm1", "Symbol", "diff", "expand",
                 "sum" // For sum called over lists
             };
             if (ASRUtils::IntrinsicFunctionRegistry::is_intrinsic_function(call_name) &&

--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -15,7 +15,7 @@ struct AttributeHandler {
     typedef ASR::asr_t* (*attribute_eval_callback)(ASR::expr_t*, Allocator &,
                                 const Location &, Vec<ASR::expr_t*> &, diag::Diagnostics &);
 
-    std::map<std::string, attribute_eval_callback> attribute_map;
+    std::map<std::string, attribute_eval_callback> attribute_map, symbolic_attribute_map;
     std::set<std::string> modify_attr_set;
 
     AttributeHandler() {
@@ -40,6 +40,11 @@ struct AttributeHandler {
         modify_attr_set = {"list@append", "list@remove",
             "list@reverse", "list@clear", "list@insert", "list@pop",
             "set@pop", "set@add", "set@remove", "dict@pop"};
+
+        symbolic_attribute_map = {
+            {"diff", &eval_symbolic_diff},
+            {"expand", &eval_symbolic_expand}
+        };
     }
 
     std::string get_type_name(ASR::ttype_t *t) {
@@ -78,6 +83,19 @@ struct AttributeHandler {
             return cb(e, al, loc, args, diag);
         } else {
             throw SemanticError(class_name + "." + attr_name + " is not implemented yet",
+                loc);
+        }
+    }
+
+    ASR::asr_t* get_symbolic_attribute(ASR::expr_t *e, std::string attr_name,
+            Allocator &al, const Location &loc, Vec<ASR::expr_t*> &args, diag::Diagnostics &diag) {
+        std::string key = attr_name;
+        auto search = symbolic_attribute_map.find(key);
+        if (search != symbolic_attribute_map.end()) {
+            attribute_eval_callback cb = search->second;
+            return cb(e, al, loc, args, diag);
+        } else {
+            throw SemanticError("S." + attr_name + " is not implemented yet",
                 loc);
         }
     }
@@ -386,6 +404,34 @@ struct AttributeHandler {
             throw SemanticAbort();
         }
         return make_DictPop_t(al, loc, s, args[0], value_type, nullptr);
+    }
+
+    static ASR::asr_t* eval_symbolic_diff(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &/*diag*/) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicFunctionRegistry::get_create_function("diff");
+        return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
+                                { throw SemanticError(msg, loc); });
+    }
+
+    static ASR::asr_t* eval_symbolic_expand(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &/*diag*/) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicFunctionRegistry::get_create_function("expand");
+        return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
+                                { throw SemanticError(msg, loc); });
     }
 
 }; // AttributeHandler


### PR DESCRIPTION
Symbolic operations in SymPy can be used as both attributes 
```
>>> from sympy import Symbol, S
>>> x = Symbol('x')
>>> y = Symbol('y')
>>> ((x + y)**S(3)).expand()
x**3 + 3*x**2*y + 3*x*y**2 + y**3
```
OR can be imported and can be called as function
```
>>> from sympy import Symbol, S, expand
>>> x = Symbol('x')
>>> y = Symbol('y')
>>> expand((x + y)**S(3))
x**3 + 3*x**2*y + 3*x*y**2 + y**3
```
Hence I have added support for both 
```
(lf) anutosh491@spbhat68:~/lpython/lpython$ cat examples/expr2.py 
from sympy import Symbol, expand

def main0():
    x: S = Symbol('x')
    y: S = Symbol('y')
    z: S = (x + y)**S(3)
    print(z.expand())
    print(expand((x + y)**S(4)))

main0()

(lf) anutosh491@spbhat68:~/lpython/lpython$ lpython --backend=c --enable-symengine examples/expr2.py 
3*x*y**2 + 3*x**2*y + x**3 + y**3
4*x*y**3 + 6*x**2*y**2 + 4*x**3*y + x**4 + y**4
```
The `diff` operation has been dealt similarly