### PR TITLE
Rename tensor to array

### DIFF
--- a/integration_tests/test_list_06.py
+++ b/integration_tests/test_list_06.py
@@ -15,8 +15,8 @@ def check_mat_and_vec(mat: list[list[f64]], vec: list[f64]):
         assert vec[i] == 2.0 * float(i)
 
 def test_list_of_lists():
-    tensors: list[list[list[list[f64]]]] = []
-    tensor: list[list[list[f64]]] = []
+    arrays: list[list[list[list[f64]]]] = []
+    array: list[list[list[f64]]] = []
     mat: list[list[f64]] = []
     vec: list[f64] = []
     rows: i32 = 10
@@ -38,7 +38,7 @@ def test_list_of_lists():
     check_mat_and_vec(mat, vec)
 
     for k in range(rows):
-        tensor.append(deepcopy(mat))
+        array.append(deepcopy(mat))
         for i in range(rows):
             for j in range(cols):
                 mat[i][j] += float(1)
@@ -46,19 +46,19 @@ def test_list_of_lists():
     for k in range(rows):
         for i in range(rows):
             for j in range(cols):
-                assert mat[i][j] - tensor[k][i][j] == f64(rows - k)
+                assert mat[i][j] - array[k][i][j] == f64(rows - k)
 
     for l in range(2 * rows):
-        tensors.append(deepcopy(tensor))
+        arrays.append(deepcopy(array))
         for i in range(rows):
             for j in range(rows):
                 for k in range(cols):
-                    tensor[i][j][k] += float(1)
+                    array[i][j][k] += float(1)
 
     for l in range(2 *  rows):
         for i in range(rows):
             for j in range(rows):
                 for k in range(cols):
-                    assert tensor[i][j][k] - tensors[l][i][j][k] == f64(2 * rows - l)
+                    assert array[i][j][k] - arrays[l][i][j][k] == f64(2 * rows - l)
 
 test_list_of_lists()

--- a/integration_tests/test_list_07.py
+++ b/integration_tests/test_list_07.py
@@ -1,17 +1,17 @@
 from lpython import c64, i32
 from copy import deepcopy
 
-def generate_complex_tensors(mat: list[list[c64]], vec: list[c64]) -> list[tuple[list[list[c64]], list[c64]]]:
-    tensor: tuple[list[list[c64]], list[c64]]
-    tensors: list[tuple[list[list[c64]], list[c64]]] = []
+def generate_complex_arrays(mat: list[list[c64]], vec: list[c64]) -> list[tuple[list[list[c64]], list[c64]]]:
+    array: tuple[list[list[c64]], list[c64]]
+    arrays: list[tuple[list[list[c64]], list[c64]]] = []
     rows: i32 = len(mat)
     cols: i32 = len(vec)
     i: i32; j: i32; k: i32
 
-    tensor = (deepcopy(mat), deepcopy(vec))
+    array = (deepcopy(mat), deepcopy(vec))
 
     for k in range(2 * rows):
-        tensors.append(deepcopy(tensor))
+        arrays.append(deepcopy(array))
         for i in range(rows):
             for j in range(cols):
                 mat[i][j] += complex(1.0, 2.0)
@@ -19,15 +19,15 @@ def generate_complex_tensors(mat: list[list[c64]], vec: list[c64]) -> list[tuple
         for i in range(cols):
             vec[i] += complex(1.0, 2.0)
 
-        tensor = (deepcopy(mat), deepcopy(vec))
+        array = (deepcopy(mat), deepcopy(vec))
 
-    return tensors
+    return arrays
 
 def test_tuple_with_lists():
     mat: list[list[c64]] = []
     vec: list[c64] = []
-    tensor: tuple[list[list[c64]], list[c64]]
-    tensors: list[tuple[list[list[c64]], list[c64]]] = []
+    array: tuple[list[list[c64]], list[c64]]
+    arrays: list[tuple[list[list[c64]], list[c64]]] = []
     i: i32
     j: i32
     k: i32
@@ -48,7 +48,7 @@ def test_tuple_with_lists():
         for j in range(cols):
             assert mat[i][j] - vec[j] == c64(i - j)
 
-    tensor = (deepcopy(mat), deepcopy(vec))
+    array = (deepcopy(mat), deepcopy(vec))
 
     for i in range(rows):
         for j in range(cols):
@@ -59,20 +59,20 @@ def test_tuple_with_lists():
 
     for i in range(rows):
         for j in range(cols):
-            assert tensor[0][i][j] - mat[i][j] == -complex(0, 3.0)
+            assert array[0][i][j] - mat[i][j] == -complex(0, 3.0)
 
     for i in range(cols):
-        assert tensor[1][i] - vec[i] == -complex(0, 2.0)
+        assert array[1][i] - vec[i] == -complex(0, 2.0)
 
-    tensors = generate_complex_tensors(mat, vec)
+    arrays = generate_complex_arrays(mat, vec)
 
     for k in range(2 * rows):
         for i in range(rows):
             for j in range(cols):
-                assert tensors[k][0][i][j] - mat[i][j] == -c64(2 * rows - k) * complex(1.0, 2.0)
+                assert arrays[k][0][i][j] - mat[i][j] == -c64(2 * rows - k) * complex(1.0, 2.0)
 
     for k in range(2 * rows):
         for i in range(cols):
-            assert tensors[k][1][i] - vec[i] == -c64(2 * rows - k) * complex(1.0, 2.0)
+            assert arrays[k][1][i] - vec[i] == -c64(2 * rows - k) * complex(1.0, 2.0)
 
 test_tuple_with_lists()


### PR DESCRIPTION
The entities in these examples are arrays or lists. We might implement proper tensors later now when we have symbolics in LPython, most likely by supporting SymPy Tensors:
https://docs.sympy.org/latest/modules/tensor/tensor.html.