### PR TITLE
Fix integration tests with Python 3.11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -444,3 +444,58 @@ jobs:
             cd integration_tests
             ./run_tests.py -b c_sym cpython_sym llvm_sym
             ./run_tests.py -b c_sym cpython_sym llvm_sym -f
+
+  python_3_11:
+    name: Run Integration tests with Python 3.11
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: lp
+          condarc: |
+            channels:
+              - conda-forge
+          create-args: >-
+            llvmdev=11.1.0
+            bison=3.4
+            re2c
+            zlib
+            cmake
+            make
+            python=3.11.4
+            numpy
+
+      - uses: hendrikmuhs/ccache-action@main
+        with:
+          key: ${{ github.job }}-${{ matrix.os }}
+
+      - name: Show Python version
+        shell: bash -e -l {0}
+        run: python --version
+
+      - name: Build
+        shell: bash -e -l {0}
+        run: |
+            ./build0.sh
+            cmake . -G"Unix Makefiles" \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DWITH_LLVM=yes \
+              -DLPYTHON_BUILD_ALL=yes \
+              -DWITH_STACKTRACE=no \
+              -DWITH_RUNTIME_STACKTRACE=no \
+              -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
+              -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+            cmake --build . -j16 --target install
+
+      - name: Test
+        shell: bash -e -l {0}
+        run: |
+            cd integration_tests
+            ./run_tests.py -b cpython

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -685,6 +685,7 @@ RUN(NAME structs_31          LABELS cpython llvm c)
 RUN(NAME structs_32          LABELS cpython llvm c)
 RUN(NAME structs_33          LABELS cpython llvm c)
 RUN(NAME structs_34          LABELS cpython llvm c)
+RUN(NAME structs_35          LABELS cpython llvm)
 
 RUN(NAME symbolics_01        LABELS cpython_sym c_sym llvm_sym NOFAST)
 RUN(NAME symbolics_02        LABELS cpython_sym c_sym llvm_sym NOFAST)

--- a/integration_tests/array_expr_03.py
+++ b/integration_tests/array_expr_03.py
@@ -1,11 +1,11 @@
-from lpython import i8, i32, dataclass
+from lpython import i8, i32, dataclass, field
 from numpy import empty, int8, array
 
 
 @dataclass
 class LPBHV_small:
     dim: i32 = 4
-    a: i8[4] = empty(4, dtype=int8)
+    a: i8[4] = field(default_factory=lambda: empty(4, dtype=int8))
 
 
 def g():

--- a/integration_tests/cast_01.py
+++ b/integration_tests/cast_01.py
@@ -1,10 +1,10 @@
-from lpython import i32, u8, u32, dataclass
+from lpython import i32, u8, u32, dataclass, field
 from numpy import empty, uint8
 
 @dataclass
 class LPBHV_small:
     dim : i32 = 4
-    a : u8[4] = empty(4, dtype=uint8)
+    a : u8[4] = field(default_factory=lambda: empty(4, dtype=uint8))
 
 def main0():
     lphv_small : LPBHV_small = LPBHV_small()

--- a/integration_tests/structs_04.py
+++ b/integration_tests/structs_04.py
@@ -1,4 +1,4 @@
-from lpython import i32, f32, f64, dataclass
+from lpython import i32, f32, f64, dataclass, field
 from copy import deepcopy
 
 @dataclass
@@ -9,7 +9,7 @@ class A:
 @dataclass
 class B:
     z: i32
-    a: A = A(f32(0.0), 0)
+    a: A = field(default_factory=lambda: A(f32(0.0), 0))
 
 def f(b: B):
     print(b.z, b.a.x, b.a.y)

--- a/integration_tests/structs_09.py
+++ b/integration_tests/structs_09.py
@@ -1,4 +1,4 @@
-from lpython import i32, f32, f64, dataclass
+from lpython import i32, f32, f64, dataclass, field
 
 @dataclass
 class C:
