### PR TITLE
Add a test for lpython emulation mode

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -763,3 +763,6 @@ RUN(NAME lpython_decorator_01    LABELS cpython)
 RUN(NAME lpython_decorator_02    LABELS cpython)
 
 COMPILE(NAME import_order_01     LABELS cpython llvm c) # any
+
+# LPython emulation mode
+RUN(NAME lpython_emulation_01    LABELS cpython)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -76,12 +76,13 @@ message("LPYTHON_RTLIB_DIR: ${LPYTHON_RTLIB_DIR}")
 message("LPYTHON_RTLIB_LIBRARY: ${LPYTHON_RTLIB_LIBRARY}")
 
 
-macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN)
+macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_NOMOD RUN_EXTRA_ARGS RUN_COPY_TO_BIN)
     set(fail ${${RUN_FAIL}})
     set(name ${${RUN_NAME}})
     set(file_name ${${RUN_FILE_NAME}})
     set(labels ${${RUN_LABELS}})
     set(extra_files ${${RUN_EXTRAFILES}})
+    set(no_mod ${${RUN_NOMOD}})
     set(extra_args ${${RUN_EXTRA_ARGS}})
     set(copy_to_bin ${${RUN_COPY_TO_BIN}})
 
@@ -213,8 +214,13 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
             endif()
 
             add_test(${name} python ${CMAKE_CURRENT_SOURCE_DIR}/${file_name}.py)
-            set_tests_properties(${name} PROPERTIES
-                ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/../src/runtime/lpython:${CMAKE_SOURCE_DIR}/..;LPYTHON_PY_MOD_NAME=${PY_MOD};LPYTHON_PY_MOD_PATH=${CMAKE_CURRENT_BINARY_DIR}")
+            if (no_mod)
+                set_tests_properties(${name} PROPERTIES
+                    ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/../src/runtime/lpython:${CMAKE_SOURCE_DIR}/..")
+            else()
+                set_tests_properties(${name} PROPERTIES
+                    ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/../src/runtime/lpython:${CMAKE_SOURCE_DIR}/..;LPYTHON_PY_MOD_NAME=${PY_MOD};LPYTHON_PY_MOD_PATH=${CMAKE_CURRENT_BINARY_DIR}")
+            endif()
             if (labels)
                 set_tests_properties(${name} PROPERTIES LABELS "${labels}")
             endif()
@@ -305,7 +311,7 @@ macro(RUN_UTIL RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXT
 endmacro(RUN_UTIL)
 
 macro(RUN)
-    set(options FAIL NOFAST ENABLE_CPYTHON LINK_NUMPY)
+    set(options FAIL NOFAST NOMOD ENABLE_CPYTHON LINK_NUMPY)
     set(oneValueArgs NAME IMPORT_PATH COPY_TO_BIN)
     set(multiValueArgs LABELS EXTRAFILES)
     cmake_parse_arguments(RUN "${options}" "${oneValueArgs}"
@@ -329,14 +335,14 @@ macro(RUN)
     endif()
 
     if (NOT FAST)
-        RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN)
+        RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_NOMOD RUN_EXTRA_ARGS RUN_COPY_TO_BIN)
     endif()
 
     if ((FAST) AND (NOT RUN_NOFAST))
         set(RUN_EXTRA_ARGS ${RUN_EXTRA_ARGS} --fast)
         set(RUN_NAME "${RUN_NAME}_FAST")
         list(REMOVE_ITEM RUN_LABELS cpython cpython_sym) # remove cpython, cpython_sym, from --fast test
-        RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_EXTRA_ARGS RUN_COPY_TO_BIN)
+        RUN_UTIL(RUN_FAIL RUN_NAME RUN_FILE_NAME RUN_LABELS RUN_EXTRAFILES RUN_NOMOD RUN_EXTRA_ARGS RUN_COPY_TO_BIN)
     endif()
 endmacro(RUN)
 
@@ -765,4 +771,4 @@ RUN(NAME lpython_decorator_02    LABELS cpython)
 COMPILE(NAME import_order_01     LABELS cpython llvm c) # any
 
 # LPython emulation mode
-RUN(NAME lpython_emulation_01    LABELS cpython)
+RUN(NAME lpython_emulation_01    LABELS cpython NOMOD)

--- a/integration_tests/lpython_emulation_01.py
+++ b/integration_tests/lpython_emulation_01.py
@@ -1,0 +1,21 @@
+import lpython_emulation_01_mod
+import lpython
+from lpython import ccall, i64
+from types import FunctionType
+lpython.CTypes.emulations = {k: v for k, v in \
+        lpython_emulation_01_mod.__dict__.items() \
+        if isinstance(v, FunctionType)}
+
+@ccall
+def f1(a: i64) -> i64:
+    pass
+
+@ccall
+def f2(a: i64):
+    pass
+
+def main():
+    assert f1(2) == 3
+    f2(4)
+
+main()

--- a/integration_tests/lpython_emulation_01_mod.py
+++ b/integration_tests/lpython_emulation_01_mod.py
@@ -1,0 +1,7 @@
+from lpython import i64
+
+def f1(a: i64) -> i64:
+    return a + 1
+
+def f2(a: i64):
+    assert a == 4

--- a/src/runtime/lpython/lpython.py
+++ b/src/runtime/lpython/lpython.py
@@ -377,6 +377,7 @@ class CTypes:
             arg_ctype = convert_type_to_ctype(arg_type)
             argtypes.append(arg_ctype)
         self.cf.argtypes = argtypes
+        self.cf.restype = None
         if "return" in self.annotations:
             res_type = self.annotations["return"]
             if res_type is not None:


### PR DESCRIPTION
The new test fails due to #2222. We first verify that it fails at the CI and then we fix it with a commit.

Fixes #2222.