### PR TITLE
[small] tidy up warnings

### DIFF
--- a/integration_tests/modules_02.py
+++ b/integration_tests/modules_02.py
@@ -1,4 +1,4 @@
-from modules_02b import f, f
+from modules_02b import f
 from lpython import i32
 
 def main0():

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1991,7 +1991,7 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
-        scanf("%lld", p);
+        scanf("%ld", p);
         return;
     }
 
@@ -2005,7 +2005,7 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
     if (unit_file_bin) {
         fread(p, sizeof(*p), 1, filep);
     } else {
-        fscanf(filep, "%lld", p);
+        fscanf(filep, "%ld", p);
     }
 }
 

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1965,7 +1965,7 @@ LFORTRAN_API void _lfortran_rewind(int32_t unit_num)
 }
 
 
-LFORTRAN_API void _lfortran_read_int32(int32_t *p, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_int32([[maybe_unused]] int32_t *p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -1987,7 +1987,7 @@ LFORTRAN_API void _lfortran_read_int32(int32_t *p, int32_t unit_num)
     }
 }
 
-LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_int64([[maybe_unused]] int64_t *p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2021,7 +2021,7 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
     }
 }
 
-LFORTRAN_API void _lfortran_read_array_int8(int8_t *p, int array_size, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_array_int8([[maybe_unused]] int8_t *p, int array_size, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2047,7 +2047,7 @@ LFORTRAN_API void _lfortran_read_array_int8(int8_t *p, int array_size, int32_t u
     }
 }
 
-LFORTRAN_API void _lfortran_read_array_int32(int32_t *p, int array_size, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_array_int32([[maybe_unused]] int32_t *p, int array_size, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2073,7 +2073,7 @@ LFORTRAN_API void _lfortran_read_array_int32(int32_t *p, int array_size, int32_t
     }
 }
 
-LFORTRAN_API void _lfortran_read_char(char **p, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_char([[maybe_unused]] char **p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2098,7 +2098,7 @@ LFORTRAN_API void _lfortran_read_char(char **p, int32_t unit_num)
     }
 }
 
-LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_float([[maybe_unused]] float *p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2120,7 +2120,7 @@ LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num)
     }
 }
 
-LFORTRAN_API void _lfortran_read_array_float(float *p, int array_size, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_array_float([[maybe_unused]] float *p, int array_size, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2146,7 +2146,7 @@ LFORTRAN_API void _lfortran_read_array_float(float *p, int array_size, int32_t u
     }
 }
 
-LFORTRAN_API void _lfortran_read_array_double(double *p, int array_size, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_array_double([[maybe_unused]] double *p, int array_size, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2172,7 +2172,7 @@ LFORTRAN_API void _lfortran_read_array_double(double *p, int array_size, int32_t
     }
 }
 
-LFORTRAN_API void _lfortran_read_array_char(char **p, int array_size, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_array_char([[maybe_unused]] char **p, int array_size, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2202,7 +2202,7 @@ LFORTRAN_API void _lfortran_read_array_char(char **p, int array_size, int32_t un
     }
 }
 
-LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_double([[maybe_unused]] double *p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1991,7 +1991,7 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
-        scanf("%ld", p);
+        scanf("%" PRId64, p);
         return;
     }
 
@@ -2005,7 +2005,7 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
     if (unit_file_bin) {
         fread(p, sizeof(*p), 1, filep);
     } else {
-        fscanf(filep, "%ld", p);
+        fscanf(filep, "%" PRId64, p);
     }
 }
 

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1991,7 +1991,13 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
-        scanf("%" PRId64, p);
+        scanf(
+#ifdef HAVE_LFORTRAN_MACHO
+            "line %lld\n"
+#else
+            "line %ld\n"
+#endif
+            , p);
         return;
     }
 
@@ -2005,7 +2011,13 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
     if (unit_file_bin) {
         fread(p, sizeof(*p), 1, filep);
     } else {
-        fscanf(filep, "%" PRId64, p);
+        fscanf(filep,
+#ifdef HAVE_LFORTRAN_MACHO
+            "line %lld\n"
+#else
+            "line %ld\n"
+#endif
+            , p);
     }
 }
 

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1993,9 +1993,9 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
         // Read from stdin
         scanf(
 #ifdef HAVE_LFORTRAN_MACHO
-            "line %lld\n"
+            "%lld\n"
 #else
-            "line %ld\n"
+            "%ld\n"
 #endif
             , p);
         return;