@@ -7,13 +7,13 @@ class C:
 @dataclass
 class B:
     z: i32
-    bc: C = C(f32(0.0))
+    bc: C = field(default_factory=lambda: C(f32(0.0)))
 
 @dataclass
 class A:
     y: f32
     x: i32
-    b: B = B(0, C(f32(0.0)))
+    b: B = field(default_factory=lambda: B(0, C(f32(0.0))))
 
 
 def f(a: A):

--- a/integration_tests/structs_10.py
+++ b/integration_tests/structs_10.py
@@ -1,18 +1,18 @@
-from lpython import i32, f64, dataclass
+from lpython import i32, f64, dataclass, field
 from numpy import empty, float64
 
 @dataclass
 class Mat:
-    mat: f64[2, 2] = empty((2, 2), dtype=float64)
+    mat: f64[2, 2] = field(default_factory=lambda: empty((2, 2), dtype=float64))
 
 @dataclass
 class Vec:
-    vec: f64[2] = empty(2, dtype=float64)
+    vec: f64[2] = field(default_factory=lambda: empty(2, dtype=float64))
 
 @dataclass
 class MatVec:
-    mat: Mat = Mat()
-    vec: Vec = Vec()
+    mat: Mat = field(default_factory=lambda: Mat())
+    vec: Vec = field(default_factory=lambda: Vec())
 
 def rotate(mat_vec: MatVec) -> f64[2]:
     rotated_vec: f64[2] = empty(2, dtype=float64)

--- a/integration_tests/structs_17.py
+++ b/integration_tests/structs_17.py
@@ -1,4 +1,4 @@
-from lpython import i32, f32, f64, dataclass
+from lpython import i32, f32, f64, dataclass, field
 
 @dataclass
 class B:
@@ -6,13 +6,13 @@ class B:
     @dataclass
     class C:
         cz: f32
-    bc: C = C(f32(0.0))
+    bc: C = field(default_factory=lambda: C(f32(0.0)))
 
 @dataclass
 class A:
     y: f32
     x: i32
-    b: B = B(0, B.C(f32(0.0)))
+    b: B = field(default_factory=lambda: B(0, B.C(f32(0.0))))
 
 
 def f(a: A):

--- a/integration_tests/structs_31.py
+++ b/integration_tests/structs_31.py
@@ -1,4 +1,4 @@
-from lpython import packed, dataclass, i32, InOut
+from lpython import packed, dataclass, field, i32, InOut
 
 @packed
 @dataclass
@@ -8,7 +8,7 @@ class inner_struct:
 @packed
 @dataclass
 class outer_struct:
-    b: inner_struct = inner_struct(0)
+    b: inner_struct = field(default_factory=lambda: inner_struct(0))
 
 def update_my_inner_struct(my_inner_struct: InOut[inner_struct]) -> None:
     my_inner_struct.a = 99999

--- a/integration_tests/structs_32.py
+++ b/integration_tests/structs_32.py
@@ -1,4 +1,4 @@
-from lpython import packed, dataclass, i32, InOut
+from lpython import packed, dataclass, field, i32, InOut
 
 
 @packed
@@ -10,7 +10,7 @@ class inner_struct:
 @packed
 @dataclass
 class outer_struct:
-    b: inner_struct = inner_struct(0)
+    b: inner_struct = field(default_factory=lambda: inner_struct(0))
 
 
 def update_my_inner_struct(my_inner_struct: InOut[inner_struct]) -> None:

--- a/integration_tests/structs_33.py
+++ b/integration_tests/structs_33.py
@@ -1,4 +1,4 @@
-from lpython import packed, dataclass, i32, ccallback, CPtr, ccall
+from lpython import packed, dataclass, field, i32
 
 # test issue 2125
 
@@ -11,7 +11,7 @@ class inner_struct:
 @packed
 @dataclass
 class outer_struct:
