### PR TITLE
Added the `llvm_sym` backend for testing symbolic operations through the llvm backend

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -441,5 +441,5 @@ jobs:
         shell: bash -e -l {0}
         run: |
             cd integration_tests
-            ./run_tests.py -b c_sym cpython_sym
-            ./run_tests.py -b c_sym cpython_sym -f
+            ./run_tests.py -b c_sym cpython_sym llvm_sym
+            ./run_tests.py -b c_sym cpython_sym llvm_sym -f

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -645,7 +645,7 @@ RUN(NAME symbolics_03        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_04        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_05        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_06        LABELS cpython_sym c_sym)
-RUN(NAME symbolics_07        LABELS cpython_sym c_sym llvm_sym)
+RUN(NAME symbolics_07        LABELS cpython_sym c_sym llvm_sym NOFAST)
 
 RUN(NAME sizeof_01           LABELS llvm c
         EXTRAFILES sizeof_01b.c)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -105,6 +105,27 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
             if (${fail})
                 set_tests_properties(${name} PROPERTIES WILL_FAIL TRUE)
             endif()
+        elseif(KIND STREQUAL "llvm_sym")
+            add_custom_command(
+                OUTPUT ${name}.o
+                COMMAND ${LPYTHON} -c ${extra_args} ${CMAKE_CURRENT_SOURCE_DIR}/${file_name}.py -o ${name}.o
+                DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${file_name}.py
+                VERBATIM)
+            add_executable(${name} ${name}.o ${extra_files})
+            set_target_properties(${name} PROPERTIES LINKER_LANGUAGE C)
+            if (APPLE)
+                set(SYMENGINE_LIB "${Python_LIBRARY_DIRS}/libsymengine.dylib")
+            else()
+                set(SYMENGINE_LIB "${Python_LIBRARY_DIRS}/libsymengine.so")
+            endif()
+            target_link_libraries(${name} lpython_rtlib ${SYMENGINE_LIB})
+            add_test(${name} ${CMAKE_CURRENT_BINARY_DIR}/${name})
+            if (labels)
+                set_tests_properties(${name} PROPERTIES LABELS "${labels}")
+            endif()
+            if (${fail})
+                set_tests_properties(${name} PROPERTIES WILL_FAIL TRUE)
+            endif()
         elseif(KIND STREQUAL "c")
             add_custom_command(
                 OUTPUT ${name}.c
@@ -624,7 +645,7 @@ RUN(NAME symbolics_03        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_04        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_05        LABELS cpython_sym c_sym)
 RUN(NAME symbolics_06        LABELS cpython_sym c_sym)
-RUN(NAME symbolics_07        LABELS cpython_sym c_sym)
+RUN(NAME symbolics_07        LABELS cpython_sym c_sym llvm_sym)
 
 RUN(NAME sizeof_01           LABELS llvm c
         EXTRAFILES sizeof_01b.c)

--- a/integration_tests/run_tests.py
+++ b/integration_tests/run_tests.py
@@ -6,7 +6,7 @@ import os
 
 # Initialization
 DEFAULT_THREADS_TO_USE = 8 # default no of threads is 8
-SUPPORTED_BACKENDS = ['llvm', 'c', 'wasm', 'cpython', 'x86', 'wasm_x86', 'wasm_x64', 'c_py', 'c_sym', 'cpython_sym']
+SUPPORTED_BACKENDS = ['llvm', 'c', 'wasm', 'cpython', 'x86', 'wasm_x86', 'wasm_x64', 'c_py', 'c_sym', 'cpython_sym', 'llvm_sym']
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 LPYTHON_PATH = f"{BASE_DIR}/../src/bin"
 
@@ -62,7 +62,7 @@ def main():
     DEFAULT_THREADS_TO_USE = args.no_of_threads or DEFAULT_THREADS_TO_USE
     fast_tests = "yes" if args.fast else "no"
     for backend in args.backends:
-        python_libs_req = "yes" if backend in ["c_py", "c_sym"] else "no"
+        python_libs_req = "yes" if backend in ["c_py", "c_sym", "llvm_sym"] else "no"
         test_backend(backend)
 
 

--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -1218,8 +1218,14 @@ int link_executable(const std::vector<std::string> &infiles,
             for (auto &s : infiles) {
                 cmd += s + " ";
             }
+            if (compiler_options.enable_symengine) {
+                cmd += " -I${CONDA_PREFIX}/include";
+            }
             cmd += + " -L"
                 + base_path + " -Wl,-rpath," + base_path + " -l" + runtime_lib + " -lm";
+            if (compiler_options.enable_symengine) {
+                cmd += " -L$CONDA_PREFIX/lib -Wl,-rpath -Wl,$CONDA_PREFIX/lib -lsymengine";
+            }
             int err = system(cmd.c_str());
             if (err) {
                 std::cout << "The command '" + cmd + "' failed." << std::endl;


### PR DESCRIPTION
This Pr does the following .
1) Introduces the llvm_sym backend . Currently we are testing symbolics_07.py and we get
```
(lf) anutosh491@spbhat68:~/lpython/lpython/integration_tests$ ./run_tests.py -b llvm_sym
-- Configuring done
-- Generating done
-- Build files have been written to: /home/anutosh491/lpython/lpython/integration_tests/_lpython-tmp-test-llvm_sym
+ make -j8
[ 50%] Generating symbolics_07.o
[100%] Linking C executable symbolics_07
[100%] Built target symbolics_07
+ ctest -j8 --output-on-failure
Test project /home/anutosh491/lpython/lpython/integration_tests/_lpython-tmp-test-llvm_sym
    Start 1: symbolics_07
1/1 Test #1: symbolics_07 .....................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
c_sym          =   0.01 sec*proc (1 test)
cpython_sym    =   0.01 sec*proc (1 test)
llvm_sym       =   0.01 sec*proc (1 test)
```
2) Adds the --enable-symengine flag support for the llvm backend (as we have the for C backend)
```
(lf) anutosh491@spbhat68:~/lpython/lpython$ lpython --enable-symengine --backend=c integration_tests/symbolics_07.py
pi
(lf) anutosh491@spbhat68:~/lpython/lpython$ lpython --enable-symengine --backend=llvm integration_tests/symbolics_07.py
pi
```