### PR TITLE
Corrections to `dict` write and pop

### DIFF
--- a/integration_tests/test_dict_14.py
+++ b/integration_tests/test_dict_14.py
@@ -1,0 +1,65 @@
+from lpython import i32
+
+def test_dict():
+    d_i32: dict[i32, i32] = {5: 1, 5: 2}
+    d_str: dict[str, i32] = {'a': 1, 'a': 2}
+    l_str_1: list[str] = []
+    l_str_2: list[str] = []
+    l_i32_1: list[i32] = []
+    l_i32_2: list[i32] = []
+    i: i32
+    s: str
+
+    assert len(d_i32) == 1
+    d_i32.pop(5)
+    assert len(d_i32) == 0
+
+    assert len(d_str) == 1
+    d_str.pop('a')
+    assert len(d_str) == 0
+
+    d_str = {'a': 2, 'a': 2, 'b': 2, 'c': 3, 'a': 5}
+    assert len(d_str) == 3
+    d_str.pop('a')
+    assert len(d_str) == 2
+    d_str.pop('b')
+    assert len(d_str) == 1
+
+    d_str['a'] = 20
+    assert len(d_str) == 2
+    d_str.pop('c')
+    assert len(d_str) == 1
+
+    l_str_1 = d_str.keys()
+    for s in l_str_1:
+        l_str_2.append(s)
+    assert l_str_2 == ['a']
+    l_i32_1 = d_str.values()
+    for i in l_i32_1:
+        l_i32_2.append(i)
+    assert l_i32_2 == [20]
+
+    d_i32 = {5: 2, 5: 2, 6: 2, 7: 3, 5: 5}
+    assert len(d_i32) == 3
+    d_i32.pop(5)
+    assert len(d_i32) == 2
+    d_i32.pop(6)
+    assert len(d_i32) == 1
+
+    d_i32[6] = 30
+    assert len(d_i32) == 2
+    d_i32.pop(7)
+    assert len(d_i32) == 1
+
+    l_i32_1 = d_i32.keys()
+    l_i32_2.clear()
+    for i in l_i32_1:
+        l_i32_2.append(i)
+    assert l_i32_2 == [6]
+    l_i32_1 = d_i32.values()
+    l_i32_2.clear()
+    for i in l_i32_1:
+        l_i32_2.append(i)
+    assert l_i32_2 == [30]
+
+test_dict()

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -588,7 +588,7 @@ namespace LCompilers {
             void write_item(llvm::Value* dict, llvm::Value* key,
                 llvm::Value* value, llvm::Module* module,
                 ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx) = 0;
+                std::map<std::string, std::map<std::string, int>>& name2memidx);
 
             virtual
             llvm::Value* read_item(llvm::Value* dict, llvm::Value* key,
@@ -692,11 +692,6 @@ namespace LCompilers {
                                               ASR::ttype_t* key_asr_type,
                                               ASR::ttype_t* value_asr_type,
                                               std::map<std::string, std::map<std::string, int>>& name2memidx);
-
-            void write_item(llvm::Value* dict, llvm::Value* key,
-                            llvm::Value* value, llvm::Module* module,
-                            ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type,
-                            std::map<std::string, std::map<std::string, int>>& name2memidx);
 
             llvm::Value* read_item(llvm::Value* dict, llvm::Value* key,
                                    llvm::Module& module, ASR::Dict_t* key_asr_type, bool enable_bounds_checking,
@@ -845,11 +840,6 @@ namespace LCompilers {
                 llvm::Module* module,
                 ASR::ttype_t* key_asr_type,
                 ASR::ttype_t* value_asr_type,
-                std::map<std::string, std::map<std::string, int>>& name2memidx);
-
-            void write_item(llvm::Value* dict, llvm::Value* key,
-                llvm::Value* value, llvm::Module* module,
-                ASR::ttype_t* key_asr_type, ASR::ttype_t* value_asr_type,
                 std::map<std::string, std::map<std::string, int>>& name2memidx);
 
             llvm::Value* read_item(llvm::Value* dict, llvm::Value* key,

--- a/tests/errors/test_dict15.py
+++ b/tests/errors/test_dict15.py
@@ -1,0 +1,8 @@
+from lpython import i32
+
+def test_dict_pop():
+    d: dict[i32, i32] = {1: 2}
+    d.pop(1)
+    d.pop(1)
+
+test_dict_pop()

--- a/tests/errors/test_dict16.py
+++ b/tests/errors/test_dict16.py
@@ -1,0 +1,8 @@
+from lpython import i32
+
+def test_dict_pop():
+    d: dict[str, i32] = {'a': 2}
+    d.pop('a')
+    d.pop('a')
+
+test_dict_pop()

--- a/tests/reference/runtime-test_dict15-6f3af0d.json
+++ b/tests/reference/runtime-test_dict15-6f3af0d.json
@@ -1,0 +1,13 @@
+{
+    "basename": "runtime-test_dict15-6f3af0d",
+    "cmd": "lpython {infile}",
+    "infile": "tests/errors/test_dict15.py",
+    "infile_hash": "6a0e507b9a9cf659cb433abbdc3435b4c63a6079eadcd7d2c765def1",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "runtime-test_dict15-6f3af0d.stderr",
+    "stderr_hash": "cb46ef04db0862506d688ebe8830a50afaaead9b0d29b0c007dd149a",
+    "returncode": 1
+}

--- a/tests/reference/runtime-test_dict15-6f3af0d.stderr
+++ b/tests/reference/runtime-test_dict15-6f3af0d.stderr
@@ -1,0 +1,1 @@
+KeyError: The dict does not contain the specified key

--- a/tests/reference/runtime-test_dict16-c5a958d.json
+++ b/tests/reference/runtime-test_dict16-c5a958d.json
@@ -1,0 +1,13 @@
+{
+    "basename": "runtime-test_dict16-c5a958d",
+    "cmd": "lpython {infile}",
+    "infile": "tests/errors/test_dict16.py",
+    "infile_hash": "7b00cfd7f6eac8338897bd99e5d953605f16927ee0f27683146b0182",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "runtime-test_dict16-c5a958d.stderr",
+    "stderr_hash": "cb46ef04db0862506d688ebe8830a50afaaead9b0d29b0c007dd149a",
+    "returncode": 1
+}

--- a/tests/reference/runtime-test_dict16-c5a958d.stderr
+++ b/tests/reference/runtime-test_dict16-c5a958d.stderr
@@ -1,0 +1,1 @@
+KeyError: The dict does not contain the specified key


### PR DESCRIPTION
Fixes #2230.
Corrects issues in `dict` insertions and deletions. Done for both linear-probing and separate-chaining.