### PR TITLE
Remove global variables

### DIFF
--- a/src/runtime/lpython_intrinsic_numpy.py
+++ b/src/runtime/lpython_intrinsic_numpy.py
@@ -1,8 +1,5 @@
 from lpython import i32, i64, f64, f32, ccall, vectorize, overload
 
-pi_64: f64 = f64(3.141592653589793238462643383279502884197)
-pi_32: f32 = f32(3.141592653589793238462643383279502884197)
-
 ########## sin ##########
 
 @ccall
@@ -274,11 +271,13 @@ def arctan(x: f32) -> f32:
 @overload
 @vectorize
 def degrees(x: f64) -> f64:
+    pi_64: Const[f64] = f64(3.141592653589793238462643383279502884197)
     return x*180.0/pi_64
 
 @overload
 @vectorize
 def degrees(x: f32) -> f32:
+    pi_32: Const[f32] = f32(3.141592653589793238462643383279502884197)
     return x*f32(f32(180)/pi_32)
 
 ########## radians ##########
@@ -286,11 +285,13 @@ def degrees(x: f32) -> f32:
 @overload
 @vectorize
 def radians(x: f64) -> f64:
+    pi_64: Const[f64] = f64(3.141592653589793238462643383279502884197)
     return x*pi_64/180.0
 
 @overload
 @vectorize
 def radians(x: f32) -> f32:
+    pi_32: Const[f32] = f32(3.141592653589793238462643383279502884197)
     return x*f32(pi_32/f32(180))
 
 ########## arcsinh ##########

--- a/tests/reference/c-bindc_06-a30d20f.json
+++ b/tests/reference/c-bindc_06-a30d20f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-bindc_06-a30d20f.stdout",
-    "stdout_hash": "6a93f686a1c2fe616c5de50dd3e339f5db7d226f48b29e5569412402",
+    "stdout_hash": "7fdf946af48e4b286aa2a5a328ed8edb8e50b98c252f7290f273d1a0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-bindc_06-a30d20f.stdout
+++ b/tests/reference/c-bindc_06-a30d20f.stdout
@@ -81,8 +81,6 @@ float _lfortran_caimag(float complex x);
 
 double _lfortran_zaimag(double complex x);
 
-float pi_32 =   3.14159265358979312e+00;
-double pi_64 =   3.14159265358979312e+00;
 double _lfortran_dacos(double x);
 
 double _lfortran_dacosh(double x);


### PR DESCRIPTION
Due to #2129, the global variables do not always work well. Until that issue is fixed, a simple workaround is to move these global variables into local variables.

Reference tests updated.