### PR TITLE
Added support for symbolic elementary functions

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -605,6 +605,7 @@ RUN(NAME symbolics_02        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_03        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_04        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_05        LABELS cpython_sym c_sym)
+RUN(NAME symbolics_06        LABELS cpython_sym c_sym)
 
 RUN(NAME sizeof_01           LABELS llvm c
         EXTRAFILES sizeof_01b.c)

--- a/integration_tests/symbolics_06.py
+++ b/integration_tests/symbolics_06.py
@@ -23,7 +23,7 @@ def test_elementary_functions():
     # test Abs
     assert(Abs(S(-10)) == S(10))
     assert(Abs(S(10)) == S(10))
-    assert(Abs(-x) == Abs(x))
+    assert(Abs(S(-1)*x) == Abs(x))
 
     # test composite functions
     a: S = exp(x)

--- a/integration_tests/symbolics_06.py
+++ b/integration_tests/symbolics_06.py
@@ -1,0 +1,37 @@
+from sympy import Symbol, sin, cos, exp, log, Abs, pi, diff
+from lpython import S
+
+def test_elementary_functions():
+
+    # test sin, cos
+    x: S = Symbol('x')
+    assert(sin(pi) == S(0))
+    assert(sin(pi/S(2)) == S(1))
+    assert(sin(S(2)*pi) == S(0))
+    assert(cos(pi) == S(-1))
+    assert(cos(pi/S(2)) == S(0))
+    assert(cos(S(2)*pi) == S(1))
+    assert(diff(sin(x), x) == cos(x))
+    assert(diff(cos(x), x) == S(-1)*sin(x))
+
+    # test exp, log
+    assert(exp(S(0)) == S(1))
+    assert(log(S(1)) == S(0))
+    assert(diff(exp(x), x) == exp(x))
+    assert(diff(log(x), x) == S(1)/x)
+
+    # test Abs
+    assert(Abs(S(-10)) == S(10))
+    assert(Abs(S(10)) == S(10))
+    assert(Abs(-x) == Abs(x))
+
+    # test composite functions
+    a: S = exp(x)
+    b: S = sin(a)
+    c: S = cos(b)
+    d: S = log(c)
+    e: S = Abs(d)
+    print(e)
+    assert(e == Abs(log(cos(sin(exp(x))))))
+
+test_elementary_functions()

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -2702,7 +2702,7 @@ PyMODINIT_FUNC PyInit_lpython_module_)" + fn_name + R"((void) {
             out += func_name; break;                                     \
         }
 
-    std::string performSymbolicOperation(const std::string& functionName, const ASR::IntrinsicFunction_t& x) {
+    std::string performBinarySymbolicOperation(const std::string& functionName, const ASR::IntrinsicFunction_t& x) {
         headers.insert("symengine/cwrapper.h");
         std::string indent(4, ' ');
         LCOMPILERS_ASSERT(x.n_args == 2);
@@ -2727,6 +2727,23 @@ PyMODINIT_FUNC PyInit_lpython_module_)" + fn_name + R"((void) {
         return target;
     }
 
+    std::string performUnarySymbolicOperation(const std::string& functionName, const ASR::IntrinsicFunction_t& x) {
+        headers.insert("symengine/cwrapper.h");
+        std::string indent(4, ' ');
+        LCOMPILERS_ASSERT(x.n_args == 1);
+        std::string target = symengine_queue.push();
+        std::string target_src = symengine_src;
+        this->visit_expr(*x.m_args[0]);
+        std::string arg1 = src;
+        std::string arg1_src = symengine_src;
+        if (ASR::is_a<ASR::Var_t>(*x.m_args[0])) {
+            symengine_queue.pop();
+        }
+        symengine_src = target_src + arg1_src;
+        symengine_src += indent + functionName + "(" + target + ", " + arg1 + ");\n";
+        return target;
+    }
+
     void visit_IntrinsicFunction(const ASR::IntrinsicFunction_t &x) {
         std::string out;
         std::string indent(4, ' ');
@@ -2745,27 +2762,51 @@ PyMODINIT_FUNC PyInit_lpython_module_)" + fn_name + R"((void) {
             SET_INTRINSIC_NAME(Exp2, "exp2");
             SET_INTRINSIC_NAME(Expm1, "expm1");
             case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicAdd)): {
-                src = performSymbolicOperation("basic_add", x);
+                src = performBinarySymbolicOperation("basic_add", x);
                 return;
             }
             case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicSub)): {
-                src = performSymbolicOperation("basic_sub", x);
+                src = performBinarySymbolicOperation("basic_sub", x);
                 return;
             }
             case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicMul)): {
-                src = performSymbolicOperation("basic_mul", x);
+                src = performBinarySymbolicOperation("basic_mul", x);
                 return;
             }
             case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicDiv)): {
-                src = performSymbolicOperation("basic_div", x);
+                src = performBinarySymbolicOperation("basic_div", x);
                 return;
             }
             case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicPow)): {
-                src = performSymbolicOperation("basic_pow", x);
+                src = performBinarySymbolicOperation("basic_pow", x);
                 return;
             }
             case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicDiff)): {
-                src = performSymbolicOperation("basic_diff", x);
+                src = performBinarySymbolicOperation("basic_diff", x);
+                return;
+            }
+            case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicSin)): {
+                src = performUnarySymbolicOperation("basic_sin", x);
+                return;
+            }
+            case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicCos)): {
+                src = performUnarySymbolicOperation("basic_cos", x);
+                return;
+            }
+            case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicLog)): {
+                src = performUnarySymbolicOperation("basic_log", x);
+                return;
+            }
+            case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicExp)): {
+                src = performUnarySymbolicOperation("basic_exp", x);
+                return;
+            }
+            case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicAbs)): {
+                src = performUnarySymbolicOperation("basic_abs", x);
+                return;
+            }
+            case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicExpand)): {
+                src = performUnarySymbolicOperation("basic_expand", x);
                 return;
             }
             case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicPi)): {
@@ -2791,22 +2832,6 @@ PyMODINIT_FUNC PyInit_lpython_module_)" + fn_name + R"((void) {
                 this->visit_expr(*x.m_args[0]);
                 std::string target = symengine_queue.push();
                 symengine_src += indent + "integer_set_si(" + target + ", " + src + ");\n";
-                src = target;
-                return;
-            }
-            case (static_cast<int64_t>(ASRUtils::IntrinsicFunctions::SymbolicExpand)): {
-                headers.insert("symengine/cwrapper.h");
-                LCOMPILERS_ASSERT(x.n_args == 1);
-                std::string target = symengine_queue.push();
-                std::string target_src = symengine_src;
-                this->visit_expr(*x.m_args[0]);
-                std::string arg1 = src;
-                std::string arg1_src = symengine_src;
-                if (ASR::is_a<ASR::Var_t>(*x.m_args[0])) {
-                    symengine_queue.pop();
-                }
-                symengine_src = target_src + arg1_src;
-                symengine_src += indent + "basic_expand(" + target + ", " + arg1 + ");\n";
                 src = target;
                 return;
             }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -7265,15 +7265,23 @@ public:
         }
 
         if (!s) {
+            std::string intrinsic_name = call_name;
             std::set<std::string> not_cpython_builtin = {
                 "sin", "cos", "gamma", "tan", "asin", "acos", "atan", "sinh", "cosh", "tanh", "exp", "exp2", "expm1", "Symbol", "diff", "expand",
                 "sum" // For sum called over lists
             };
-            if (ASRUtils::IntrinsicFunctionRegistry::is_intrinsic_function(call_name) &&
+            std::set<std::string> symbolic_functions = {
+                "sin", "cos", "log", "exp", "Abs"
+            };
+            if ((symbolic_functions.find(call_name) != symbolic_functions.end()) &&
+                imported_functions[call_name] == "sympy"){
+                intrinsic_name = "Symbolic" + std::string(1, std::toupper(call_name[0])) + call_name.substr(1);
+            }
+            if (ASRUtils::IntrinsicFunctionRegistry::is_intrinsic_function(intrinsic_name) &&
                 (not_cpython_builtin.find(call_name) == not_cpython_builtin.end() ||
                 imported_functions.find(call_name) != imported_functions.end() )) {
                 ASRUtils::create_intrinsic_function create_func =
-                    ASRUtils::IntrinsicFunctionRegistry::get_create_function(call_name);
+                    ASRUtils::IntrinsicFunctionRegistry::get_create_function(intrinsic_name);
                 Vec<ASR::expr_t*> args_; args_.reserve(al, x.n_args);
                 visit_expr_list(x.m_args, x.n_args, args_);
                 if (ASRUtils::is_array(ASRUtils::expr_type(args_[0])) &&


### PR DESCRIPTION
This Pr implements 5 elementary symbolic functions (`sin`, `cos`, `exp`, `log`, `Abs`) through a macro `create_symbolic_unary_macro` as all of these functions take in a single argument . Hence something like the following can be accomplished. 
```
(lf) anutosh491@spbhat68:~/lpython/lpython$ cat examples/expr2.py 
from sympy import Symbol, Abs, sin, pi, log, exp
def main0():
    x: S = Symbol('x')
    y: S = Symbol('y')
    z: S = exp(x**S(2) + pi)
    print(z)
    print(sin(z))
    print(log(z + Abs(S(-10))))

main0()

(lf) anutosh491@spbhat68:~/lpython/lpython$ lpython --backend=c --enable-symengine examples/expr2.py 
exp(x**2 + pi)
sin(exp(x**2 + pi))
log(10 + exp(x**2 + pi))