@@ -2013,9 +2013,9 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
     } else {
         fscanf(filep,
 #ifdef HAVE_LFORTRAN_MACHO
-            "line %lld\n"
+            "%lld\n"
 #else
-            "line %ld\n"
+            "%ld\n"
 #endif
             , p);
     }

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1965,7 +1965,7 @@ LFORTRAN_API void _lfortran_rewind(int32_t unit_num)
 }
 
 
-LFORTRAN_API void _lfortran_read_int32([[maybe_unused]] int32_t *p, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_int32(int32_t *p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -1987,7 +1987,7 @@ LFORTRAN_API void _lfortran_read_int32([[maybe_unused]] int32_t *p, int32_t unit
     }
 }
 
-LFORTRAN_API void _lfortran_read_int64([[maybe_unused]] int64_t *p, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2021,7 +2021,7 @@ LFORTRAN_API void _lfortran_read_int64([[maybe_unused]] int64_t *p, int32_t unit
     }
 }
 
-LFORTRAN_API void _lfortran_read_array_int8([[maybe_unused]] int8_t *p, int array_size, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_array_int8(int8_t *p, int array_size, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2047,7 +2047,7 @@ LFORTRAN_API void _lfortran_read_array_int8([[maybe_unused]] int8_t *p, int arra
     }
 }
 
-LFORTRAN_API void _lfortran_read_array_int32([[maybe_unused]] int32_t *p, int array_size, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_array_int32(int32_t *p, int array_size, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2073,7 +2073,7 @@ LFORTRAN_API void _lfortran_read_array_int32([[maybe_unused]] int32_t *p, int ar
     }
 }
 
-LFORTRAN_API void _lfortran_read_char([[maybe_unused]] char **p, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_char(char **p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2098,7 +2098,7 @@ LFORTRAN_API void _lfortran_read_char([[maybe_unused]] char **p, int32_t unit_nu
     }
 }
 
-LFORTRAN_API void _lfortran_read_float([[maybe_unused]] float *p, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_float(float *p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2120,7 +2120,7 @@ LFORTRAN_API void _lfortran_read_float([[maybe_unused]] float *p, int32_t unit_n
     }
 }
 
-LFORTRAN_API void _lfortran_read_array_float([[maybe_unused]] float *p, int array_size, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_array_float(float *p, int array_size, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2146,7 +2146,7 @@ LFORTRAN_API void _lfortran_read_array_float([[maybe_unused]] float *p, int arra
     }
 }
 
-LFORTRAN_API void _lfortran_read_array_double([[maybe_unused]] double *p, int array_size, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_array_double(double *p, int array_size, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2172,7 +2172,7 @@ LFORTRAN_API void _lfortran_read_array_double([[maybe_unused]] double *p, int ar
     }
 }
 
-LFORTRAN_API void _lfortran_read_array_char([[maybe_unused]] char **p, int array_size, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_array_char(char **p, int array_size, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin
@@ -2202,7 +2202,7 @@ LFORTRAN_API void _lfortran_read_array_char([[maybe_unused]] char **p, int array
     }
 }
 
-LFORTRAN_API void _lfortran_read_double([[maybe_unused]] double *p, int32_t unit_num)
+LFORTRAN_API void _lfortran_read_double(double *p, int32_t unit_num)
 {
     if (unit_num == -1) {
         // Read from stdin

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -1993,9 +1993,9 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
         // Read from stdin
         scanf(
 #ifdef HAVE_LFORTRAN_MACHO
-            "%lld\n"
+            "%lld"
 #else
-            "%ld\n"
+            "%ld"
 #endif
             , p);
         return;
@@ -2013,9 +2013,9 @@ LFORTRAN_API void _lfortran_read_int64(int64_t *p, int32_t unit_num)
     } else {
         fscanf(filep,
 #ifdef HAVE_LFORTRAN_MACHO
-            "%lld\n"
+            "%lld"
 #else
-            "%ld\n"
+            "%ld"
 #endif
             , p);
     }

--- a/tests/reference/asr-modules_02-ec92e6f.json
+++ b/tests/reference/asr-modules_02-ec92e6f.json
@@ -2,12 +2,12 @@
     "basename": "asr-modules_02-ec92e6f",
     "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/modules_02.py",
-    "infile_hash": "c3ce0b2b9780f27f787297f75e5477e990481b962dcee420809540e0",
+    "infile_hash": "dcb00ac27cbbcdec61d81f1df9e852ba81a2197e7804ec89cab76e44",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-modules_02-ec92e6f.stdout",
     "stdout_hash": "20ce6ad550f4e6b83356075795a39dafee13dc48bebf2eaf65d13edd",
-    "stderr": "asr-modules_02-ec92e6f.stderr",
-    "stderr_hash": "132af04271d3bfd523848990e734bfa3c0aed6e4b85ec4eb87e66720",
+    "stderr": null,
+    "stderr_hash": null,
     "returncode": 0
 }

--- a/tests/reference/asr_json-modules_02-53952e6.json
+++ b/tests/reference/asr_json-modules_02-53952e6.json
@@ -2,12 +2,12 @@
     "basename": "asr_json-modules_02-53952e6",
     "cmd": "lpython --show-asr --json --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/modules_02.py",
-    "infile_hash": "c3ce0b2b9780f27f787297f75e5477e990481b962dcee420809540e0",
+    "infile_hash": "dcb00ac27cbbcdec61d81f1df9e852ba81a2197e7804ec89cab76e44",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_json-modules_02-53952e6.stdout",
-    "stdout_hash": "a859b5986d89d954341c31440f12d9111194940e7725b7425c3ce22c",
-    "stderr": "asr_json-modules_02-53952e6.stderr",
-    "stderr_hash": "132af04271d3bfd523848990e734bfa3c0aed6e4b85ec4eb87e66720",
+    "stdout_hash": "516ac96572cd1828a6716655438d49ccef8fe35c4158a7664431c797",
+    "stderr": null,
+    "stderr_hash": null,
     "returncode": 0
 }

--- a/tests/reference/asr_json-modules_02-53952e6.json
+++ b/tests/reference/asr_json-modules_02-53952e6.json
@@ -6,8 +6,8 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr_json-modules_02-53952e6.stdout",
-    "stdout_hash": "c6ddff7faf420128366955f59e91126e3edb9c0367caed8c333562ec",
-    "stderr": "asr_json-modules_02-53952e6.stderr",
-    "stderr_hash": "132af04271d3bfd523848990e734bfa3c0aed6e4b85ec4eb87e66720",
+    "stdout_hash": "c97d528fedb41f6d0e8bfa0cee1c0c9333844130b7694cb0cd5e2c4c",
+    "stderr": null,
+    "stderr_hash": null,
     "returncode": 0
 }

--- a/tests/reference/asr_json-modules_02-53952e6.stdout
+++ b/tests/reference/asr_json-modules_02-53952e6.stdout
@@ -36,7 +36,7 @@
                                             },
                                             "loc": {
                                                 "first": 0,
-                                                "last": 128,
+                                                "last": 125,
                                                 "first_filename": "tests/../integration_tests/modules_02.py",
                                                 "first_line": 1,
                                                 "first_column": 1,
@@ -59,8 +59,8 @@
                                                     "dt": []
                                                 },
                                                 "loc": {
-                                                    "first": 122,
-                                                    "last": 128,
+                                                    "first": 119,
+                                                    "last": 125,
                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                     "first_line": 10,
                                                     "first_column": 1,
@@ -78,7 +78,7 @@
                                     },
                                     "loc": {
                                         "first": 0,
-                                        "last": 128,
+                                        "last": 125,
                                         "first_filename": "tests/../integration_tests/modules_02.py",
                                         "first_line": 1,
                                         "first_column": 1,
@@ -99,14 +99,14 @@
                                         "access": "Public"
                                     },
                                     "loc": {
-                                        "first": 27,
-                                        "last": 27,
+                                        "first": 24,
+                                        "last": 24,
                                         "first_filename": "tests/../integration_tests/modules_02.py",
                                         "first_line": 1,
-                                        "first_column": 28,
+                                        "first_column": 25,
                                         "last_filename": "tests/../integration_tests/modules_02.py",
                                         "last_line": 1,
-                                        "last_column": 28
+                                        "last_column": 25
                                     }
                                 },
                                 "main0": {
@@ -131,8 +131,8 @@
                                                                 "kind": 4
                                                             },
                                                             "loc": {
-                                                                "first": 74,
-                                                                "last": 76,
+                                                                "first": 71,
+                                                                "last": 73,
                                                                 "first_filename": "tests/../integration_tests/modules_02.py",
                                                                 "first_line": 5,
                                                                 "first_column": 8,
@@ -148,8 +148,8 @@
                                                         "value_attr": false
                                                     },
                                                     "loc": {
-                                                        "first": 71,
-                                                        "last": 76,
+                                                        "first": 68,
+                                                        "last": 73,
                                                         "first_filename": "tests/../integration_tests/modules_02.py",
                                                         "first_line": 5,
                                                         "first_column": 5,
@@ -178,8 +178,8 @@
                                                 "is_restriction": false
                                             },
                                             "loc": {
-                                                "first": 54,
-                                                "last": 119,
+                                                "first": 51,
+                                                "last": 116,
                                                 "first_filename": "tests/../integration_tests/modules_02.py",
                                                 "first_line": 4,
                                                 "first_column": 1,
@@ -202,8 +202,8 @@
                                                             "v": "x (SymbolTable7)"
                                                         },
                                                         "loc": {
-                                                            "first": 82,
-                                                            "last": 82,
+                                                            "first": 79,
+                                                            "last": 79,
                                                             "first_filename": "tests/../integration_tests/modules_02.py",
                                                             "first_line": 6,
                                                             "first_column": 5,
@@ -228,8 +228,8 @@
                                                                                     "kind": 4
                                                                                 },
                                                                                 "loc": {
-                                                                                    "first": 87,
-                                                                                    "last": 87,
+                                                                                    "first": 84,
+                                                                                    "last": 84,
                                                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                                                     "first_line": 6,
                                                                                     "first_column": 10,
@@ -240,8 +240,8 @@
                                                                             }
                                                                         },
                                                                         "loc": {
-                                                                            "first": 87,
-                                                                            "last": 87,
+                                                                            "first": 84,
+                                                                            "last": 84,
                                                                             "first_filename": "tests/../integration_tests/modules_02.py",
                                                                             "first_line": 6,
                                                                             "first_column": 10,
@@ -261,8 +261,8 @@
                                                                                     "kind": 4
                                                                                 },
                                                                                 "loc": {
-                                                                                    "first": 89,
-                                                                                    "last": 89,
+                                                                                    "first": 86,
+                                                                                    "last": 86,
                                                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                                                     "first_line": 6,
                                                                                     "first_column": 12,
@@ -273,8 +273,8 @@
                                                                             }
                                                                         },
                                                                         "loc": {
-                                                                            "first": 89,
-                                                                            "last": 89,
+                                                                            "first": 86,
+                                                                            "last": 86,
                                                                             "first_filename": "tests/../integration_tests/modules_02.py",
                                                                             "first_line": 6,
                                                                             "first_column": 12,
@@ -289,8 +289,8 @@
                                                                             "kind": 4
                                                                         },
                                                                         "loc": {
-                                                                            "first": 87,
-                                                                            "last": 87,
+                                                                            "first": 84,
+                                                                            "last": 84,
                                                                             "first_filename": "tests/../integration_tests/modules_02.py",
                                                                             "first_line": 6,
                                                                             "first_column": 10,
@@ -309,8 +309,8 @@
                                                                                     "kind": 4
                                                                                 },
                                                                                 "loc": {
-                                                                                    "first": 87,
-                                                                                    "last": 87,
+                                                                                    "first": 84,
+                                                                                    "last": 84,
                                                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                                                     "first_line": 6,
                                                                                     "first_column": 10,
@@ -321,8 +321,8 @@
                                                                             }
                                                                         },
                                                                         "loc": {
-                                                                            "first": 87,
-                                                                            "last": 89,
+                                                                            "first": 84,
+                                                                            "last": 86,
                                                                             "first_filename": "tests/../integration_tests/modules_02.py",
                                                                             "first_line": 6,
                                                                             "first_column": 10,
@@ -333,8 +333,8 @@
                                                                     }
                                                                 },
                                                                 "loc": {
-                                                                    "first": 87,
-                                                                    "last": 89,
+                                                                    "first": 84,
+                                                                    "last": 86,
                                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                                     "first_line": 6,
                                                                     "first_column": 10,
@@ -354,8 +354,8 @@
                                                                             "kind": 4
                                                                         },
                                                                         "loc": {
-                                                                            "first": 92,
-                                                                            "last": 92,
+                                                                            "first": 89,
+                                                                            "last": 89,
                                                                             "first_filename": "tests/../integration_tests/modules_02.py",
                                                                             "first_line": 6,
                                                                             "first_column": 15,
@@ -366,8 +366,8 @@
                                                                     }
                                                                 },
                                                                 "loc": {
-                                                                    "first": 92,
-                                                                    "last": 92,
+                                                                    "first": 89,
+                                                                    "last": 89,
                                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                                     "first_line": 6,
                                                                     "first_column": 15,
@@ -382,8 +382,8 @@
                                                                     "kind": 4
                                                                 },
                                                                 "loc": {
-                                                                    "first": 87,
-                                                                    "last": 87,
+                                                                    "first": 84,
+                                                                    "last": 84,
                                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                                     "first_line": 6,
                                                                     "first_column": 10,
@@ -402,8 +402,8 @@
                                                                             "kind": 4
                                                                         },
                                                                         "loc": {
-                                                                            "first": 87,
-                                                                            "last": 87,
+                                                                            "first": 84,
+                                                                            "last": 84,
                                                                             "first_filename": "tests/../integration_tests/modules_02.py",
                                                                             "first_line": 6,
                                                                             "first_column": 10,
@@ -414,8 +414,8 @@
                                                                     }
                                                                 },
                                                                 "loc": {
-                                                                    "first": 86,
-                                                                    "last": 92,
+                                                                    "first": 83,
+                                                                    "last": 89,
                                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                                     "first_line": 6,
                                                                     "first_column": 9,
@@ -426,8 +426,8 @@
                                                             }
                                                         },
                                                         "loc": {
-                                                            "first": 86,
-                                                            "last": 92,
+                                                            "first": 83,
+                                                            "last": 89,
                                                             "first_filename": "tests/../integration_tests/modules_02.py",
                                                             "first_line": 6,
                                                             "first_column": 9,
@@ -439,8 +439,8 @@
                                                     "overloaded": []
                                                 },
                                                 "loc": {
-                                                    "first": 82,
-                                                    "last": 92,
+                                                    "first": 79,
+                                                    "last": 89,
                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                     "first_line": 6,
                                                     "first_column": 5,
@@ -461,8 +461,8 @@
                                                                     "v": "x (SymbolTable7)"
                                                                 },
                                                                 "loc": {
-                                                                    "first": 105,
-                                                                    "last": 105,
+                                                                    "first": 102,
+                                                                    "last": 102,
                                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                                     "first_line": 7,
                                                                     "first_column": 12,
@@ -482,8 +482,8 @@
                                                                             "kind": 4
                                                                         },
                                                                         "loc": {
-                                                                            "first": 110,
-                                                                            "last": 111,
+                                                                            "first": 107,
+                                                                            "last": 108,
                                                                             "first_filename": "tests/../integration_tests/modules_02.py",
                                                                             "first_line": 7,
                                                                             "first_column": 17,
@@ -494,8 +494,8 @@
                                                                     }
                                                                 },
                                                                 "loc": {
-                                                                    "first": 110,
-                                                                    "last": 111,
+                                                                    "first": 107,
+                                                                    "last": 108,
                                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                                     "first_line": 7,
                                                                     "first_column": 17,
@@ -510,8 +510,8 @@
                                                                     "kind": 4
                                                                 },
                                                                 "loc": {
-                                                                    "first": 105,
-                                                                    "last": 111,
+                                                                    "first": 102,
+                                                                    "last": 108,
                                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                                     "first_line": 7,
                                                                     "first_column": 12,
@@ -523,8 +523,8 @@
                                                             "value": []
                                                         },
                                                         "loc": {
-                                                            "first": 105,
-                                                            "last": 111,
+                                                            "first": 102,
+                                                            "last": 108,
                                                             "first_filename": "tests/../integration_tests/modules_02.py",
                                                             "first_line": 7,
                                                             "first_column": 12,
@@ -536,8 +536,8 @@
                                                     "msg": []
                                                 },
                                                 "loc": {
-                                                    "first": 98,
-                                                    "last": 111,
+                                                    "first": 95,
+                                                    "last": 108,
                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                     "first_line": 7,
                                                     "first_column": 5,
@@ -555,8 +555,8 @@
                                                     "dt": []
                                                 },
                                                 "loc": {
-                                                    "first": 117,
-                                                    "last": 119,
+                                                    "first": 114,
+                                                    "last": 116,
                                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                                     "first_line": 8,
                                                     "first_column": 5,
@@ -573,8 +573,8 @@
                                         "module_file": []
                                     },
                                     "loc": {
-                                        "first": 54,
-                                        "last": 119,
+                                        "first": 51,
+                                        "last": 116,
                                         "first_filename": "tests/../integration_tests/modules_02.py",
                                         "first_line": 4,
                                         "first_column": 1,
@@ -594,7 +594,7 @@
                     },
                     "loc": {
                         "first": 0,
-                        "last": 128,
+                        "last": 125,
                         "first_filename": "tests/../integration_tests/modules_02.py",
                         "first_line": 1,
                         "first_column": 1,
@@ -622,7 +622,7 @@
                                     },
                                     "loc": {
                                         "first": 0,
-                                        "last": 128,
+                                        "last": 125,
                                         "first_filename": "tests/../integration_tests/modules_02.py",
                                         "first_line": 1,
                                         "first_column": 1,
@@ -648,7 +648,7 @@
                                 },
                                 "loc": {
                                     "first": 0,
-                                    "last": 128,
+                                    "last": 125,
                                     "first_filename": "tests/../integration_tests/modules_02.py",
                                     "first_line": 1,
                                     "first_column": 1,
@@ -661,7 +661,7 @@
                     },
                     "loc": {
                         "first": 0,
-                        "last": 128,
+                        "last": 125,
                         "first_filename": "tests/../integration_tests/modules_02.py",
                         "first_line": 1,
                         "first_column": 1,
@@ -701,8 +701,8 @@
                                                 "is_restriction": false
                                             },
                                             "loc": {
-                                                "first": 157,
-                                                "last": 189,
+                                                "first": 154,
+                                                "last": 186,
                                                 "first_filename": "tests/../integration_tests/modules_02b.py",
                                                 "first_line": 3,
                                                 "first_column": 1,
@@ -725,8 +725,8 @@
                                                     "dt": []
                                                 },
                                                 "loc": {
-                                                    "first": 170,
-                                                    "last": 172,
+                                                    "first": 167,
+                                                    "last": 169,
                                                     "first_filename": "tests/../integration_tests/modules_02b.py",
                                                     "first_line": 4,
                                                     "first_column": 5,
@@ -752,8 +752,8 @@
                                                                         "len_expr": []
                                                                     },
                                                                     "loc": {
-                                                                        "first": 184,
-                                                                        "last": 188,
+                                                                        "first": 181,
+                                                                        "last": 185,
                                                                         "first_filename": "tests/../integration_tests/modules_02b.py",
                                                                         "first_line": 5,
                                                                         "first_column": 11,
@@ -764,8 +764,8 @@
                                                                 }
                                                             },
                                                             "loc": {
-                                                                "first": 184,
-                                                                "last": 188,
+                                                                "first": 181,
+                                                                "last": 185,
                                                                 "first_filename": "tests/../integration_tests/modules_02b.py",
                                                                 "first_line": 5,
                                                                 "first_column": 11,
@@ -779,8 +779,8 @@
                                                     "end": []
                                                 },
                                                 "loc": {
-                                                    "first": 178,
-                                                    "last": 189,
+                                                    "first": 175,
+                                                    "last": 186,
                                                     "first_filename": "tests/../integration_tests/modules_02b.py",
                                                     "first_line": 5,
                                                     "first_column": 5,
@@ -797,8 +797,8 @@
                                         "module_file": []
                                     },
                                     "loc": {
-                                        "first": 157,
-                                        "last": 189,
+                                        "first": 154,
+                                        "last": 186,
                                         "first_filename": "tests/../integration_tests/modules_02b.py",
                                         "first_line": 3,
                                         "first_column": 1,
@@ -819,8 +819,8 @@
                                         "access": "Public"
                                     },
                                     "loc": {
-                                        "first": 154,
-                                        "last": 154,
+                                        "first": 151,
+                                        "last": 151,
                                         "first_filename": "tests/../integration_tests/modules_02b.py",
                                         "first_line": 1,
                                         "first_column": 25,
@@ -839,8 +839,8 @@
                         "intrinsic": false
                     },
                     "loc": {
-                        "first": 130,
-                        "last": 189,
+                        "first": 127,
+                        "last": 186,
                         "first_filename": "tests/../integration_tests/modules_02b.py",
                         "first_line": 1,
                         "first_column": 1,
@@ -880,8 +880,8 @@
                                                 "is_restriction": false
                                             },
                                             "loc": {
-                                                "first": 191,
-                                                "last": 215,
+                                                "first": 188,
+                                                "last": 212,
                                                 "first_filename": "tests/../integration_tests/modules_02c.py",
                                                 "first_line": 1,
                                                 "first_column": 1,
@@ -910,8 +910,8 @@
                                                                         "len_expr": []
                                                                     },
                                                                     "loc": {
-                                                                        "first": 210,
-                                                                        "last": 214,
+                                                                        "first": 207,
+                                                                        "last": 211,
                                                                         "first_filename": "tests/../integration_tests/modules_02c.py",
                                                                         "first_line": 2,
                                                                         "first_column": 11,
@@ -922,8 +922,8 @@
                                                                 }
                                                             },
                                                             "loc": {
-                                                                "first": 210,
-                                                                "last": 214,
+                                                                "first": 207,
+                                                                "last": 211,
                                                                 "first_filename": "tests/../integration_tests/modules_02c.py",
                                                                 "first_line": 2,
                                                                 "first_column": 11,
@@ -937,8 +937,8 @@
                                                     "end": []
                                                 },
                                                 "loc": {
-                                                    "first": 204,
-                                                    "last": 215,
+                                                    "first": 201,
+                                                    "last": 212,
                                                     "first_filename": "tests/../integration_tests/modules_02c.py",
                                                     "first_line": 2,
                                                     "first_column": 5,
@@ -955,8 +955,8 @@
                                         "module_file": []
                                     },
                                     "loc": {
-                                        "first": 191,
-                                        "last": 215,
+                                        "first": 188,
+                                        "last": 212,
                                         "first_filename": "tests/../integration_tests/modules_02c.py",
                                         "first_line": 1,
                                         "first_column": 1,
@@ -973,8 +973,8 @@
                         "intrinsic": false
                     },
                     "loc": {
-                        "first": 191,
-                        "last": 215,
+                        "first": 188,
+                        "last": 212,
                         "first_filename": "tests/../integration_tests/modules_02c.py",
                         "first_line": 1,
                         "first_column": 1,
@@ -989,7 +989,7 @@
     },
     "loc": {
         "first": 0,
-        "last": 128,
+        "last": 125,
         "first_filename": "tests/../integration_tests/modules_02.py",
         "first_line": 1,
         "first_column": 1,


### PR DESCRIPTION
Hi, the PR removes warnings during build time and tests. Please see:
```cpp
/home/khushi/Documents/lpython/src/libasr/runtime/lfortran_intrinsics.c: In function ‘_lfortran_read_int64’:
/home/khushi/Documents/lpython/src/libasr/runtime/lfortran_intrinsics.c: In function ‘_lfortran_read_int64’:
/home/khushi/Documents/lpython/src/libasr/runtime/lfortran_intrinsics.c:1994:19: warning: format ‘%lld’ expects argument of type ‘long long int *’, but argument 2 has type ‘int64_t *’ {aka ‘long int *’} [-Wformat=]
 1994 |         scanf("%lld", p);
      |                ~~~^   ~
      |                   |   |
      |                   |   int64_t * {aka long int *}
      |                   long long int *
      |                %ld
/home/khushi/Documents/lpython/src/libasr/runtime/lfortran_intrinsics.c:1994:19: warning: format ‘%lld’ expects argument of type ‘long long int *’, but argument 2 has type ‘int64_t *’ {aka ‘long int *’} [-Wformat=]
 1994 |         scanf("%lld", p);
      |                ~~~^   ~
      |                   |   |
      |                   |   int64_t * {aka long int *}
      |                   long long int *
      |                %ld
/home/khushi/Documents/lpython/src/libasr/runtime/lfortran_intrinsics.c:2008:27: warning: format ‘%lld’ expects argument of type ‘long long int *’, but argument 3 has type ‘int64_t *’ {aka ‘long int *’} [-Wformat=]
 2008 |         fscanf(filep, "%lld", p);
      |                        ~~~^   ~
      |                           |   |
      |                           |   int64_t * {aka long int *}
      |                           long long int *
      |                        %ld
/home/khushi/Documents/lpython/src/libasr/runtime/lfortran_intrinsics.c:2008:27: warning: format ‘%lld’ expects argument of type ‘long long int *’, but argument 3 has type ‘int64_t *’ {aka ‘long int *’} [-Wformat=]
 2008 |         fscanf(filep, "%lld", p);
      |                        ~~~^   ~
      |                           |   |
      |                           |   int64_t * {aka long int *}
      |                           long long int *
      |                        %ld
```
and
```python
warning: The symbol 'f' imported from modules_02b will shadow the existing symbol 'f'
 --> /home/khushi/Documents/lpython/integration_tests/modules_02.py:1:25
  |
1 | from modules_02b import f, f
  |                         ^ old symbol
  |
1 | from modules_02b import f, f
  |                            ^ new symbol
```
cc @certik @czgdp1807 