### PR TITLE
CI: Provide release flags, exclude -march=native

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -335,6 +335,7 @@ jobs:
             export CXXFLAGS="-Werror"
             cmake . -GNinja \
               -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_CXX_FLAGS_RELEASE="-Wall -Wextra -O3 -funroll-loops -DNDEBUG" \
               -DWITH_LLVM=yes \
               -DLFORTRAN_BUILD_ALL=yes \
               -DWITH_STACKTRACE=no \


### PR DESCRIPTION
>I think we just need to lower the optimization options, perhaps keep -O3, but remove -march=native or something like that.

towards https://github.com/lcompilers/lpython/issues/2162#issuecomment-1644965229