### PR TITLE
Unsigned integers improvement and fixes

### DIFF
--- a/integration_tests/cast_02.py
+++ b/integration_tests/cast_02.py
@@ -34,9 +34,46 @@ def test_02():
     print(w)
     assert w == u32(11)
 
+def test_03():
+    x : u32 = u32(-10)
+    print(x)
+    assert x == u32(4294967286)
+
+    y: u16 = u16(x)
+    print(y)
+    assert y == u16(65526)
+
+    z: u64 = u64(y)
+    print(z)
+    assert z == u64(65526)
+
+    w: u8 = u8(z)
+    print(w)
+    assert w == u8(246)
+
+def test_04():
+    x : u64 = u64(-11)
+    print(x)
+    # TODO: We are unable to store the following u64 in AST/R
+    # assert x == u64(18446744073709551605)
+
+    y: u8 = u8(x)
+    print(y)
+    assert y == u8(245)
+
+    z: u16 = u16(y)
+    print(z)
+    assert z == u16(245)
+
+    w: u32 = u32(z)
+    print(w)
+    assert w == u32(245)
+
 
 def main0():
     test_01()
     test_02()
+    test_03()
+    test_04()
 
 main0()

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5345,7 +5345,8 @@ public:
         tmp = builder->CreateNot(tmp);
     }
 
-    void visit_IntegerUnaryMinus(const ASR::IntegerUnaryMinus_t &x) {
+    template <typename T>
+    void handle_SU_IntegerUnaryMinus(const T& x) {
         if (x.m_value) {
             this->visit_expr_wrapper(x.m_value, true);
             return;
@@ -5356,15 +5357,12 @@ public:
         tmp = builder->CreateSub(zero, tmp);
     }
 
+    void visit_IntegerUnaryMinus(const ASR::IntegerUnaryMinus_t &x) {
+        handle_SU_IntegerUnaryMinus(x);
+    }
+
     void visit_UnsignedIntegerUnaryMinus(const ASR::UnsignedIntegerUnaryMinus_t &x) {
-        if (x.m_value) {
-            this->visit_expr_wrapper(x.m_value, true);
-            return;
-        }
-        this->visit_expr_wrapper(x.m_arg, true);
-        int kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(x.m_arg));
-        llvm::Value *one = llvm::ConstantInt::get(context, llvm::APInt(kind * 8, 1, true));
-        tmp = builder->CreateAdd(builder->CreateNot(tmp), one); // compute 2's complement
+        handle_SU_IntegerUnaryMinus(x);
     }
 
     void visit_RealUnaryMinus(const ASR::RealUnaryMinus_t &x) {

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6025,8 +6025,7 @@ public:
                 }
                 break;
             }
-            case (ASR::cast_kindType::IntegerToInteger) :
-            case (ASR::cast_kindType::UnsignedIntegerToUnsignedInteger) : {
+            case (ASR::cast_kindType::IntegerToInteger) : {
                 int arg_kind = -1, dest_kind = -1;
                 extract_kinds(x, arg_kind, dest_kind);
                 if( arg_kind > 0 && dest_kind > 0 &&
@@ -6034,6 +6033,20 @@ public:
                 {
                     if (dest_kind > arg_kind) {
                         tmp = builder->CreateSExt(tmp, llvm_utils->getIntType(dest_kind));
+                    } else {
+                        tmp = builder->CreateTrunc(tmp, llvm_utils->getIntType(dest_kind));
+                    }
+                }
+                break;
+            }
+            case (ASR::cast_kindType::UnsignedIntegerToUnsignedInteger) : {
+                int arg_kind = -1, dest_kind = -1;
+                extract_kinds(x, arg_kind, dest_kind);
+                if( arg_kind > 0 && dest_kind > 0 &&
+                    arg_kind != dest_kind )
+                {
+                    if (dest_kind > arg_kind) {
+                        tmp = builder->CreateZExt(tmp, llvm_utils->getIntType(dest_kind));
                     } else {
                         tmp = builder->CreateTrunc(tmp, llvm_utils->getIntType(dest_kind));
                     }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -3602,9 +3602,8 @@ public:
                 if (ASRUtils::expr_value(operand) != nullptr) {
                     int64_t op_value = ASR::down_cast<ASR::UnsignedIntegerConstant_t>(
                                             ASRUtils::expr_value(operand))->m_n;
-                    op_value = (~op_value) + 1; // compute 2's complement
                     value = ASR::down_cast<ASR::expr_t>(ASR::make_UnsignedIntegerConstant_t(
-                        al, x.base.base.loc, op_value, operand_type));
+                        al, x.base.base.loc, -op_value, operand_type));
                 }
                 tmp = ASR::make_UnsignedIntegerUnaryMinus_t(al, x.base.base.loc, operand,
                                                     operand_type, value);


### PR DESCRIPTION
On main:
```bash
$ cat examples/expr2.py 
from lpython import u32, u64

def test():
    x : u32 = u32(-10)
    print(x)
    assert x == u32(4294967286)

    z: u64 = u64(x)
    print(z)
    assert z == u64(4294967286)

test()
$ python examples/expr2.py     
4294967286
4294967286
$ lpython examples/expr2.py
4294967286
18446744073709551606
AssertionError
```

On branch:
```bash
$ cat examples/expr2.py     
from lpython import u32, u64

def test():
    x : u32 = u32(-10)
    print(x)
    assert x == u32(4294967286)

    z: u64 = u64(x)
    print(z)
    assert z == u64(4294967286)

test()
$ python examples/expr2.py     
4294967286
4294967286
$ lpython examples/expr2.py
4294967286
4294967286
```