### PR TITLE
Shorter names for global_initializer() and global_statements()

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -428,7 +428,7 @@ void get_calls_to_global_init_and_stmts(Allocator &al, const Location &loc, Symb
     ASR::Module_t* mod, std::vector<ASR::asr_t *> &tmp_vec) {
 
     std::string mod_name = mod->m_name;
-    std::string g_func_name = mod_name + "__global_initializer";
+    std::string g_func_name = mod_name + "global_init";
     ASR::symbol_t *g_func = mod->m_symtab->get_symbol(g_func_name);
     if (g_func && !scope->get_symbol(g_func_name)) {
         ASR::symbol_t *es = ASR::down_cast<ASR::symbol_t>(
@@ -441,7 +441,7 @@ void get_calls_to_global_init_and_stmts(Allocator &al, const Location &loc, Symb
             es, g_func, nullptr, 0, nullptr, nullptr, false));
     }
 
-    g_func_name = mod_name + "__global_statements";
+    g_func_name = mod_name + "global_stmts";
     g_func = mod->m_symtab->get_symbol(g_func_name);
     if (g_func && !scope->get_symbol(g_func_name)) {
         ASR::symbol_t *es = ASR::down_cast<ASR::symbol_t>(
@@ -4803,7 +4803,7 @@ public:
             // `pass_wrap_global_stmts_into_function` pass
             unit->m_items = global_init.p;
             unit->n_items = global_init.size();
-            std::string func_name = module_name + "__global_initializer";
+            std::string func_name = module_name + "global_init";
             LCompilers::PassOptions pass_options;
             pass_options.run_fun = func_name;
             pass_wrap_global_stmts(al, *unit, pass_options);
@@ -4826,7 +4826,7 @@ public:
         if (items.n > 0) {
             unit->m_items = items.p;
             unit->n_items = items.size();
-            std::string func_name = module_name + "__global_statements";
+            std::string func_name = module_name + "global_stmts";
             // Wrap all the global statements into a Function
             LCompilers::PassOptions pass_options;
             pass_options.run_fun = func_name;

--- a/tests/reference/asr-array_01_decl-39cf894.json
+++ b/tests/reference/asr-array_01_decl-39cf894.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_01_decl-39cf894.stdout",
-    "stdout_hash": "150d5c201e389b6a146b7c7779048379519336a4f035fd7c4bc74a3f",
+    "stdout_hash": "b45d33de49ca7e90f8327f100d88a858c8449acf8d8fa2bc527b346f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_01_decl-39cf894.stdout
+++ b/tests/reference/asr-array_01_decl-39cf894.stdout
@@ -55,14 +55,14 @@
                                     (Integer 4)
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         207
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -918,22 +918,22 @@
                     (SymbolTable
                         208
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     208
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        208 __main____global_statements
-                        2 __main____global_statements
+                        208 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-array_02_decl-e8f6874.json
+++ b/tests/reference/asr-array_02_decl-e8f6874.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_02_decl-e8f6874.stdout",
-    "stdout_hash": "161c1c315c83399ca9f2f303efe354535ecf820e5529dcddc5b9a059",
+    "stdout_hash": "40e73d0d895210f7571f8a31ef8d426401f5cb57819271790fb4f7d6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_02_decl-e8f6874.stdout
+++ b/tests/reference/asr-array_02_decl-e8f6874.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         205
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -704,22 +704,22 @@
                     (SymbolTable
                         206
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     206
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        206 __main____global_statements
-                        2 __main____global_statements
+                        206 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-bindc_01-6d521a9.json
+++ b/tests/reference/asr-bindc_01-6d521a9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-bindc_01-6d521a9.stdout",
-    "stdout_hash": "6d5d14fd8d94205b92c250418a6b8f8db22282bd6d5f9d10677ef660",
+    "stdout_hash": "ec7543eae1d1bbaeba72993e35e98165ba0248ab59dc6597f9c50e7b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-bindc_01-6d521a9.stdout
+++ b/tests/reference/asr-bindc_01-6d521a9.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         4
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -185,22 +185,22 @@
                     (SymbolTable
                         5
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     5
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        5 __main____global_statements
-                        2 __main____global_statements
+                        5 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-bindc_02-bc1a7ea.json
+++ b/tests/reference/asr-bindc_02-bc1a7ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-bindc_02-bc1a7ea.stdout",
-    "stdout_hash": "85f0714bd83ac6e159ac5495baa2359741e49e63b8ac049093b27f42",
+    "stdout_hash": "e7c1aac9ae8d0cc269135f3d79b99fbda0574b09d8d7d20bced754ec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-bindc_02-bc1a7ea.stdout
+++ b/tests/reference/asr-bindc_02-bc1a7ea.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         201
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -396,22 +396,22 @@
                     (SymbolTable
                         202
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     202
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        202 __main____global_statements
-                        2 __main____global_statements
+                        202 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-callback_01-df40fd5.json
+++ b/tests/reference/asr-callback_01-df40fd5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-callback_01-df40fd5.stdout",
-    "stdout_hash": "6d2cb98041fd7ca591cdd1d108b8e33cf28596ae877e7483040b53f3",
+    "stdout_hash": "5be73c5b09034604701853c55fffbdca38993aa3f92782e89a50c91e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-callback_01-df40fd5.stdout
+++ b/tests/reference/asr-callback_01-df40fd5.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         9
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -544,22 +544,22 @@
                     (SymbolTable
                         10
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     10
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        10 __main____global_statements
-                        2 __main____global_statements
+                        10 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-cast-435c233.json
+++ b/tests/reference/asr-cast-435c233.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-cast-435c233.stdout",
-    "stdout_hash": "2eb7eb0ad87875a041581987ca9c61e0a10a7c9211300f7415798c18",
+    "stdout_hash": "fe198b3570faed74e1d6babc91b93c715f90a21cf5e19b40351e3299",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-cast-435c233.stdout
+++ b/tests/reference/asr-cast-435c233.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         126
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -253,22 +253,22 @@
                     (SymbolTable
                         127
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     127
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        127 __main____global_statements
-                        2 __main____global_statements
+                        127 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-doconcurrentloop_01-3fdc189.json
+++ b/tests/reference/asr-doconcurrentloop_01-3fdc189.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-doconcurrentloop_01-3fdc189.stdout",
-    "stdout_hash": "7442f71652c630ae36046e585b31c0983ecf34c08a4b373524d28d21",
+    "stdout_hash": "0975f7d22eeb12c370338f1c6b5edb6292a8f4e076cb484ccab66b06",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-doconcurrentloop_01-3fdc189.stdout
+++ b/tests/reference/asr-doconcurrentloop_01-3fdc189.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         7
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -555,22 +555,22 @@
                     (SymbolTable
                         8
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     8
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        8 __main____global_statements
-                        2 __main____global_statements
+                        8 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-elemental_01-b58df26.json
+++ b/tests/reference/asr-elemental_01-b58df26.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-elemental_01-b58df26.stdout",
-    "stdout_hash": "2b9dac7b800b8314765e8f12067cb0e64249c591c1c40c0da50d7da2",
+    "stdout_hash": "7ce2e5fe829c8e51cf8f467dfd726fef8da1601c714b5af3e24dd1af",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-elemental_01-b58df26.stdout
+++ b/tests/reference/asr-elemental_01-b58df26.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         233
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -3374,22 +3374,22 @@
                     (SymbolTable
                         234
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     234
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        234 __main____global_statements
-                        2 __main____global_statements
+                        234 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-expr12-5c5b71e.json
+++ b/tests/reference/asr-expr12-5c5b71e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr12-5c5b71e.stdout",
-    "stdout_hash": "097041cc0937b367c46a53c826b551d9e214ad4d3bad67c26704f69e",
+    "stdout_hash": "68b01cfc65c60b82cb2ba5017c95cb10e05d130d085674593975310e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr12-5c5b71e.stdout
+++ b/tests/reference/asr-expr12-5c5b71e.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         6
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -282,22 +282,22 @@
                     (SymbolTable
                         7
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     7
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        7 __main____global_statements
-                        2 __main____global_statements
+                        7 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-expr7-480ba2f.json
+++ b/tests/reference/asr-expr7-480ba2f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr7-480ba2f.stdout",
-    "stdout_hash": "602c62582bd7d87a4e830301c7768108cb3ccaa274d8881ed42fb49d",
+    "stdout_hash": "1f6e6f0d3e5dac3d97e184b853cc86c06b31e6b797035f7db5f85bec",
     "stderr": "asr-expr7-480ba2f.stderr",
     "stderr_hash": "6e9790ac88db1a9ead8f64a91ba8a6605de67167037908a74b77be0c",
     "returncode": 0

--- a/tests/reference/asr-expr7-480ba2f.stdout
+++ b/tests/reference/asr-expr7-480ba2f.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         128
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -346,22 +346,22 @@
                     (SymbolTable
                         129
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     129
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        129 __main____global_statements
-                        2 __main____global_statements
+                        129 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-expr9-814e4bc.json
+++ b/tests/reference/asr-expr9-814e4bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr9-814e4bc.stdout",
-    "stdout_hash": "8d85ccfee47553c2118a54edff3ec47d4defde4cdb7894409bb611fe",
+    "stdout_hash": "a8334d45029aef40c38c8014b64aa2520c38fdc0186ae85869d72c36",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr9-814e4bc.stdout
+++ b/tests/reference/asr-expr9-814e4bc.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         7
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -399,22 +399,22 @@
                     (SymbolTable
                         8
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     8
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        8 __main____global_statements
-                        2 __main____global_statements
+                        8 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-expr_01-211000e.json
+++ b/tests/reference/asr-expr_01-211000e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr_01-211000e.stdout",
-    "stdout_hash": "fa6280a9e657d395ed07ee267ab585c292f4802a89a584c23b80e38a",
+    "stdout_hash": "41ef0d077c9deb5cbf309b21493b9d6780254a09a635e4c01dcc096e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr_01-211000e.stdout
+++ b/tests/reference/asr-expr_01-211000e.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         4
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -170,22 +170,22 @@
                     (SymbolTable
                         5
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     5
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        5 __main____global_statements
-                        2 __main____global_statements
+                        5 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-expr_01-a0d4829.json
+++ b/tests/reference/asr-expr_01-a0d4829.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr_01-a0d4829.stdout",
-    "stdout_hash": "0837af084448c8d23412f62163b528db23d05a3ff5d6a6b7928de274",
+    "stdout_hash": "22c544446be0bf9235672437a74b58e230def3217713441058c35b49",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr_01-a0d4829.stdout
+++ b/tests/reference/asr-expr_01-a0d4829.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         6
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -393,22 +393,22 @@
                     (SymbolTable
                         7
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     7
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        7 __main____global_statements
-                        2 __main____global_statements
+                        7 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-expr_05-3a37324.json
+++ b/tests/reference/asr-expr_05-3a37324.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr_05-3a37324.stdout",
-    "stdout_hash": "2b6332dd9b8b5da3a21921e56896e648c5e3dfb68c8a48bf3bee9b46",
+    "stdout_hash": "b647c29262d846c6a9470081add7c497093bf643f3834e9504dbe784",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr_05-3a37324.stdout
+++ b/tests/reference/asr-expr_05-3a37324.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         128
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -1639,22 +1639,22 @@
                     (SymbolTable
                         129
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     129
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        129 __main____global_statements
-                        2 __main____global_statements
+                        129 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-expr_07-7742668.json
+++ b/tests/reference/asr-expr_07-7742668.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr_07-7742668.stdout",
-    "stdout_hash": "3c2e1854a6a30add9fdabaf1e03187718d3119071bae936111f747cb",
+    "stdout_hash": "05202a24fb95d20a4ae8d229b4bcd3729916613a20603101197da0f8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr_07-7742668.stdout
+++ b/tests/reference/asr-expr_07-7742668.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         6
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -407,22 +407,22 @@
                     (SymbolTable
                         7
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     7
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        7 __main____global_statements
-                        2 __main____global_statements
+                        7 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-expr_09-f3e89c8.json
+++ b/tests/reference/asr-expr_09-f3e89c8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr_09-f3e89c8.stdout",
-    "stdout_hash": "a2e5d05312c740e943f2a2de0641f1311ce3e8718b46145d0ea26601",
+    "stdout_hash": "ecfde426a62ac9860418a88dd60edcea1ce2ac278554857680143a35",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr_09-f3e89c8.stdout
+++ b/tests/reference/asr-expr_09-f3e89c8.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         8
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -984,22 +984,22 @@
                     (SymbolTable
                         9
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     9
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        9 __main____global_statements
-                        2 __main____global_statements
+                        9 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-expr_10-d39708c.json
+++ b/tests/reference/asr-expr_10-d39708c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr_10-d39708c.stdout",
-    "stdout_hash": "b7e632ba002dc30922be9afaf8e6cf6bff195c030b1244cc9f65e6bf",
+    "stdout_hash": "0a4b79034e67e8b6d3eb0d84aea96436f45dea9e63ce4b3910c76dd7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr_10-d39708c.stdout
+++ b/tests/reference/asr-expr_10-d39708c.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         6
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -276,22 +276,22 @@
                     (SymbolTable
                         7
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     7
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        7 __main____global_statements
-                        2 __main____global_statements
+                        7 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-expr_12-6769be0.json
+++ b/tests/reference/asr-expr_12-6769be0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr_12-6769be0.stdout",
-    "stdout_hash": "15f1a6c802222c6b2369866cabf6df1e1a6a83832ed71477adfe478b",
+    "stdout_hash": "d2a7d644dcafd925278b7bd2689679b2a0c3cb3397a784579679b64a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr_12-6769be0.stdout
+++ b/tests/reference/asr-expr_12-6769be0.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         6
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -419,22 +419,22 @@
                     (SymbolTable
                         7
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     7
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        7 __main____global_statements
-                        2 __main____global_statements
+                        7 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-expr_14-f2bd343.json
+++ b/tests/reference/asr-expr_14-f2bd343.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr_14-f2bd343.stdout",
-    "stdout_hash": "c4cc37daa39b21bb008134a34a63db13ea16d0c708059750f8e62024",
+    "stdout_hash": "38802a7dc7857816979d9549fda992e3637ca30ab8db286db22340a4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr_14-f2bd343.stdout
+++ b/tests/reference/asr-expr_14-f2bd343.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         4
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -904,22 +904,22 @@
                     (SymbolTable
                         5
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     5
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        5 __main____global_statements
-                        2 __main____global_statements
+                        5 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-func_inline_01-56af272.json
+++ b/tests/reference/asr-func_inline_01-56af272.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-func_inline_01-56af272.stdout",
-    "stdout_hash": "2e7ef7f86099aa9cf8dd6bdfe8696fb6d4b4810ed266b97d7d3da502",
+    "stdout_hash": "0bb57e1f00283e1d9702b73b5ac6e2cd149919abafe5f228b1650859",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-func_inline_01-56af272.stdout
+++ b/tests/reference/asr-func_inline_01-56af272.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         5
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -288,22 +288,22 @@
                     (SymbolTable
                         6
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     6
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        6 __main____global_statements
-                        2 __main____global_statements
+                        6 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-generics_01-d616074.json
+++ b/tests/reference/asr-generics_01-d616074.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_01-d616074.stdout",
-    "stdout_hash": "70344c6286bad94b92e7194878e41e52a727ec3048aa65262da655ee",
+    "stdout_hash": "dfabe5a70a7f43494584ff8aeda7b7c86ed518fae456658f1f534daf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_01-d616074.stdout
+++ b/tests/reference/asr-generics_01-d616074.stdout
@@ -211,14 +211,14 @@
                                     .false.
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         9
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -687,22 +687,22 @@
                     (SymbolTable
                         10
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     10
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        10 __main____global_statements
-                        2 __main____global_statements
+                        10 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-generics_02-e2ea5c9.json
+++ b/tests/reference/asr-generics_02-e2ea5c9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_02-e2ea5c9.stdout",
-    "stdout_hash": "c407c95fb97ed73b63c30e1f5dc88dfa72e541ac487489c4a82c9f8e",
+    "stdout_hash": "06fea11e3d245974eb6e026ef7754acae43816a4cbd10c7c27ce37c8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_02-e2ea5c9.stdout
+++ b/tests/reference/asr-generics_02-e2ea5c9.stdout
@@ -131,14 +131,14 @@
                                     .false.
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         5
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -295,22 +295,22 @@
                     (SymbolTable
                         6
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     6
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        6 __main____global_statements
-                        2 __main____global_statements
+                        6 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-generics_array_01-682b1b2.json
+++ b/tests/reference/asr-generics_array_01-682b1b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_01-682b1b2.stdout",
-    "stdout_hash": "42b21ffdf7b39ef4d9ba925d85158d6f58e65b1395be155f2785cb6c",
+    "stdout_hash": "a775edc9db3eb3909fe9e1d7738fac8ba0bbf37b539dcca81dfa0e9e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_01-682b1b2.stdout
+++ b/tests/reference/asr-generics_array_01-682b1b2.stdout
@@ -141,14 +141,14 @@
                                     .false.
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         203
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -418,22 +418,22 @@
                     (SymbolTable
                         204
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     204
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        204 __main____global_statements
-                        2 __main____global_statements
+                        204 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-generics_array_02-22c8dc1.json
+++ b/tests/reference/asr-generics_array_02-22c8dc1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_02-22c8dc1.stdout",
-    "stdout_hash": "3143f1c9f013457cb4318f098e426c314ef33fcb82bba14b9effa58e",
+    "stdout_hash": "09d9897aaa20a1b3c1c89d8738012e8294157d00c1c8f5051e397386",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_02-22c8dc1.stdout
+++ b/tests/reference/asr-generics_array_02-22c8dc1.stdout
@@ -445,14 +445,14 @@
                                     .false.
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         208
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -1264,22 +1264,22 @@
                     (SymbolTable
                         209
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     209
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        209 __main____global_statements
-                        2 __main____global_statements
+                        209 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-generics_array_03-fb3706c.json
+++ b/tests/reference/asr-generics_array_03-fb3706c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_03-fb3706c.stdout",
-    "stdout_hash": "562b83bcbd20ecf3c1e7483b72264c9a0e1e10335d885eab90464430",
+    "stdout_hash": "86d2c72679993c975ec6e7b98748749863fb5db1dfda78010ac7207b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_03-fb3706c.stdout
+++ b/tests/reference/asr-generics_array_03-fb3706c.stdout
@@ -683,14 +683,14 @@
                                     .false.
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         209
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -1739,22 +1739,22 @@
                     (SymbolTable
                         210
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     210
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        210 __main____global_statements
-                        2 __main____global_statements
+                        210 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-generics_list_01-39c4044.json
+++ b/tests/reference/asr-generics_list_01-39c4044.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_list_01-39c4044.stdout",
-    "stdout_hash": "8fb0ba5bf10eb6a7784edd6e2b2ab8f89784f3ec020edfab2b1c79af",
+    "stdout_hash": "d53f6f826430b0aa861db8f7932cdd9f24d61cddb7527ad97b61b595",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_list_01-39c4044.stdout
+++ b/tests/reference/asr-generics_list_01-39c4044.stdout
@@ -640,14 +640,14 @@
                                     .false.
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         20
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -1992,22 +1992,22 @@
                     (SymbolTable
                         21
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     21
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        21 __main____global_statements
-                        2 __main____global_statements
+                        21 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-global_scope1-354e217.json
+++ b/tests/reference/asr-global_scope1-354e217.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-global_scope1-354e217.stdout",
-    "stdout_hash": "2fdd4daf8acf640cf0b372c9e195db98167791a30a3b59bc8910f47d",
+    "stdout_hash": "a8135cc1724a7d8f68c2d2136484125b8962b707c21873560dbaa04b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-global_scope1-354e217.stdout
+++ b/tests/reference/asr-global_scope1-354e217.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         3
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -69,22 +69,22 @@
                     (SymbolTable
                         4
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     4
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        4 __main____global_statements
-                        2 __main____global_statements
+                        4 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-global_syms_01-273906f.json
+++ b/tests/reference/asr-global_syms_01-273906f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-global_syms_01-273906f.stdout",
-    "stdout_hash": "8f13a92c5b5e8d5b5a7c14179b98ac162fb65c82403f1489907fe56f",
+    "stdout_hash": "8a038638305efddca192d6bdb758eb4f5c4e701efc7a21e1cdd14a06",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-global_syms_01-273906f.stdout
+++ b/tests/reference/asr-global_syms_01-273906f.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         4
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -164,22 +164,22 @@
                     (SymbolTable
                         5
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     5
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        5 __main____global_statements
-                        2 __main____global_statements
+                        5 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-loop1-10d3109.json
+++ b/tests/reference/asr-loop1-10d3109.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-loop1-10d3109.stdout",
-    "stdout_hash": "7d5deebc5f24162766b5c39fbfd88f6385b8d3343f851814f48dbc57",
+    "stdout_hash": "25e0882ec286f388253c8fd367e03f135204a71f5550a7f773938ae6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-loop1-10d3109.stdout
+++ b/tests/reference/asr-loop1-10d3109.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         8
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -579,22 +579,22 @@
                     (SymbolTable
                         9
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     9
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        9 __main____global_statements
-                        2 __main____global_statements
+                        9 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-loop4-3d3216e.json
+++ b/tests/reference/asr-loop4-3d3216e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-loop4-3d3216e.stdout",
-    "stdout_hash": "6e32b58c4dabfc67bb3b1f8c9b091b80281d761246a1a889f1300f2b",
+    "stdout_hash": "f74b039f6ca87f2d78637403f0039095208cb96167a72af3ada13690",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-loop4-3d3216e.stdout
+++ b/tests/reference/asr-loop4-3d3216e.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         5
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -151,22 +151,22 @@
                     (SymbolTable
                         6
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     6
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        6 __main____global_statements
-                        2 __main____global_statements
+                        6 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-modules_02-ec92e6f.json
+++ b/tests/reference/asr-modules_02-ec92e6f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_02-ec92e6f.stdout",
-    "stdout_hash": "51c58e43d231fdb96250975fb6064062d7855cb9da9fad762681ad8d",
+    "stdout_hash": "20ce6ad550f4e6b83356075795a39dafee13dc48bebf2eaf65d13edd",
     "stderr": "asr-modules_02-ec92e6f.stderr",
     "stderr_hash": "132af04271d3bfd523848990e734bfa3c0aed6e4b85ec4eb87e66720",
     "returncode": 0

--- a/tests/reference/asr-modules_02-ec92e6f.stdout
+++ b/tests/reference/asr-modules_02-ec92e6f.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         8
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -142,22 +142,22 @@
                     (SymbolTable
                         9
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     9
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        9 __main____global_statements
-                        2 __main____global_statements
+                        9 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-print_02-afbe092.json
+++ b/tests/reference/asr-print_02-afbe092.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-print_02-afbe092.stdout",
-    "stdout_hash": "2167cccb2e69fcd2e647a005c22513d7f3fdc0f209926e7b8f14829d",
+    "stdout_hash": "7d720d7ce5e8ce34faf6115b15788289382dd344e4716efc29cb7251",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-print_02-afbe092.stdout
+++ b/tests/reference/asr-print_02-afbe092.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         8
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -2932,22 +2932,22 @@
                     (SymbolTable
                         9
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     9
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        9 __main____global_statements
-                        2 __main____global_statements
+                        9 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-print_list_tuple_03-9de3736.json
+++ b/tests/reference/asr-print_list_tuple_03-9de3736.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-print_list_tuple_03-9de3736.stdout",
-    "stdout_hash": "aea957929d0d4b4d8a2a6fd6053f13fe2bab7a0c1f28ef02cdfea5c5",
+    "stdout_hash": "bc2f13615265f5b0339b735e2dfb39050221bf4dc5c026f118259d7e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-print_list_tuple_03-9de3736.stdout
+++ b/tests/reference/asr-print_list_tuple_03-9de3736.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         4
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -219,22 +219,22 @@
                     (SymbolTable
                         5
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     5
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        5 __main____global_statements
-                        2 __main____global_statements
+                        5 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-structs_01-66dc2c9.json
+++ b/tests/reference/asr-structs_01-66dc2c9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_01-66dc2c9.stdout",
-    "stdout_hash": "8350bfcc6eb01320f7073cb23ff5c248064a14cc3041a9a5283ad7cd",
+    "stdout_hash": "7996e199fb4e186baf6f87ea3e596a417bcc23ab748eaffa82c89a65",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_01-66dc2c9.stdout
+++ b/tests/reference/asr-structs_01-66dc2c9.stdout
@@ -58,14 +58,14 @@
                                     ()
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         6
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -165,22 +165,22 @@
                     (SymbolTable
                         7
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     7
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        7 __main____global_statements
-                        2 __main____global_statements
+                        7 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-structs_01-be14d49.json
+++ b/tests/reference/asr-structs_01-be14d49.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_01-be14d49.stdout",
-    "stdout_hash": "adebe7528e93ac10486a55c301a3d3f7a391946ce5c633a4a3811872",
+    "stdout_hash": "218ab5e7739164434c7c772962ada9767d7294eabe2a6878facf4e76",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_01-be14d49.stdout
+++ b/tests/reference/asr-structs_01-be14d49.stdout
@@ -58,14 +58,14 @@
                                     ()
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         8
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -510,22 +510,22 @@
                     (SymbolTable
                         9
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     9
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        9 __main____global_statements
-                        2 __main____global_statements
+                        9 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-structs_02-2ab459a.json
+++ b/tests/reference/asr-structs_02-2ab459a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_02-2ab459a.stdout",
-    "stdout_hash": "1d4b53a95e74aa0e77fd05e9a1935431975ac4c53bedfc0812d630c5",
+    "stdout_hash": "0b6313bb78db340840b2865b32eac8165152b998c834c91c569bf78f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_02-2ab459a.stdout
+++ b/tests/reference/asr-structs_02-2ab459a.stdout
@@ -58,14 +58,14 @@
                                     ()
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         7
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -378,22 +378,22 @@
                     (SymbolTable
                         8
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     8
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        8 __main____global_statements
-                        2 __main____global_statements
+                        8 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-structs_03-0cef911.json
+++ b/tests/reference/asr-structs_03-0cef911.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_03-0cef911.stdout",
-    "stdout_hash": "43977b9e3eda91739650dc655739e11667e846ad694b12ed115768da",
+    "stdout_hash": "b2a00a060603229dc89344c1f93407c95b95ef9980a64171d19aeb57",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_03-0cef911.stdout
+++ b/tests/reference/asr-structs_03-0cef911.stdout
@@ -58,14 +58,14 @@
                                     ()
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         7
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -359,22 +359,22 @@
                     (SymbolTable
                         8
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     8
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        8 __main____global_statements
-                        2 __main____global_statements
+                        8 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-structs_04-387747b.json
+++ b/tests/reference/asr-structs_04-387747b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_04-387747b.stdout",
-    "stdout_hash": "f8877e9ca9bbbc7205f14bffe5fe27e294cfdf48be08a29d23f703de",
+    "stdout_hash": "09d05bf16bc1779c18c3bd66defec27c181a2115e9a0e52affaaf17c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_04-387747b.stdout
+++ b/tests/reference/asr-structs_04-387747b.stdout
@@ -130,14 +130,14 @@
                                     ()
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         9
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -623,22 +623,22 @@
                     (SymbolTable
                         10
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     10
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        10 __main____global_statements
-                        2 __main____global_statements
+                        10 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-structs_05-fa98307.json
+++ b/tests/reference/asr-structs_05-fa98307.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_05-fa98307.stdout",
-    "stdout_hash": "4b806b198de30dfa11c6e311ab3d3d96dad325f3c43adb900832c0fa",
+    "stdout_hash": "dc3d73243eff18d08010fb4566a90b895639855e74a4c5622445f790",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_05-fa98307.stdout
+++ b/tests/reference/asr-structs_05-fa98307.stdout
@@ -148,14 +148,14 @@
                                     ()
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         206
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -1433,22 +1433,22 @@
                     (SymbolTable
                         207
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     207
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        207 __main____global_statements
-                        2 __main____global_statements
+                        207 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-structs_16-44de89a.json
+++ b/tests/reference/asr-structs_16-44de89a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_16-44de89a.stdout",
-    "stdout_hash": "62d4d544128cae35648865fc1145c9837268ece68629ffc4784c45a8",
+    "stdout_hash": "9ebf9426938d92178b3a8fdca450859753b0299d3b2b8cb48272469e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_16-44de89a.stdout
+++ b/tests/reference/asr-structs_16-44de89a.stdout
@@ -108,14 +108,14 @@
                                     ()
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         8
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -302,22 +302,22 @@
                     (SymbolTable
                         9
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     9
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        9 __main____global_statements
-                        2 __main____global_statements
+                        9 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_bool_binop-f856ef0.json
+++ b/tests/reference/asr-test_bool_binop-f856ef0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_bool_binop-f856ef0.stdout",
-    "stdout_hash": "658e68adaa9b8c606aa2c81d878b2d3569dbe164f3a432c3d1205667",
+    "stdout_hash": "f0780ca86a1b917cbac3f32e74d91a56a81e45a6c5cceaf0428744b8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_bool_binop-f856ef0.stdout
+++ b/tests/reference/asr-test_bool_binop-f856ef0.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         126
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -441,22 +441,22 @@
                     (SymbolTable
                         127
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     127
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        127 __main____global_statements
-                        2 __main____global_statements
+                        127 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_builtin-aa64615.json
+++ b/tests/reference/asr-test_builtin-aa64615.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin-aa64615.stdout",
-    "stdout_hash": "6ed85c2c8a8d46a5f877ea5c1a8e4a6c50d0ec04fa6eb967ad76aea3",
+    "stdout_hash": "1a601d371a9968f247d0c93a5437343b5fc47ab795d8d3fd9595eea7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin-aa64615.stdout
+++ b/tests/reference/asr-test_builtin-aa64615.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         6
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -2124,22 +2124,22 @@
                     (SymbolTable
                         7
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     7
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        7 __main____global_statements
-                        2 __main____global_statements
+                        7 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_builtin_abs-c74d2c9.json
+++ b/tests/reference/asr-test_builtin_abs-c74d2c9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_abs-c74d2c9.stdout",
-    "stdout_hash": "f8f7596f530965f2bda001faf89ef55113b6e05114803ed4816c4fcf",
+    "stdout_hash": "8704ba46954782edf300582475bf3afa482fd9a44fee030a0731b8b9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_abs-c74d2c9.stdout
+++ b/tests/reference/asr-test_builtin_abs-c74d2c9.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         4
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -580,22 +580,22 @@
                     (SymbolTable
                         5
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     5
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        5 __main____global_statements
-                        2 __main____global_statements
+                        5 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_builtin_bin-52ba9fa.json
+++ b/tests/reference/asr-test_builtin_bin-52ba9fa.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_bin-52ba9fa.stdout",
-    "stdout_hash": "cbe1e42fbf30e713730390429c73a6e0c52b5fa476951baa600ca178",
+    "stdout_hash": "35fd706bf737b8dc604b612a080f41a5d136dc302de1705b051e8173",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_bin-52ba9fa.stdout
+++ b/tests/reference/asr-test_builtin_bin-52ba9fa.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         126
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -246,22 +246,22 @@
                     (SymbolTable
                         127
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     127
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        127 __main____global_statements
-                        2 __main____global_statements
+                        127 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_builtin_bool-330223a.json
+++ b/tests/reference/asr-test_builtin_bool-330223a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_bool-330223a.stdout",
-    "stdout_hash": "d82f6b4d55b4058b3cb601f6241821deb3b4bdd5837e4dc42e7f6641",
+    "stdout_hash": "af74c45e877a75d102e9fee40ee41450ec37afbb80135a31b7d85cd7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_bool-330223a.stdout
+++ b/tests/reference/asr-test_builtin_bool-330223a.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         126
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -871,22 +871,22 @@
                     (SymbolTable
                         127
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     127
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        127 __main____global_statements
-                        2 __main____global_statements
+                        127 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_builtin_float-20601dd.json
+++ b/tests/reference/asr-test_builtin_float-20601dd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_float-20601dd.stdout",
-    "stdout_hash": "70047df956296d7e9b8b4a3333cb2a14afb4f778dffe5791f7f14763",
+    "stdout_hash": "30bd7a1456c6e4b74a7c6310f2c49c9593924e9728cdba8151b2c15a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_float-20601dd.stdout
+++ b/tests/reference/asr-test_builtin_float-20601dd.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         4
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -505,22 +505,22 @@
                     (SymbolTable
                         5
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     5
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        5 __main____global_statements
-                        2 __main____global_statements
+                        5 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_builtin_hex-64bd268.json
+++ b/tests/reference/asr-test_builtin_hex-64bd268.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_hex-64bd268.stdout",
-    "stdout_hash": "f5c8c98ea9cc9a07bcbab7c7be21a64144c23a0c5d2f4d8afb98e742",
+    "stdout_hash": "b93da13f9a14f24cb5e78a4787b832ca1cdbf9a71383df5618d0f68f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_hex-64bd268.stdout
+++ b/tests/reference/asr-test_builtin_hex-64bd268.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         126
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -221,22 +221,22 @@
                     (SymbolTable
                         127
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     127
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        127 __main____global_statements
-                        2 __main____global_statements
+                        127 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_builtin_int-8f88fdc.json
+++ b/tests/reference/asr-test_builtin_int-8f88fdc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_int-8f88fdc.stdout",
-    "stdout_hash": "2279ed2c015d645174f1cfe26b712509719ddc8360b45d79cc0a5272",
+    "stdout_hash": "ac7c1dc83cf2a510b118f03332645f9503a084c66a9c61ce4833d3e1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_int-8f88fdc.stdout
+++ b/tests/reference/asr-test_builtin_int-8f88fdc.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         6
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -985,22 +985,22 @@
                     (SymbolTable
                         7
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     7
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        7 __main____global_statements
-                        2 __main____global_statements
+                        7 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_builtin_len-55b0dec.json
+++ b/tests/reference/asr-test_builtin_len-55b0dec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_len-55b0dec.stdout",
-    "stdout_hash": "b840c0122afd41f04637060df6e4d8c0187e2e67f31ad644144b553f",
+    "stdout_hash": "2a3e339bcf76aded62305d7667f0f17439bb96609a8106cb933d37e0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_len-55b0dec.stdout
+++ b/tests/reference/asr-test_builtin_len-55b0dec.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         6
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -666,22 +666,22 @@
                     (SymbolTable
                         7
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     7
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        7 __main____global_statements
-                        2 __main____global_statements
+                        7 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_builtin_oct-20b9066.json
+++ b/tests/reference/asr-test_builtin_oct-20b9066.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_oct-20b9066.stdout",
-    "stdout_hash": "81fe3a03da5970367f2a6e2a6a4c3e421c14aa74e23d1b2ec0a91810",
+    "stdout_hash": "b8f9b2a1b3725db48a5116069cb07add8d72c2bb020d1098cea2416c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_oct-20b9066.stdout
+++ b/tests/reference/asr-test_builtin_oct-20b9066.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         126
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -221,22 +221,22 @@
                     (SymbolTable
                         127
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     127
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        127 __main____global_statements
-                        2 __main____global_statements
+                        127 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_builtin_pow-f02fcda.json
+++ b/tests/reference/asr-test_builtin_pow-f02fcda.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_pow-f02fcda.stdout",
-    "stdout_hash": "2e8de674a09eb381e95604df7acd7b0bfd8fdfae8c1ba2457c79412d",
+    "stdout_hash": "d9a0be4ec0fc5fcd2189eb31e408db9e1f874faf0f0cde793e12a82a",
     "stderr": "asr-test_builtin_pow-f02fcda.stderr",
     "stderr_hash": "859ce76c74748f2d32c7eab92cfbba789a78d4cbf5818646b99806ea",
     "returncode": 0

--- a/tests/reference/asr-test_builtin_pow-f02fcda.stdout
+++ b/tests/reference/asr-test_builtin_pow-f02fcda.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         126
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -1894,22 +1894,22 @@
                     (SymbolTable
                         127
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     127
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        127 __main____global_statements
-                        2 __main____global_statements
+                        127 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_builtin_round-7417a21.json
+++ b/tests/reference/asr-test_builtin_round-7417a21.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_round-7417a21.stdout",
-    "stdout_hash": "140ed1b578997c4bfac1c492e568447e6096a3673da94045b34309b4",
+    "stdout_hash": "17378338ac36a654f02894d1712968c68bdd257e6716d9bc6435e741",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_round-7417a21.stdout
+++ b/tests/reference/asr-test_builtin_round-7417a21.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         126
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -894,22 +894,22 @@
                     (SymbolTable
                         127
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     127
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        127 __main____global_statements
-                        2 __main____global_statements
+                        127 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_builtin_str-580e920.json
+++ b/tests/reference/asr-test_builtin_str-580e920.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_str-580e920.stdout",
-    "stdout_hash": "5869436dc7dad9581fe5088ceb646bb304ddc9f8ef790e6550687c9b",
+    "stdout_hash": "757004fd20974ca9ccee145fcb6fdcc725839c3eb87ec97919c8115c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_str-580e920.stdout
+++ b/tests/reference/asr-test_builtin_str-580e920.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         8
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -1446,22 +1446,22 @@
                     (SymbolTable
                         9
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     9
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        9 __main____global_statements
-                        2 __main____global_statements
+                        9 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_c_interop_01-e374f43.json
+++ b/tests/reference/asr-test_c_interop_01-e374f43.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_c_interop_01-e374f43.stdout",
-    "stdout_hash": "44025c97e50dc31d8f819a14d2c68dc0d5d3bfceb3a035a3574f6f13",
+    "stdout_hash": "36d1ce849d522551d3a6959c4120c020948daffd48736099af330484",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_c_interop_01-e374f43.stdout
+++ b/tests/reference/asr-test_c_interop_01-e374f43.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         8
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -686,22 +686,22 @@
                     (SymbolTable
                         9
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     9
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        9 __main____global_statements
-                        2 __main____global_statements
+                        9 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_complex_01-a6def58.json
+++ b/tests/reference/asr-test_complex_01-a6def58.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_complex_01-a6def58.stdout",
-    "stdout_hash": "441c69486af4dc17fbcc4f53c78b1370581c1a163d8d2f2d3d1ca01d",
+    "stdout_hash": "0692ef127000dfc8a418218e1e295bd41b5e17a46d06e21890961e99",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_complex_01-a6def58.stdout
+++ b/tests/reference/asr-test_complex_01-a6def58.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         130
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -1988,22 +1988,22 @@
                     (SymbolTable
                         131
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     131
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        131 __main____global_statements
-                        2 __main____global_statements
+                        131 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_complex_02-782ba2d.json
+++ b/tests/reference/asr-test_complex_02-782ba2d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_complex_02-782ba2d.stdout",
-    "stdout_hash": "1e7549a2aa22da9868cfa04bac02cfc0dd518f027c079ef6c3050a73",
+    "stdout_hash": "2219e40d60d28c61a23b07625bb185439d8338973c5d2312f2252718",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_complex_02-782ba2d.stdout
+++ b/tests/reference/asr-test_complex_02-782ba2d.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         129
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -693,22 +693,22 @@
                     (SymbolTable
                         130
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     130
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main____global_statements
-                        2 __main____global_statements
+                        130 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_end_sep_keywords-2226a67.json
+++ b/tests/reference/asr-test_end_sep_keywords-2226a67.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_end_sep_keywords-2226a67.stdout",
-    "stdout_hash": "3a586fde04b4d918381f4de704d1505e74617f283c1f33ba6aa8a538",
+    "stdout_hash": "4946b03b00e3231e12fb3fc0f79a7b715cedf4e5dc74b3625a3098ae",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_end_sep_keywords-2226a67.stdout
+++ b/tests/reference/asr-test_end_sep_keywords-2226a67.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         4
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -164,22 +164,22 @@
                     (SymbolTable
                         5
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     5
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        5 __main____global_statements
-                        2 __main____global_statements
+                        5 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_max_min-3c2fc51.json
+++ b/tests/reference/asr-test_max_min-3c2fc51.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_max_min-3c2fc51.stdout",
-    "stdout_hash": "242c1a412e974ad9ef7365e670304564f67b14f0c258df5c858c0206",
+    "stdout_hash": "2f0d706f9ac6d985b0781a10cb989bccf5923a82410bf4d526b32935",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_max_min-3c2fc51.stdout
+++ b/tests/reference/asr-test_max_min-3c2fc51.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         130
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -789,22 +789,22 @@
                     (SymbolTable
                         131
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     131
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        131 __main____global_statements
-                        2 __main____global_statements
+                        131 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_numpy_03-e600a49.json
+++ b/tests/reference/asr-test_numpy_03-e600a49.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_03-e600a49.stdout",
-    "stdout_hash": "3acd291a004d49bc3ba0ce95e14db9aae73d98c3cba9decd07df2eaf",
+    "stdout_hash": "fb4a623059b7a8e743a10f405685a9a8a1ade809ae6520425bd579be",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_03-e600a49.stdout
+++ b/tests/reference/asr-test_numpy_03-e600a49.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         217
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -1847,22 +1847,22 @@
                     (SymbolTable
                         218
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     218
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        218 __main____global_statements
-                        2 __main____global_statements
+                        218 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_numpy_04-ecbb614.json
+++ b/tests/reference/asr-test_numpy_04-ecbb614.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_04-ecbb614.stdout",
-    "stdout_hash": "cc0a0d7278ed1e730bda49e8d46376117b0c93205a3d01ddc760093c",
+    "stdout_hash": "e799b8f3fc51ba9c73139a5f846eed42ccd500e8820257594909d567",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_04-ecbb614.stdout
+++ b/tests/reference/asr-test_numpy_04-ecbb614.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         203
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -492,22 +492,22 @@
                     (SymbolTable
                         204
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     204
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        204 __main____global_statements
-                        2 __main____global_statements
+                        204 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_pow-3f5d550.json
+++ b/tests/reference/asr-test_pow-3f5d550.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_pow-3f5d550.stdout",
-    "stdout_hash": "06113ac0abcd53bcf0b9b5e44644db0087c15ca1f349e1e284358263",
+    "stdout_hash": "ad18bd130c410404f1e423b3ce7d48b9833b31c9f959d13046ed0262",
     "stderr": "asr-test_pow-3f5d550.stderr",
     "stderr_hash": "3d950301563cce75654f28bf41f6f53428ed1f5ae997774345f374a3",
     "returncode": 0

--- a/tests/reference/asr-test_pow-3f5d550.stdout
+++ b/tests/reference/asr-test_pow-3f5d550.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         126
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -134,22 +134,22 @@
                     (SymbolTable
                         127
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     127
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        127 __main____global_statements
-                        2 __main____global_statements
+                        127 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-test_unary_op_03-e799eae.json
+++ b/tests/reference/asr-test_unary_op_03-e799eae.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_unary_op_03-e799eae.stdout",
-    "stdout_hash": "aa082e4726f8dd1870b7d525055bbcf9ea6533aab13248599708b84a",
+    "stdout_hash": "4511db7e0936003a81bcb4c6b4c1cbc60070f29a9fd7dd04e8d3d137",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_unary_op_03-e799eae.stdout
+++ b/tests/reference/asr-test_unary_op_03-e799eae.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         4
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -166,22 +166,22 @@
                     (SymbolTable
                         5
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     5
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        5 __main____global_statements
-                        2 __main____global_statements
+                        5 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr-vec_01-66ac423.json
+++ b/tests/reference/asr-vec_01-66ac423.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-vec_01-66ac423.stdout",
-    "stdout_hash": "74838bb6f4aea541d2dc51c5fad4e68924a20fd02a5bb42d8f3bd582",
+    "stdout_hash": "a8b2e65b405cfab777d35efd6f739b9bd4041478a831ba3470468a54",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-vec_01-66ac423.stdout
+++ b/tests/reference/asr-vec_01-66ac423.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         204
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -240,22 +240,22 @@
                     (SymbolTable
                         205
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     205
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        205 __main____global_statements
-                        2 __main____global_statements
+                        205 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/asr_json-modules_02-53952e6.json
+++ b/tests/reference/asr_json-modules_02-53952e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_json-modules_02-53952e6.stdout",
-    "stdout_hash": "d285bece8f91160c451326d3373700dabd781e24fe022b812bff957c",
+    "stdout_hash": "a859b5986d89d954341c31440f12d9111194940e7725b7425c3ce22c",
     "stderr": "asr_json-modules_02-53952e6.stderr",
     "stderr_hash": "132af04271d3bfd523848990e734bfa3c0aed6e4b85ec4eb87e66720",
     "returncode": 0

--- a/tests/reference/asr_json-modules_02-53952e6.stdout
+++ b/tests/reference/asr_json-modules_02-53952e6.stdout
@@ -10,14 +10,14 @@
                         "symtab": {
                             "node": "SymbolTable2",
                             "fields": {
-                                "__main____global_statements": {
+                                "__main__global_stmts": {
                                     "node": "Function",
                                     "fields": {
                                         "symtab": {
                                             "node": "SymbolTable8",
                                             "fields": {}
                                         },
-                                        "name": "__main____global_statements",
+                                        "name": "__main__global_stmts",
                                         "function_signature": {
                                             "node": "FunctionType",
                                             "fields": {
@@ -609,15 +609,15 @@
                         "symtab": {
                             "node": "SymbolTable9",
                             "fields": {
-                                "__main____global_statements": {
+                                "__main__global_stmts": {
                                     "node": "ExternalSymbol",
                                     "fields": {
                                         "parent_symtab": 9,
-                                        "name": "__main____global_statements",
-                                        "external": "__main____global_statements (SymbolTable2)",
+                                        "name": "__main__global_stmts",
+                                        "external": "__main__global_stmts (SymbolTable2)",
                                         "module_name": "__main__",
                                         "scope_names": [],
-                                        "original_name": "__main____global_statements",
+                                        "original_name": "__main__global_stmts",
                                         "access": "Public"
                                     },
                                     "loc": {
@@ -641,8 +641,8 @@
                             {
                                 "node": "SubroutineCall",
                                 "fields": {
-                                    "name": "__main____global_statements (SymbolTable9)",
-                                    "original_name": "__main____global_statements (SymbolTable2)",
+                                    "name": "__main__global_stmts (SymbolTable9)",
+                                    "original_name": "__main__global_stmts (SymbolTable2)",
                                     "args": [],
                                     "dt": []
                                 },

--- a/tests/reference/c-expr7-bb2692a.json
+++ b/tests/reference/c-expr7-bb2692a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-expr7-bb2692a.stdout",
-    "stdout_hash": "49af46a64f7f11d442e2216c1bb51d307305cc70980caa7952cc85d1",
+    "stdout_hash": "241378f1e16504e72b5ed9ad7fc0fa88ecfafb0373b545bf381a9397",
     "stderr": "c-expr7-bb2692a.stderr",
     "stderr_hash": "6e9790ac88db1a9ead8f64a91ba8a6605de67167037908a74b77be0c",
     "returncode": 0

--- a/tests/reference/c-expr7-bb2692a.stdout
+++ b/tests/reference/c-expr7-bb2692a.stdout
@@ -11,7 +11,7 @@
 void test_pow();
 int32_t test_pow_1(int32_t a, int32_t b);
 void main0();
-void __main____global_statements();
+void __main__global_stmts();
 
 
 
@@ -49,7 +49,7 @@ void main0()
     c = test_pow_1(1, 2);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     main0();
 }
@@ -57,6 +57,6 @@ void __main____global_statements()
 int main(int argc, char* argv[])
 {
     _lpython_set_argv(argc, argv);
-    __main____global_statements();
+    __main__global_stmts();
     return 0;
 }

--- a/tests/reference/c-expr_01-28f449f.json
+++ b/tests/reference/c-expr_01-28f449f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-expr_01-28f449f.stdout",
-    "stdout_hash": "b9e6df09a73026d76ea9eefed3e2b211476b1ac55956ee8150a4a417",
+    "stdout_hash": "182f1a13f6ba0679a3107a8a9cc181130651a9f5d2f2acf7c382e431",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-expr_01-28f449f.stdout
+++ b/tests/reference/c-expr_01-28f449f.stdout
@@ -9,7 +9,7 @@
 inline __attribute__((always_inline)) int32_t add(int32_t x, int32_t y);
 inline __attribute__((always_inline)) int32_t and_op(int32_t x, int32_t y);
 void main0();
-void __main____global_statements();
+void __main__global_stmts();
 
 
 
@@ -41,7 +41,7 @@ void main0()
     ASSERT(z == 16);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     main0();
 }
@@ -49,6 +49,6 @@ void __main____global_statements()
 int main(int argc, char* argv[])
 {
     _lpython_set_argv(argc, argv);
-    __main____global_statements();
+    __main__global_stmts();
     return 0;
 }

--- a/tests/reference/c-expr_11-c452314.json
+++ b/tests/reference/c-expr_11-c452314.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-expr_11-c452314.stdout",
-    "stdout_hash": "828e55148962eac31cff8246dbf28003a81b9852481aa1e584128ecb",
+    "stdout_hash": "2d6fe10d9189c578a5a20e042153115de54220d02a56baedc15efc31",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-expr_11-c452314.stdout
+++ b/tests/reference/c-expr_11-c452314.stdout
@@ -7,7 +7,7 @@
 #include <lfortran_intrinsics.h>
 
 void f();
-void __main____global_statements();
+void __main__global_stmts();
 
 
 
@@ -22,7 +22,7 @@ void f()
     printf("%d\n", b);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     f();
 }
@@ -30,6 +30,6 @@ void __main____global_statements()
 int main(int argc, char* argv[])
 {
     _lpython_set_argv(argc, argv);
-    __main____global_statements();
+    __main__global_stmts();
     return 0;
 }

--- a/tests/reference/c-expr_12-93c7780.json
+++ b/tests/reference/c-expr_12-93c7780.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-expr_12-93c7780.stdout",
-    "stdout_hash": "6162cc3c452b530aef96db7443c95a0db16bce78b119b9a4ccf91f6a",
+    "stdout_hash": "4cbfe2f301edb2e5df13058ec0ff1415277851ee8ffcdda264b2f239",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-expr_12-93c7780.stdout
+++ b/tests/reference/c-expr_12-93c7780.stdout
@@ -23,7 +23,7 @@ struct i16
 void g(struct i16* *x, struct i16* y);
 void check(struct i16* *ptr);
 void f();
-void __main____global_statements();
+void __main__global_stmts();
 
 
 
@@ -57,7 +57,7 @@ void f()
     check(&yptr1);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     f();
 }
@@ -65,6 +65,6 @@ void __main____global_statements()
 int main(int argc, char* argv[])
 {
     _lpython_set_argv(argc, argv);
-    __main____global_statements();
+    __main__global_stmts();
     return 0;
 }

--- a/tests/reference/c-func_static_01-fc146ec.json
+++ b/tests/reference/c-func_static_01-fc146ec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-func_static_01-fc146ec.stdout",
-    "stdout_hash": "77431288e9f3af7e7f5d2a2859ade52772a79789337db403b3dc9943",
+    "stdout_hash": "ba4195c88f493b5e4d007ced548cd22bb7b12a7ba6a21df7526018bb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-func_static_01-fc146ec.stdout
+++ b/tests/reference/c-func_static_01-fc146ec.stdout
@@ -8,7 +8,7 @@
 
 static int64_t fib(int64_t n);
 void main0();
-void __main____global_statements();
+void __main__global_stmts();
 
 
 
@@ -33,7 +33,7 @@ void main0()
     ASSERT(ans == 5);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     main0();
 }
@@ -41,6 +41,6 @@ void __main____global_statements()
 int main(int argc, char* argv[])
 {
     _lpython_set_argv(argc, argv);
-    __main____global_statements();
+    __main__global_stmts();
     return 0;
 }

--- a/tests/reference/c-loop1-3e341c7.json
+++ b/tests/reference/c-loop1-3e341c7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-loop1-3e341c7.stdout",
-    "stdout_hash": "241f7395d191f7dd26195e71200be7e23a30969f2cca993137eb8b2d",
+    "stdout_hash": "c83616df972c7b3f966dab1ae3c339147a426324bd33890a9d13144e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-loop1-3e341c7.stdout
+++ b/tests/reference/c-loop1-3e341c7.stdout
@@ -10,7 +10,7 @@ int32_t test_factorial_1(int32_t x);
 int32_t test_factorial_2(int32_t x);
 int64_t test_factorial_3(int32_t x);
 void main0();
-void __main____global_statements();
+void __main__global_stmts();
 
 
 
@@ -72,7 +72,7 @@ void main0()
     j = test_factorial_3(5);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     main0();
 }
@@ -80,6 +80,6 @@ void __main____global_statements()
 int main(int argc, char* argv[])
 {
     _lpython_set_argv(argc, argv);
-    __main____global_statements();
+    __main__global_stmts();
     return 0;
 }

--- a/tests/reference/c-loop4-eec10d3.json
+++ b/tests/reference/c-loop4-eec10d3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-loop4-eec10d3.stdout",
-    "stdout_hash": "9c6c8fd97e7c24685ba75f6037f45993f3f739817b4fb6650cd9cab8",
+    "stdout_hash": "8eea5321c1fd80c9bce62d443a5bc4709a5a9cfcb95fc38c8f369ce4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-loop4-eec10d3.stdout
+++ b/tests/reference/c-loop4-eec10d3.stdout
@@ -7,7 +7,7 @@
 #include <lfortran_intrinsics.h>
 
 void test_for();
-void __main____global_statements();
+void __main__global_stmts();
 
 
 
@@ -28,7 +28,7 @@ void test_for()
     }
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     test_for();
 }
@@ -36,6 +36,6 @@ void __main____global_statements()
 int main(int argc, char* argv[])
 {
     _lpython_set_argv(argc, argv);
-    __main____global_statements();
+    __main__global_stmts();
     return 0;
 }

--- a/tests/reference/c-print_01-4d44628.json
+++ b/tests/reference/c-print_01-4d44628.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-print_01-4d44628.stdout",
-    "stdout_hash": "eeedca2639797a26c43f22383f01cdd16382d27921d87a70687c44d9",
+    "stdout_hash": "618b140a8c12a6798b60e01373d930af2a8d6df85b5aed54227b3462",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-print_01-4d44628.stdout
+++ b/tests/reference/c-print_01-4d44628.stdout
@@ -6,7 +6,7 @@
 #include <lfortran_intrinsics.h>
 
 void f();
-void __main____global_statements();
+void __main__global_stmts();
 
 
 
@@ -27,7 +27,7 @@ void f()
     printf("%s%s%s\n", "LCompilers", " ", "LPython");
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     f();
 }
@@ -35,6 +35,6 @@ void __main____global_statements()
 int main(int argc, char* argv[])
 {
     _lpython_set_argv(argc, argv);
-    __main____global_statements();
+    __main__global_stmts();
     return 0;
 }

--- a/tests/reference/c-test_import_02-d2c54c4.json
+++ b/tests/reference/c-test_import_02-d2c54c4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-test_import_02-d2c54c4.stdout",
-    "stdout_hash": "96649585d0a2f2f8e55f872b58bb924983457db3679b43525112a3ec",
+    "stdout_hash": "dc4de2618a3ad2e6c3f4eaa2b203104e51758040bb1f2ab14d85ba3a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-test_import_02-d2c54c4.stdout
+++ b/tests/reference/c-test_import_02-d2c54c4.stdout
@@ -9,7 +9,7 @@
 int32_t add(int32_t x, int32_t y);
 int32_t multiply(int32_t x, int32_t y);
 void f();
-void __main____global_statements();
+void __main__global_stmts();
 
 
 
@@ -40,7 +40,7 @@ void f()
     ASSERT(multiply(10, 20) == 200);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     f();
 }
@@ -48,6 +48,6 @@ void __main____global_statements()
 int main(int argc, char* argv[])
 {
     _lpython_set_argv(argc, argv);
-    __main____global_statements();
+    __main__global_stmts();
     return 0;
 }

--- a/tests/reference/c-test_issue_518-fbbd299.json
+++ b/tests/reference/c-test_issue_518-fbbd299.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-test_issue_518-fbbd299.stdout",
-    "stdout_hash": "651a207e618ca25fb733b618072bd3586b652da51a824ddd03d681d1",
+    "stdout_hash": "2140b84aa94533cf8a3cc994b6eefa42b22cb03615c99967a9e3b1e9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-test_issue_518-fbbd299.stdout
+++ b/tests/reference/c-test_issue_518-fbbd299.stdout
@@ -9,7 +9,7 @@
 int64_t fib(int64_t n);
 void main0();
 void _xx_lcompilers_changed_main_xx();
-void __main____global_statements();
+void __main__global_stmts();
 
 
 
@@ -41,7 +41,7 @@ void _xx_lcompilers_changed_main_xx()
     ASSERT(ans == 55);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     main0();
     _xx_lcompilers_changed_main_xx();
@@ -50,6 +50,6 @@ void __main____global_statements()
 int main(int argc, char* argv[])
 {
     _lpython_set_argv(argc, argv);
-    __main____global_statements();
+    __main__global_stmts();
     return 0;
 }

--- a/tests/reference/c-variable_decl_03-fa1823b.json
+++ b/tests/reference/c-variable_decl_03-fa1823b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-variable_decl_03-fa1823b.stdout",
-    "stdout_hash": "c6088ef2edb0ff2113dad651f6f782fb8dfdbe32a563d25eaa8eb0b4",
+    "stdout_hash": "db9d4425ea564096988a8799be60a068865d3757cb7c72b44bdcebc5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/c-variable_decl_03-fa1823b.stdout
+++ b/tests/reference/c-variable_decl_03-fa1823b.stdout
@@ -8,7 +8,7 @@
 double _lcompilers_abs_f64(double x);
 double f();
 void _xx_lcompilers_changed_main_xx();
-void __main____global_statements();
+void __main__global_stmts();
 
 
 
@@ -39,7 +39,7 @@ void _xx_lcompilers_changed_main_xx()
     ASSERT(_lcompilers_abs_f64(t1 -   5.50000000000000000e+00*  1.00000000000000000e+06) <=   9.99999999999999955e-07);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     _xx_lcompilers_changed_main_xx();
 }
@@ -47,6 +47,6 @@ void __main____global_statements()
 int main(int argc, char* argv[])
 {
     _lpython_set_argv(argc, argv);
-    __main____global_statements();
+    __main__global_stmts();
     return 0;
 }

--- a/tests/reference/cpp-doconcurrentloop_01-4e9f274.json
+++ b/tests/reference/cpp-doconcurrentloop_01-4e9f274.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-doconcurrentloop_01-4e9f274.stdout",
-    "stdout_hash": "9f90ea60f0e9d60db320463e517b09fac3c539fa4119428aa7b1e551",
+    "stdout_hash": "cef4c9a2fa79bd4f12c0842cc4cae9d0be7f1891b5c66ee6b229bb9f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-doconcurrentloop_01-4e9f274.stdout
+++ b/tests/reference/cpp-doconcurrentloop_01-4e9f274.stdout
@@ -33,7 +33,7 @@ struct f32_10000_1
 };
 
 // Forward declarations
-void __main____global_statements();
+void __main__global_stmts();
 void main0();
 
 template <typename T0, typename T1, typename T2>
@@ -84,7 +84,7 @@ void main0()
     std::cout << "End Stream Triad" << std::endl;
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     main0();
 }
@@ -92,7 +92,7 @@ void __main____global_statements()
 namespace {
 
 void main2() {
-    __main____global_statements();
+    __main__global_stmts();
 }
 
 }

--- a/tests/reference/cpp-expr12-fd2ea87.json
+++ b/tests/reference/cpp-expr12-fd2ea87.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr12-fd2ea87.stdout",
-    "stdout_hash": "ade4edd1e3586b786d3860b244053fe7c2f78e518b4392fe95626727",
+    "stdout_hash": "3fd932aa8477bf21939c1376aa02973ffaa27249dded08685a4f8a27",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr12-fd2ea87.stdout
+++ b/tests/reference/cpp-expr12-fd2ea87.stdout
@@ -18,7 +18,7 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 }
 
 // Forward declarations
-void __main____global_statements();
+void __main__global_stmts();
 int32_t check();
 void main0();
 int32_t test(int32_t a, int32_t b);
@@ -48,7 +48,7 @@ void main0()
     x = check();
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     main0();
 }
@@ -56,7 +56,7 @@ void __main____global_statements()
 namespace {
 
 void main2() {
-    __main____global_statements();
+    __main__global_stmts();
 }
 
 }

--- a/tests/reference/cpp-expr15-1661c0d.json
+++ b/tests/reference/cpp-expr15-1661c0d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr15-1661c0d.stdout",
-    "stdout_hash": "9f8482285dd48f735d4d59d18a878e7fca978188cef61719e9a2cad3",
+    "stdout_hash": "c6660bd5efa0a0602ea96a86d5c44220cb4390dea4eebf4cb16211bc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr15-1661c0d.stdout
+++ b/tests/reference/cpp-expr15-1661c0d.stdout
@@ -18,7 +18,7 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 }
 
 // Forward declarations
-void __main____global_statements();
+void __main__global_stmts();
 double test1();
 std::complex<double> test2();
 int32_t test3();
@@ -69,7 +69,7 @@ int32_t test3()
     return _lpython_return_variable;
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     std::cout << test1() << std::endl;
     std::cout << test2() << std::endl;
@@ -79,7 +79,7 @@ void __main____global_statements()
 namespace {
 
 void main2() {
-    __main____global_statements();
+    __main__global_stmts();
 }
 
 }

--- a/tests/reference/cpp-expr7-529bd53.json
+++ b/tests/reference/cpp-expr7-529bd53.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr7-529bd53.stdout",
-    "stdout_hash": "0ddb624844237f1333b49b580bb956d0f202df4fa834cff3dc8b4e75",
+    "stdout_hash": "8f72ce4b2d8f170884e171b1bdfa4a4ea07344825b6787d814a446cf",
     "stderr": "cpp-expr7-529bd53.stderr",
     "stderr_hash": "6e9790ac88db1a9ead8f64a91ba8a6605de67167037908a74b77be0c",
     "returncode": 0

--- a/tests/reference/cpp-expr7-529bd53.stdout
+++ b/tests/reference/cpp-expr7-529bd53.stdout
@@ -18,7 +18,7 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 }
 
 // Forward declarations
-void __main____global_statements();
+void __main__global_stmts();
 void main0();
 void test_pow();
 int32_t test_pow_1(int32_t a, int32_t b);
@@ -62,7 +62,7 @@ void main0()
     c = test_pow_1(1, 2);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     main0();
 }
@@ -70,7 +70,7 @@ void __main____global_statements()
 namespace {
 
 void main2() {
-    __main____global_statements();
+    __main__global_stmts();
 }
 
 }

--- a/tests/reference/cpp-expr9-48868e9.json
+++ b/tests/reference/cpp-expr9-48868e9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr9-48868e9.stdout",
-    "stdout_hash": "539f9a3a88fb6c7d4af637faada51269bde7815558614a4938561dde",
+    "stdout_hash": "8322420a1f1df346d89982ca461b6d08b67c2dab936e74d2a5f544f7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr9-48868e9.stdout
+++ b/tests/reference/cpp-expr9-48868e9.stdout
@@ -18,7 +18,7 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 }
 
 // Forward declarations
-void __main____global_statements();
+void __main__global_stmts();
 void main0();
 int32_t test_return_1(int32_t a);
 std::string test_return_2(int32_t a);
@@ -61,7 +61,7 @@ void main0()
     i = test_return_3(4);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     main0();
 }
@@ -69,7 +69,7 @@ void __main____global_statements()
 namespace {
 
 void main2() {
-    __main____global_statements();
+    __main__global_stmts();
 }
 
 }

--- a/tests/reference/cpp-expr_11-422c839.json
+++ b/tests/reference/cpp-expr_11-422c839.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr_11-422c839.stdout",
-    "stdout_hash": "ee523e892c8a9e54cc670f9305d4c791e165b79679b71f44e6d9167c",
+    "stdout_hash": "c015d4446b89b36b010a37f5651e19ef8615ca00148c4ff51f8c5e3d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr_11-422c839.stdout
+++ b/tests/reference/cpp-expr_11-422c839.stdout
@@ -18,7 +18,7 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 }
 
 // Forward declarations
-void __main____global_statements();
+void __main__global_stmts();
 void f();
 namespace {
 }
@@ -34,7 +34,7 @@ void f()
     std::cout << b << std::endl;
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     f();
 }
@@ -42,7 +42,7 @@ void __main____global_statements()
 namespace {
 
 void main2() {
-    __main____global_statements();
+    __main__global_stmts();
 }
 
 }

--- a/tests/reference/cpp-loop1-0a8cf3b.json
+++ b/tests/reference/cpp-loop1-0a8cf3b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-loop1-0a8cf3b.stdout",
-    "stdout_hash": "c202de96b07e1cf07918733e723bd99ea3315075e50e1b4951eaa895",
+    "stdout_hash": "47940a3d90ec65bad62ffb4a582149a8ed514e48071a45bb7eb3fe5b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-loop1-0a8cf3b.stdout
+++ b/tests/reference/cpp-loop1-0a8cf3b.stdout
@@ -18,7 +18,7 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 }
 
 // Forward declarations
-void __main____global_statements();
+void __main__global_stmts();
 void main0();
 int32_t test_factorial_1(int32_t x);
 int32_t test_factorial_2(int32_t x);
@@ -84,7 +84,7 @@ void main0()
     j = test_factorial_3(5);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     main0();
 }
@@ -92,7 +92,7 @@ void __main____global_statements()
 namespace {
 
 void main2() {
-    __main____global_statements();
+    __main__global_stmts();
 }
 
 }

--- a/tests/reference/cpp-loop4-cdb2174.json
+++ b/tests/reference/cpp-loop4-cdb2174.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-loop4-cdb2174.stdout",
-    "stdout_hash": "035b662f52288e24d70badd9d31be5732b0dab53842213af73de9ffe",
+    "stdout_hash": "a7a82cd77e9ab3cc7ed092234263ce57db724e0352d8bad31d090fcb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-loop4-cdb2174.stdout
+++ b/tests/reference/cpp-loop4-cdb2174.stdout
@@ -18,7 +18,7 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 }
 
 // Forward declarations
-void __main____global_statements();
+void __main__global_stmts();
 void test_for();
 namespace {
 }
@@ -40,7 +40,7 @@ void test_for()
     }
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     test_for();
 }
@@ -48,7 +48,7 @@ void __main____global_statements()
 namespace {
 
 void main2() {
-    __main____global_statements();
+    __main__global_stmts();
 }
 
 }

--- a/tests/reference/cpp-print_01-026ef17.json
+++ b/tests/reference/cpp-print_01-026ef17.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-print_01-026ef17.stdout",
-    "stdout_hash": "5c0f2040403d427b91360a090c99838d85416907ce1e3c4e7ae1906b",
+    "stdout_hash": "27da0159fcbc074b4527f6dc2ad9fbde547b888311fc5b92083eb0b9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-print_01-026ef17.stdout
+++ b/tests/reference/cpp-print_01-026ef17.stdout
@@ -18,7 +18,7 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 }
 
 // Forward declarations
-void __main____global_statements();
+void __main__global_stmts();
 void f();
 namespace {
 }
@@ -40,7 +40,7 @@ void f()
     std::cout << "LCompilers" << " " << "LPython" << std::endl;
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     f();
 }
@@ -48,7 +48,7 @@ void __main____global_statements()
 namespace {
 
 void main2() {
-    __main____global_statements();
+    __main__global_stmts();
 }
 
 }

--- a/tests/reference/cpp-test_builtin_pow-56b3f92.json
+++ b/tests/reference/cpp-test_builtin_pow-56b3f92.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-test_builtin_pow-56b3f92.stdout",
-    "stdout_hash": "0097d37ea4d51dd804fdf434749b0574e2fa754fbac6295e7373cfed",
+    "stdout_hash": "65d68d4aa112fa00894bf7023d10caa4cdfeb7b9656a7769e5b86121",
     "stderr": "cpp-test_builtin_pow-56b3f92.stderr",
     "stderr_hash": "859ce76c74748f2d32c7eab92cfbba789a78d4cbf5818646b99806ea",
     "returncode": 0

--- a/tests/reference/cpp-test_builtin_pow-56b3f92.stdout
+++ b/tests/reference/cpp-test_builtin_pow-56b3f92.stdout
@@ -19,7 +19,7 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 }
 
 // Forward declarations
-void __main____global_statements();
+void __main__global_stmts();
 void test_pow();
 double __lpython_overloaded_0__pow(int32_t x, int32_t y);
 int32_t __lpython_overloaded_10__pow(int32_t x, int32_t y, int32_t z);
@@ -280,7 +280,7 @@ void test_pow()
     c1 = __lpython_overloaded_9__pow(c1, 4);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     test_pow();
 }
@@ -288,7 +288,7 @@ void __main____global_statements()
 namespace {
 
 void main2() {
-    __main____global_statements();
+    __main__global_stmts();
 }
 
 }

--- a/tests/reference/cpp-test_list_repeat2-698d7f4.json
+++ b/tests/reference/cpp-test_list_repeat2-698d7f4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-test_list_repeat2-698d7f4.stdout",
-    "stdout_hash": "14efeab8658ae9018f5e5c846626c48309521131d0506519fc810845",
+    "stdout_hash": "b3979f6c5ea575cbbb0ae75fe566f811f6bb92aca2e698e6d0564326",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-test_list_repeat2-698d7f4.stdout
+++ b/tests/reference/cpp-test_list_repeat2-698d7f4.stdout
@@ -46,7 +46,7 @@ inline struct list_r32* list_repeat_r32(struct list_r32* x, int32_t freq);
 inline struct list_r32* list_section_r32(struct list_r32* x, int32_t idx1, int32_t idx2, int32_t step, bool i1_present, bool i2_present);
 
 // Forward declarations
-void __main____global_statements();
+void __main__global_stmts();
 float add_list(struct list_r32 x);
 struct list_r32 create_list(int32_t n);
 void main0();
@@ -95,7 +95,7 @@ void main0()
     std::cout << add_list(x) << std::endl;
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     main0();
 }
@@ -103,7 +103,7 @@ void __main____global_statements()
 namespace {
 
 void main2() {
-    __main____global_statements();
+    __main__global_stmts();
 }
 
 }

--- a/tests/reference/cpp-test_unary_op_03-fd9669a.json
+++ b/tests/reference/cpp-test_unary_op_03-fd9669a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-test_unary_op_03-fd9669a.stdout",
-    "stdout_hash": "aff27257321144de834a75c76c4782e9890acb6e963a7628c6e173f4",
+    "stdout_hash": "50205765dbafb525c90c7551a7217ca5b5c197047dfe471ffd2f4dec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-test_unary_op_03-fd9669a.stdout
+++ b/tests/reference/cpp-test_unary_op_03-fd9669a.stdout
@@ -18,7 +18,7 @@ Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
 }
 
 // Forward declarations
-void __main____global_statements();
+void __main__global_stmts();
 void f();
 namespace {
 }
@@ -35,7 +35,7 @@ void f()
     assert (~i == 235345);
 }
 
-void __main____global_statements()
+void __main__global_stmts()
 {
     f();
 }
@@ -43,7 +43,7 @@ void __main____global_statements()
 namespace {
 
 void main2() {
-    __main____global_statements();
+    __main__global_stmts();
 }
 
 }

--- a/tests/reference/llvm-bindc_01-c984f09.json
+++ b/tests/reference/llvm-bindc_01-c984f09.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc_01-c984f09.stdout",
-    "stdout_hash": "ecdb788f763b3cec85fdad8eebb12885d0ff2379f12c2af872f07ab3",
+    "stdout_hash": "36302aceabcf2682f3e954ab4bc56dd960fe532dc7799cb58baa19a3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc_01-c984f09.stdout
+++ b/tests/reference/llvm-bindc_01-c984f09.stdout
@@ -9,7 +9,7 @@ source_filename = "LFortran"
 @3 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
 @4 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
 
-define void @__module___main_____main____global_statements() {
+define void @__module___main_____main__global_stmts() {
 .entry:
   %0 = load void*, void** @queries, align 8
   %1 = bitcast void* %0 to i16*
@@ -74,7 +74,7 @@ declare void @exit(i32)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  call void @__module___main_____main____global_statements()
+  call void @__module___main_____main__global_stmts()
   ret i32 0
 }
 

--- a/tests/reference/llvm-bool1-af4376b.json
+++ b/tests/reference/llvm-bool1-af4376b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bool1-af4376b.stdout",
-    "stdout_hash": "67aa70ac6c056fd3f2fc14dad3874356de056006d4019994fb134fa2",
+    "stdout_hash": "cb60cdc2beb220bbe693b54079b5ebc7efcdc2cdc830c3cc0e213c39",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bool1-af4376b.stdout
+++ b/tests/reference/llvm-bool1-af4376b.stdout
@@ -22,7 +22,7 @@ source_filename = "LFortran"
 @18 = private unnamed_addr constant [5 x i8] c"True\00", align 1
 @19 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @__module___main_____main____global_statements() {
+define void @__module___main_____main__global_stmts() {
 .entry:
   call void @__module___main___test_bool()
   br label %return
@@ -57,7 +57,7 @@ declare void @_lfortran_printf(i8*, ...)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  call void @__module___main_____main____global_statements()
+  call void @__module___main_____main__global_stmts()
   ret i32 0
 }
 

--- a/tests/reference/llvm-expr_01-54467c1.json
+++ b/tests/reference/llvm-expr_01-54467c1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-expr_01-54467c1.stdout",
-    "stdout_hash": "1a7e03f37d8c48b6fe6a9edc9bb100e4ffc5d054337529a46df07d2d",
+    "stdout_hash": "8018bddb16bb05f28f77e84b0c4bb63a5515c75d5fee087543a243b5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-expr_01-54467c1.stdout
+++ b/tests/reference/llvm-expr_01-54467c1.stdout
@@ -5,7 +5,7 @@ source_filename = "LFortran"
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1
 
-define void @__module___main_____main____global_statements() {
+define void @__module___main_____main__global_stmts() {
 .entry:
   call void @__module___main___main0()
   br label %return
@@ -34,7 +34,7 @@ declare void @_lfortran_printf(i8*, ...)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  call void @__module___main_____main____global_statements()
+  call void @__module___main_____main__global_stmts()
   ret i32 0
 }
 

--- a/tests/reference/llvm-func_inline_01-2d4583a.json
+++ b/tests/reference/llvm-func_inline_01-2d4583a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-func_inline_01-2d4583a.stdout",
-    "stdout_hash": "46f36afd3fc5124f7a909234b51be9057082b0232c018d4b0aea662a",
+    "stdout_hash": "a91f2155136dbc019a41e5b1006d9b4a9e1f7def08086e307aafd15c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-func_inline_01-2d4583a.stdout
+++ b/tests/reference/llvm-func_inline_01-2d4583a.stdout
@@ -6,7 +6,7 @@ source_filename = "LFortran"
 @2 = private unnamed_addr constant [7 x i8] c"%lld%s\00", align 1
 @3 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
 
-define void @__module___main_____main____global_statements() {
+define void @__module___main_____main__global_stmts() {
 .entry:
   call void @__module___main____xx_lcompilers_changed_main_xx()
   br label %return
@@ -93,7 +93,7 @@ declare void @exit(i32)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  call void @__module___main_____main____global_statements()
+  call void @__module___main_____main__global_stmts()
   ret i32 0
 }
 

--- a/tests/reference/llvm-print_04-443a8d8.json
+++ b/tests/reference/llvm-print_04-443a8d8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-print_04-443a8d8.stdout",
-    "stdout_hash": "71ff455ab0705ae1cbeb1de9f7a4e3de76e38a96724019e71e9c474c",
+    "stdout_hash": "5fd7d7df606b54cd4d8304825a94448d366762055fdc5de73c61738c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-print_04-443a8d8.stdout
+++ b/tests/reference/llvm-print_04-443a8d8.stdout
@@ -18,7 +18,7 @@ source_filename = "LFortran"
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @11 = private unnamed_addr constant [7 x i8] c"%hhi%s\00", align 1
 
-define void @__module___main_____main____global_statements() {
+define void @__module___main_____main__global_stmts() {
 .entry:
   %0 = load i64, i64* @u, align 4
   call void (i8*, ...) @_lfortran_printf(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @2, i32 0, i32 0), i64 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
@@ -39,7 +39,7 @@ declare void @_lfortran_printf(i8*, ...)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  call void @__module___main_____main____global_statements()
+  call void @__module___main_____main__global_stmts()
   ret i32 0
 }
 

--- a/tests/reference/llvm-test_issue_518-cdb641a.json
+++ b/tests/reference/llvm-test_issue_518-cdb641a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-test_issue_518-cdb641a.stdout",
-    "stdout_hash": "6b4d9514ee030fa910844e76780681a5b99c13a772ce4407fbe04f44",
+    "stdout_hash": "61bea2762ce630ed6295649a1653e608a77cc1165f7575d28fdfefd1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-test_issue_518-cdb641a.stdout
+++ b/tests/reference/llvm-test_issue_518-cdb641a.stdout
@@ -4,7 +4,7 @@ source_filename = "LFortran"
 @0 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
 @1 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
 
-define void @__module___main_____main____global_statements() {
+define void @__module___main_____main__global_stmts() {
 .entry:
   call void @__module___main___main0()
   call void @__module___main____xx_lcompilers_changed_main_xx()
@@ -114,7 +114,7 @@ declare void @exit(i32)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  call void @__module___main_____main____global_statements()
+  call void @__module___main_____main__global_stmts()
   ret i32 0
 }
 

--- a/tests/reference/llvm-test_unary_op_03-046fb86.json
+++ b/tests/reference/llvm-test_unary_op_03-046fb86.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-test_unary_op_03-046fb86.stdout",
-    "stdout_hash": "b2ab2a7819aadaee6f2d476894bef09dc605a4245b0a16e03915f28f",
+    "stdout_hash": "1e9e596b5383d76430007e2e89893f64e5b07c21d46edeea5bd5acba",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-test_unary_op_03-046fb86.stdout
+++ b/tests/reference/llvm-test_unary_op_03-046fb86.stdout
@@ -4,7 +4,7 @@ source_filename = "LFortran"
 @0 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
 @1 = private unnamed_addr constant [16 x i8] c"AssertionError\0A\00", align 1
 
-define void @__module___main_____main____global_statements() {
+define void @__module___main_____main__global_stmts() {
 .entry:
   call void @__module___main___f()
   br label %return
@@ -62,7 +62,7 @@ declare void @exit(i32)
 define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1)
-  call void @__module___main_____main____global_statements()
+  call void @__module___main_____main__global_stmts()
   ret i32 0
 }
 

--- a/tests/reference/llvm_dbg-expr_01-9fc5f30.json
+++ b/tests/reference/llvm_dbg-expr_01-9fc5f30.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm_dbg-expr_01-9fc5f30.stdout",
-    "stdout_hash": "2b6aeabe4378b1377f3ea0025b1176e8ec9cd9fd46870f69acea15c3",
+    "stdout_hash": "f5424d14e2553fd4ea59a66c0d1560e435f0871cdfc5250f6a5df57d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm_dbg-expr_01-9fc5f30.stdout
+++ b/tests/reference/llvm_dbg-expr_01-9fc5f30.stdout
@@ -5,7 +5,7 @@ source_filename = "LFortran"
 @1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @2 = private unnamed_addr constant [5 x i8] c"%d%s\00", align 1
 
-define void @__module___main_____main____global_statements() !dbg !3 {
+define void @__module___main_____main__global_stmts() !dbg !3 {
 .entry:
   call void @__module___main___main0(), !dbg !6
   br label %return, !dbg !6
@@ -41,7 +41,7 @@ declare void @_lfortran_printf(i8*, ...)
 define i32 @main(i32 %0, i8** %1) !dbg !22 {
 .entry:
   call void @_lpython_set_argv(i32 %0, i8** %1), !dbg !25
-  call void @__module___main_____main____global_statements(), !dbg !25
+  call void @__module___main_____main__global_stmts(), !dbg !25
   ret i32 0, !dbg !25
 }
 
@@ -54,7 +54,7 @@ attributes #0 = { nounwind readnone speculatable willreturn }
 !0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "LPython Compiler", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
 !1 = !DIFile(filename: "tests/expr_01.py", directory: ".")
 !2 = !{}
-!3 = distinct !DISubprogram(name: "__main____global_statements", scope: !1, file: !1, line: 1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!3 = distinct !DISubprogram(name: "__main__global_stmts", scope: !1, file: !1, line: 1, type: !4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !4 = !DISubroutineType(types: !5)
 !5 = !{null}
 !6 = !DILocation(line: 9, column: 1, scope: !3)

--- a/tests/reference/pass_class_constructor-structs_16-5e3508f.json
+++ b/tests/reference/pass_class_constructor-structs_16-5e3508f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_class_constructor-structs_16-5e3508f.stdout",
-    "stdout_hash": "73dde106b7ff79b8752d44f573e93dda66af82b7bf92247a46e9609b",
+    "stdout_hash": "74b7cad17c2d6f7774e930e8a24b9bf35ca37425c7a3fa6f4851ef84",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_class_constructor-structs_16-5e3508f.stdout
+++ b/tests/reference/pass_class_constructor-structs_16-5e3508f.stdout
@@ -108,14 +108,14 @@
                                     ()
                                     ()
                                 ),
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         8
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -331,22 +331,22 @@
                     (SymbolTable
                         9
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     9
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        9 __main____global_statements
-                        2 __main____global_statements
+                        9 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/pass_inline_function_calls-func_inline_01-8b6a5da.json
+++ b/tests/reference/pass_inline_function_calls-func_inline_01-8b6a5da.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_inline_function_calls-func_inline_01-8b6a5da.stdout",
-    "stdout_hash": "c5045bbe93cc2a62e5d20f1fce265a818ef7c619d2fc9d3499e81331",
+    "stdout_hash": "7663857180d522294ed1b3012593172c8ffde3c3fa016f8c0f8185aa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_inline_function_calls-func_inline_01-8b6a5da.stdout
+++ b/tests/reference/pass_inline_function_calls-func_inline_01-8b6a5da.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         5
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -407,22 +407,22 @@
                     (SymbolTable
                         6
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     6
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        6 __main____global_statements
-                        2 __main____global_statements
+                        6 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/pass_loop_vectorise-vec_01-be9985e.json
+++ b/tests/reference/pass_loop_vectorise-vec_01-be9985e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_loop_vectorise-vec_01-be9985e.stdout",
-    "stdout_hash": "a80e2262c97da3cb451e3b7d89e900ccd67bdfeb1a38c4f6ce0998c5",
+    "stdout_hash": "1450eb1e82f1e03ee2c1ab8cf46b7cc5fb4a44df5af0d598b3779df3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_loop_vectorise-vec_01-be9985e.stdout
+++ b/tests/reference/pass_loop_vectorise-vec_01-be9985e.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         204
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -472,22 +472,22 @@
                     (SymbolTable
                         205
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     205
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        205 __main____global_statements
-                        2 __main____global_statements
+                        205 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/pass_print_list_tuple-print_02-09600eb.json
+++ b/tests/reference/pass_print_list_tuple-print_02-09600eb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_print_list_tuple-print_02-09600eb.stdout",
-    "stdout_hash": "cc65ae9e783fb40e87538cbfa27b303f711d8194260b56d2bf7fc300",
+    "stdout_hash": "92cf61833ce7c5944c99f073590128d6199de5ae303f96c4a384ee19",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_print_list_tuple-print_02-09600eb.stdout
+++ b/tests/reference/pass_print_list_tuple-print_02-09600eb.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         8
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -8736,22 +8736,22 @@
                     (SymbolTable
                         9
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     9
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        9 __main____global_statements
-                        2 __main____global_statements
+                        9 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/pass_print_list_tuple-print_list_tuple_03-195fa9c.json
+++ b/tests/reference/pass_print_list_tuple-print_list_tuple_03-195fa9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_print_list_tuple-print_list_tuple_03-195fa9c.stdout",
-    "stdout_hash": "6b4d20ca689b187e0aa7277045a814d68ccee872510bb3d81b81b9c8",
+    "stdout_hash": "2dbf3429f4e3c9e37321ed5251aebc13df479e2001fb95f16f37ed2f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_print_list_tuple-print_list_tuple_03-195fa9c.stdout
+++ b/tests/reference/pass_print_list_tuple-print_list_tuple_03-195fa9c.stdout
@@ -7,14 +7,14 @@
                     (SymbolTable
                         2
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (Function
                                     (SymbolTable
                                         4
                                         {
                                             
                                         })
-                                    __main____global_statements
+                                    __main__global_stmts
                                     (FunctionType
                                         []
                                         ()
@@ -497,22 +497,22 @@
                     (SymbolTable
                         5
                         {
-                            __main____global_statements:
+                            __main__global_stmts:
                                 (ExternalSymbol
                                     5
-                                    __main____global_statements
-                                    2 __main____global_statements
+                                    __main__global_stmts
+                                    2 __main__global_stmts
                                     __main__
                                     []
-                                    __main____global_statements
+                                    __main__global_stmts
                                     Public
                                 )
                         })
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        5 __main____global_statements
-                        2 __main____global_statements
+                        5 __main__global_stmts
+                        2 __main__global_stmts
                         []
                         ()
                     )]

--- a/tests/reference/wat-bool1-234bcd1.json
+++ b/tests/reference/wat-bool1-234bcd1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-bool1-234bcd1.stdout",
-    "stdout_hash": "d28fb463525cbccae5ca855c226dd654450c73ecdeab1c885a5750aa",
+    "stdout_hash": "2ad7e7fd37dbdc380ed1fb9e4879efed1cf87dc9472196189215487b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-bool1-234bcd1.stdout
+++ b/tests/reference/wat-bool1-234bcd1.stdout
@@ -177,7 +177,7 @@
     )
     (memory (;0;) 100 100)
     (export "memory" (memory 0))
-    (export "__main____global_statements" (func 2))
+    (export "__main__global_stmts" (func 2))
     (export "test_bool" (func 3))
     (export "_start" (func 4))
     (export "print_i64" (func 5))

--- a/tests/reference/wat-expr9-f73afd1.json
+++ b/tests/reference/wat-expr9-f73afd1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-expr9-f73afd1.stdout",
-    "stdout_hash": "86dc499106d377e163868991460dcd42f91dac8b5eb68f17d0bb76fb",
+    "stdout_hash": "24c9e7908c6c26b7b02f35db04295334fd8a45c90aa411146cf1cb16",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-expr9-f73afd1.stdout
+++ b/tests/reference/wat-expr9-f73afd1.stdout
@@ -68,7 +68,7 @@
     )
     (memory (;0;) 100 100)
     (export "memory" (memory 0))
-    (export "__main____global_statements" (func 2))
+    (export "__main__global_stmts" (func 2))
     (export "main0" (func 3))
     (export "test_return_1" (func 4))
     (export "test_return_2" (func 5))

--- a/tests/reference/wat-loop1-e0046d4.json
+++ b/tests/reference/wat-loop1-e0046d4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-loop1-e0046d4.stdout",
-    "stdout_hash": "5ef67cb70d3d56bae0e17b585065e93e7470d910090e0329f66e720e",
+    "stdout_hash": "b8c4cf026606e374e199425dede3419e41b30f935b6a1c71add8f508",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-loop1-e0046d4.stdout
+++ b/tests/reference/wat-loop1-e0046d4.stdout
@@ -154,7 +154,7 @@
     )
     (memory (;0;) 100 100)
     (export "memory" (memory 0))
-    (export "__main____global_statements" (func 2))
+    (export "__main__global_stmts" (func 2))
     (export "main0" (func 3))
     (export "test_factorial_1" (func 4))
     (export "test_factorial_2" (func 5))

--- a/tests/reference/wat-print_str-385e953.json
+++ b/tests/reference/wat-print_str-385e953.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "wat-print_str-385e953.stdout",
-    "stdout_hash": "9420bd5984e72b38128a512ef601ef2b43d55c8afc9fc0a213a67d6f",
+    "stdout_hash": "85817d1daa2da68a42d98f7742e17d562c67019cd40562d4aabb9ece",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/wat-print_str-385e953.stdout
+++ b/tests/reference/wat-print_str-385e953.stdout
@@ -109,7 +109,7 @@
     )
     (memory (;0;) 100 100)
     (export "memory" (memory 0))
-    (export "__main____global_statements" (func 2))
+    (export "__main__global_stmts" (func 2))
     (export "main0" (func 3))
     (export "printCompOperations" (func 4))
     (export "_start" (func 5))


### PR DESCRIPTION
The existing names seem very long. They surpass the node width in the ASR Visualization.

Main Branch:
<img width="518" alt="Screenshot 2023-08-02 at 6 20 15 PM" src="https://github.com/lcompilers/lpython/assets/43722035/69ae2962-857b-4fb0-ac6a-c8400c2555cf">

PR Branch:
<img width="518" alt="Screenshot 2023-08-02 at 6 22 42 PM" src="https://github.com/lcompilers/lpython/assets/43722035/13d45cff-edc4-4722-b664-6026265642c8">