-    inner_s : inner_struct = inner_struct()
+    inner_s : inner_struct = field(default_factory=lambda: inner_struct())
 
 
 def check() -> None:

--- a/integration_tests/structs_35.py
+++ b/integration_tests/structs_35.py
@@ -1,0 +1,26 @@
+from lpython import dataclass, field, i32
+from numpy import array
+
+@dataclass
+class X:
+    a: i32 = 123
+    b: bool = True
+    c: list[i32] = field(default_factory=lambda: [1, 2, 3])
+    d: i32[3] = field(default_factory=lambda: array([4, 5, 6]))
+    e: i32 = field(default=-5)
+
+def main0():
+    x: X = X()
+    print(x)
+    assert x.a == 123
+    assert x.b == True
+    assert x.c[0] == 1
+    assert x.d[1] == 5
+    assert x.e == -5
+    x.c[0] = 3
+    x.d[0] = 3
+    print(x)
+    assert x.c[0] == 3
+    assert x.d[0] == 3
+
+main0()

--- a/src/runtime/lpython/lpython.py
+++ b/src/runtime/lpython/lpython.py
@@ -2,7 +2,7 @@ from inspect import getfullargspec, getcallargs, isclass, getsource
 import os
 import ctypes
 import platform
-from dataclasses import dataclass as py_dataclass, is_dataclass as py_is_dataclass
+from dataclasses import dataclass as py_dataclass, is_dataclass as py_is_dataclass, field
 import functools
 
 
@@ -11,7 +11,7 @@ __slots__ = ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64",
         "overload", "ccall", "TypeVar", "pointer", "c_p_pointer", "Pointer",
         "p_c_pointer", "vectorize", "inline", "Union", "static",
         "packed", "Const", "sizeof", "ccallable", "ccallback", "Callable",
-        "Allocatable", "In", "Out", "InOut", "dataclass", "S"]
+        "Allocatable", "In", "Out", "InOut", "dataclass", "field", "S"]
 
 # data-types
 

--- a/src/runtime/lpython/lpython.py
+++ b/src/runtime/lpython/lpython.py
@@ -717,9 +717,9 @@ class LpythonJITCache:
         python_path = "-I" + get_python_inc() + " "
         numpy_path = "-I" + get_include() + " "
         rt_path_01 = "-I" + get_rtlib_dir() + "/../libasr/runtime "
-        rt_path_02 = "-L" + get_rtlib_dir() + " -Wl,-rpath " \
+        rt_path_02 = "-L" + get_rtlib_dir() + " -Wl,-rpath," \
             + get_rtlib_dir() + " -llpython_runtime "
-        python_lib = "-L" + get_python_lib() + "/../.. -lpython" + \
+        python_lib = "-L" + get_python_lib() + "/../.." + f" -Wl,-rpath,{get_python_lib()+'/../..'}" + " -lpython" + \
             get_python_version() + " -lm"
 
         # ----------------------------------------------------------------------

--- a/tests/reference/asr-structs_04-387747b.json
+++ b/tests/reference/asr-structs_04-387747b.json
@@ -2,7 +2,7 @@
     "basename": "asr-structs_04-387747b",
     "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/structs_04.py",
-    "infile_hash": "c19af3c3fbac1430c22c5aaf69aea7c622faa9d7c4e7734edbd0066d",
+    "infile_hash": "1e20c2ac044ab88183c50ecb481ac7c50992ed622f8bb94772c6df25",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_04-387747b.stdout",


### PR DESCRIPTION
fixes https://github.com/lcompilers/lpython/issues/2267

Python 3.11 has a breaking change for `@dataclass`. With python `3.11`, the default values for `@dataclass` members need to be `immutable` (or `hashable`). More info: https://docs.python.org/3.11/whatsnew/3.11.html#dataclasses, https://github.com/huggingface/datasets/issues/5230

The PR also adds a CI check for integrations tests with python `3.11.3`, so that it does break in future.