### PR TITLE
C: Fix passing array elements as reference

### DIFF
--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -1072,6 +1072,14 @@ PyMODINIT_FUNC PyInit_lpython_module_)" + fn_name + R"((void) {
                 } else {
                     args += src;
                 }
+            } else if (ASR::is_a<ASR::ArrayItem_t>(*m_args[i].m_value)) {
+                ASR::Variable_t* param = ASRUtils::EXPR2VAR(f->m_args[i]);
+                if (param->m_intent == ASRUtils::intent_inout
+                    || param->m_intent == ASRUtils::intent_out || ASR::is_a<ASR::Struct_t>(*type)) {
+                    args += "&" + src;
+                } else {
+                    args += src;
+                }
             } else {
                 if( ASR::is_a<ASR::Struct_t>(*type) ) {
                     args += "&" + src;


### PR DESCRIPTION
This PR contains changes in the C Backend from https://github.com/lfortran/lfortran/pull/2460. If the CI passes here, it ensures that the changes work with both LFortran and LPython.