### PR TITLE
Added Support for Symbolic `func` attribute

### DIFF
--- a/integration_tests/symbolics_02.py
+++ b/integration_tests/symbolics_02.py
@@ -1,35 +1,51 @@
-from sympy import Symbol, pi
+from sympy import Symbol, pi, Add, Mul, Pow
 from lpython import S
 
 def test_symbolic_operations():
     x: S = Symbol('x')
     y: S = Symbol('y')
-    p1: S = pi
-    p2: S = pi
+    pi1: S = pi
+    pi2: S = pi
     
     # Addition
     z: S = x + y
+    z1: bool = z.func == Add
+    z2: bool = z.func == Mul
     assert(z == x + y)
+    assert(z1 == True)
+    assert(z2 == False)
     print(z)
     
     # Subtraction
     w: S = x - y
+    w1: bool = w.func == Add
     assert(w == x - y)
+    assert(w1 == True)
     print(w)
     
     # Multiplication
     u: S = x * y
+    u1: bool = u.func == Mul
     assert(u == x * y)
+    assert(u1 == True)
     print(u)
 
     # Division
     v: S = x / y
+    v1: bool = v.func == Mul
     assert(v == x / y)
+    assert(v1 == True)
     print(v)
 
     # Power
     p: S = x ** y
+    p1: bool = p.func == Pow
+    p2: bool = p.func == Add
+    p3: bool = p.func == Mul
     assert(p == x ** y)
+    assert(p1 == True)
+    assert(p2 == False)
+    assert(p3 == False)
     print(p)
 
     # Casting
@@ -40,13 +56,13 @@ def test_symbolic_operations():
     print(c)
 
     # Comparison
-    b1: bool = p1 == p2
+    b1: bool = pi1 == pi2
     print(b1)
     assert(b1 == True)
-    b2: bool = p1 != pi
+    b2: bool = pi1 != pi
     print(b2)
     assert(b2 == False)
-    b3: bool = p1 != x
+    b3: bool = pi1 != x
     print(b3)
     assert(b3 == True)
     b4: bool = pi == Symbol("x")

--- a/integration_tests/symbolics_02.py
+++ b/integration_tests/symbolics_02.py
@@ -14,6 +14,10 @@ def test_symbolic_operations():
     assert(z == x + y)
     assert(z1 == True)
     assert(z2 == False)
+    if z.func == Add:
+        assert True
+    else:
+        assert False
     print(z)
     
     # Subtraction
@@ -21,6 +25,10 @@ def test_symbolic_operations():
     w1: bool = w.func == Add
     assert(w == x - y)
     assert(w1 == True)
+    if w.func == Add:
+        assert True
+    else:
+        assert False
     print(w)
     
     # Multiplication
@@ -28,6 +36,10 @@ def test_symbolic_operations():
     u1: bool = u.func == Mul
     assert(u == x * y)
     assert(u1 == True)
+    if u.func == Mul:
+        assert True
+    else:
+        assert False
     print(u)
 
     # Division
@@ -35,6 +47,10 @@ def test_symbolic_operations():
     v1: bool = v.func == Mul
     assert(v == x / y)
     assert(v1 == True)
+    if v.func == Mul:
+        assert True
+    else:
+        assert False
     print(v)
 
     # Power
@@ -46,6 +62,10 @@ def test_symbolic_operations():
     assert(p1 == True)
     assert(p2 == False)
     assert(p3 == False)
+    if p.func == Pow:
+        assert True
+    else:
+        assert False
     print(p)
 
     # Casting

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -3472,9 +3472,9 @@ namespace IntrinsicScalarFunctionRegistry {
                 {"SymbolicExp", {&SymbolicExp::create_SymbolicExp, &SymbolicExp::eval_SymbolicExp}},
                 {"SymbolicAbs", {&SymbolicAbs::create_SymbolicAbs, &SymbolicAbs::eval_SymbolicAbs}},
                 {"has", {&SymbolicHasSymbolQ::create_SymbolicHasSymbolQ, &SymbolicHasSymbolQ::eval_SymbolicHasSymbolQ}},
-                {"is_Add", {&SymbolicAddQ::create_SymbolicAddQ, &SymbolicAddQ::eval_SymbolicAddQ}},
-                {"is_Mul", {&SymbolicMulQ::create_SymbolicMulQ, &SymbolicMulQ::eval_SymbolicMulQ}},
-                {"is_Pow", {&SymbolicPowQ::create_SymbolicPowQ, &SymbolicPowQ::eval_SymbolicPowQ}},
+                {"AddQ", {&SymbolicAddQ::create_SymbolicAddQ, &SymbolicAddQ::eval_SymbolicAddQ}},
+                {"MulQ", {&SymbolicMulQ::create_SymbolicMulQ, &SymbolicMulQ::eval_SymbolicMulQ}},
+                {"PowQ", {&SymbolicPowQ::create_SymbolicPowQ, &SymbolicPowQ::eval_SymbolicPowQ}},
     };
 
     static inline bool is_intrinsic_function(const std::string& name) {

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -77,6 +77,7 @@ enum class IntrinsicScalarFunctions : int64_t {
     SymbolicExp,
     SymbolicAbs,
     SymbolicHasSymbolQ,
+    SymbolicFuncQ,
     // ...
 };
 
@@ -137,6 +138,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(SymbolicExp)
         INTRINSIC_NAME_CASE(SymbolicAbs)
         INTRINSIC_NAME_CASE(SymbolicHasSymbolQ)
+        INTRINSIC_NAME_CASE(SymbolicFuncQ)
         default : {
             throw LCompilersException("pickle: intrinsic_id not implemented");
         }
@@ -2960,6 +2962,44 @@ namespace SymbolicHasSymbolQ {
     }
 } // namespace SymbolicHasSymbolQ
 
+namespace SymbolicFuncQ {
+    static inline void verify_args(const ASR::IntrinsicScalarFunction_t& x,
+        diag::Diagnostics& diagnostics) {
+        ASRUtils::require_impl(x.n_args == 1, "Intrinsic function SymbolicFuncQ"
+            "accepts exactly 1 argument", x.base.base.loc, diagnostics);
+
+        ASR::ttype_t* input_type = ASRUtils::expr_type(x.m_args[0]);
+        ASRUtils::require_impl(ASR::is_a<ASR::SymbolicExpression_t>(*input_type),
+            "SymbolicFuncQ expects an argument of type SymbolicExpression",
+            x.base.base.loc, diagnostics);
+    }
+
+    static inline ASR::expr_t* eval_SymbolicFuncQ(Allocator &/*al*/,
+        const Location &/*loc*/, ASR::ttype_t *, Vec<ASR::expr_t*> &/*args*/) {
+        /*TODO*/
+        return nullptr;
+    }
+
+    static inline ASR::asr_t* create_SymbolicFuncQ(Allocator& al,
+        const Location& loc, Vec<ASR::expr_t*>& args,
+        const std::function<void (const std::string &, const Location &)> err) {
+
+        if (args.size() != 1) {
+            err("Intrinsic function SymbolicFuncQ accepts exactly 1 argument", loc);
+        }
+
+        ASR::ttype_t* argtype = ASRUtils::expr_type(args[0]);
+        if (!ASR::is_a<ASR::SymbolicExpression_t>(*argtype)) {
+            err("Argument of SymbolicFuncQ function must be of type SymbolicExpression",
+                args[0]->base.loc);
+        }
+
+        return UnaryIntrinsicFunction::create_UnaryFunction(al, loc, args, eval_SymbolicFuncQ,
+            static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicFuncQ), 0, character(0));
+    }
+} // namespace SymbolicFuncQ
+
+
 #define create_symbolic_unary_macro(X)                                                    \
 namespace X {                                                                             \
     static inline void verify_args(const ASR::IntrinsicScalarFunction_t& x,               \
@@ -3111,6 +3151,8 @@ namespace IntrinsicScalarFunctionRegistry {
             {nullptr, &SymbolicAbs::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicHasSymbolQ),
             {nullptr, &SymbolicHasSymbolQ::verify_args}},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicFuncQ),
+            {nullptr, &SymbolicFuncQ::verify_args}},
     };
 
     static const std::map<int64_t, std::string>& intrinsic_function_id_to_name = {
@@ -3213,6 +3255,8 @@ namespace IntrinsicScalarFunctionRegistry {
             "SymbolicAbs"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicHasSymbolQ),
             "SymbolicHasSymbolQ"},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicFuncQ),
+            "SymbolicFuncQ"},
     };
 
 
@@ -3267,6 +3311,7 @@ namespace IntrinsicScalarFunctionRegistry {
                 {"SymbolicExp", {&SymbolicExp::create_SymbolicExp, &SymbolicExp::eval_SymbolicExp}},
                 {"SymbolicAbs", {&SymbolicAbs::create_SymbolicAbs, &SymbolicAbs::eval_SymbolicAbs}},
                 {"has", {&SymbolicHasSymbolQ::create_SymbolicHasSymbolQ, &SymbolicHasSymbolQ::eval_SymbolicHasSymbolQ}},
+                {"func", {&SymbolicFuncQ::create_SymbolicFuncQ, &SymbolicFuncQ::eval_SymbolicFuncQ}},
     };
 
     static inline bool is_intrinsic_function(const std::string& name) {

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -1091,6 +1091,20 @@ public:
         }
     }
 
+    void visit_If(const ASR::If_t& x) {
+        ASR::If_t& xx = const_cast<ASR::If_t&>(x);
+        transform_stmts(xx.m_body, xx.n_body);
+        transform_stmts(xx.m_orelse, xx.n_orelse);
+        SymbolTable* module_scope = current_scope->parent;
+        if (ASR::is_a<ASR::IntrinsicScalarFunction_t>(*xx.m_test)) {
+            ASR::IntrinsicScalarFunction_t* intrinsic_func = ASR::down_cast<ASR::IntrinsicScalarFunction_t>(xx.m_test);
+            if (intrinsic_func->m_type->type == ASR::ttypeType::Logical) {
+                ASR::expr_t* function_call = process_attributes(al, xx.base.base.loc, xx.m_test, module_scope);
+                xx.m_test = function_call;
+            }
+        }
+    }
+
     void visit_SubroutineCall(const ASR::SubroutineCall_t &x) {
         SymbolTable* module_scope = current_scope->parent;
         Vec<ASR::call_arg_t> call_args;

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -711,27 +711,32 @@ public:
         return module_scope->get_symbol(name);
     }
 
-    ASR::symbol_t* declare_basic_assign_function(Allocator& al, const Location& loc, SymbolTable* module_scope) {
-        std::string name = "basic_assign";
+    ASR::symbol_t* declare_basic_eq_function(Allocator& al, const Location& loc, SymbolTable* module_scope) {
+        std::string name = "basic_eq";
         symbolic_dependencies.push_back(name);
         if (!module_scope->get_symbol(name)) {
             std::string header = "symengine/cwrapper.h";
             SymbolTable* fn_symtab = al.make_new<SymbolTable>(module_scope);
 
             Vec<ASR::expr_t*> args;
-            args.reserve(al, 2);
+            args.reserve(al, 1);
             ASR::symbol_t* arg1 = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
+                al, loc, fn_symtab, s2c(al, "_lpython_return_variable"), nullptr, 0, ASR::intentType::ReturnVar,
+                nullptr, nullptr, ASR::storage_typeType::Default, ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)),
+                nullptr, ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required, false));
+            fn_symtab->add_symbol(s2c(al, "_lpython_return_variable"), arg1);
+            ASR::symbol_t* arg2 = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
                 al, loc, fn_symtab, s2c(al, "x"), nullptr, 0, ASR::intentType::In,
                 nullptr, nullptr, ASR::storage_typeType::Default, ASRUtils::TYPE(ASR::make_CPtr_t(al, loc)),
                 nullptr, ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required, true));
-            fn_symtab->add_symbol(s2c(al, "x"), arg1);
-            args.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, loc, arg1)));
-            ASR::symbol_t* arg2 = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
+            fn_symtab->add_symbol(s2c(al, "x"), arg2);
+            args.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, loc, arg2)));
+            ASR::symbol_t* arg3 = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
                 al, loc, fn_symtab, s2c(al, "y"), nullptr, 0, ASR::intentType::In,
                 nullptr, nullptr, ASR::storage_typeType::Default, ASRUtils::TYPE(ASR::make_CPtr_t(al, loc)),
                 nullptr, ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required, true));
-            fn_symtab->add_symbol(s2c(al, "y"), arg2);
-            args.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, loc, arg2)));
+            fn_symtab->add_symbol(s2c(al, "y"), arg3);
+            args.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, loc, arg3)));
 
             Vec<ASR::stmt_t*> body;
             body.reserve(al, 1);
@@ -739,9 +744,10 @@ public:
             Vec<char*> dep;
             dep.reserve(al, 1);
 
+            ASR::expr_t* return_var = ASRUtils::EXPR(ASR::make_Var_t(al, loc, fn_symtab->get_symbol("_lpython_return_variable")));
             ASR::asr_t* subrout = ASRUtils::make_Function_t_util(al, loc,
                 fn_symtab, s2c(al, name), dep.p, dep.n, args.p, args.n, body.p, body.n,
-                nullptr, ASR::abiType::BindC, ASR::accessType::Public,
+                return_var, ASR::abiType::BindC, ASR::accessType::Public,
                 ASR::deftypeType::Interface, s2c(al, name), false, false, false,
                 false, false, nullptr, 0, false, false, false, s2c(al, header));
             ASR::symbol_t* symbol = ASR::down_cast<ASR::symbol_t>(subrout);

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -665,6 +665,45 @@ public:
         return module_scope->get_symbol(name);
     }
 
+    ASR::symbol_t* declare_basic_get_class_from_id_function(Allocator& al, const Location& loc, SymbolTable* module_scope) {
+        std::string name = "basic_get_class_from_id";
+        symbolic_dependencies.push_back(name);
+        if (!module_scope->get_symbol(name)) {
+            std::string header = "symengine/cwrapper.h";
+            SymbolTable* fn_symtab = al.make_new<SymbolTable>(module_scope);
+
+            Vec<ASR::expr_t*> args;
+            args.reserve(al, 1);
+            ASR::symbol_t* arg1 = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
+                al, loc, fn_symtab, s2c(al, "_lpython_return_variable"), nullptr, 0, ASR::intentType::ReturnVar,
+                nullptr, nullptr, ASR::storage_typeType::Default, ASRUtils::TYPE(ASR::make_Character_t(al, loc, 1, -2, nullptr)),
+                nullptr, ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required, false));
+            fn_symtab->add_symbol(s2c(al, "_lpython_return_variable"), arg1);
+            ASR::symbol_t* arg2 = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
+                al, loc, fn_symtab, s2c(al, "x"), nullptr, 0, ASR::intentType::In,
+                nullptr, nullptr, ASR::storage_typeType::Default, ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)),
+                nullptr, ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required, true));
+            fn_symtab->add_symbol(s2c(al, "x"), arg2);
+            args.push_back(al, ASRUtils::EXPR(ASR::make_Var_t(al, loc, arg2)));
+
+            Vec<ASR::stmt_t*> body;
+            body.reserve(al, 1);
+
+            Vec<char*> dep;
+            dep.reserve(al, 1);
+
+            ASR::expr_t* return_var = ASRUtils::EXPR(ASR::make_Var_t(al, loc, fn_symtab->get_symbol("_lpython_return_variable")));
+            ASR::asr_t* subrout = ASRUtils::make_Function_t_util(al, loc,
+                fn_symtab, s2c(al, name), dep.p, dep.n, args.p, args.n, body.p, body.n,
+                return_var, ASR::abiType::BindC, ASR::accessType::Public,
+                ASR::deftypeType::Interface, s2c(al, name), false, false, false,
+                false, false, nullptr, 0, false, false, false, s2c(al, header));
+            ASR::symbol_t* symbol = ASR::down_cast<ASR::symbol_t>(subrout);
+            module_scope->add_symbol(s2c(al, name), symbol);
+        }
+        return module_scope->get_symbol(name);
+    }
+
     ASR::expr_t* process_attributes(Allocator &al, const Location &loc, ASR::expr_t* expr,
         SymbolTable* module_scope) {
         if (ASR::is_a<ASR::IntrinsicScalarFunction_t>(*expr)) {
@@ -732,94 +771,26 @@ public:
                     break;
                 }
                 case LCompilers::ASRUtils::IntrinsicScalarFunctions::SymbolicFuncQ: {
+                    ASR::symbol_t* basic_get_class_from_id_sym = declare_basic_get_class_from_id_function(al, loc, module_scope);
                     ASR::symbol_t* basic_get_type_sym = declare_basic_get_type_function(al, loc, module_scope);
                     ASR::expr_t* value1 = handle_argument(al, loc, intrinsic_func->m_args[0]);
-                    Vec<ASR::call_arg_t> call_args;
-                    call_args.reserve(al, 1);
-                    ASR::call_arg_t call_arg;
-                    call_arg.loc = loc;
-                    call_arg.m_value = value1;
-                    call_args.push_back(al, call_arg);
-                    ASR::expr_t* function_call = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
-                        basic_get_type_sym, basic_get_type_sym, call_args.p, call_args.n,
+                    Vec<ASR::call_arg_t> call_args1, call_args2;
+                    call_args1.reserve(al, 1);
+                    call_args2.reserve(al, 1);
+                    ASR::call_arg_t call_arg1, call_arg2;
+                    call_arg1.loc = loc;
+                    call_arg1.m_value = value1;
+                    call_args1.push_back(al, call_arg1);
+                    ASR::expr_t* function_call1 = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
+                        basic_get_type_sym, basic_get_type_sym, call_args1.p, call_args1.n,
                         ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)), nullptr, nullptr));
 
-                    // Declare a temporary integer variable
-                    ASR::ttype_t *int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4));
-                    ASR::symbol_t* int_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al, loc, current_scope,
-                                        s2c(al, "temp_integer"), nullptr, 0,
-                                        ASR::intentType::Local, nullptr,
-                                        nullptr, ASR::storage_typeType::Default, int_type, nullptr,
-                                        ASR::abiType::Source, ASR::Public, ASR::presenceType::Required, false));
-
-                    if (!current_scope->get_symbol(s2c(al, "temp_integer"))) {
-                        current_scope->add_symbol(s2c(al, "temp_integer"), int_sym);
-                    }
-                    ASR::symbol_t* temp_int_sym = current_scope->get_symbol("temp_integer");
-                    ASR::expr_t* target_int = ASRUtils::EXPR(ASR::make_Var_t(al, loc, temp_int_sym));
-                    ASR::stmt_t* stmt1 = ASRUtils::STMT(ASR::make_Assignment_t(al, loc, target_int, function_call, nullptr));
-                    pass_result.push_back(al, stmt1);
-
-                    // Declare a temporary string variable
-                    ASR::ttype_t* char_type = ASRUtils::TYPE(ASR::make_Character_t(al, loc, 1, -2, nullptr));
-                    ASR::symbol_t* str_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(al, loc, current_scope,
-                                        s2c(al, "temp_string"), nullptr, 0,
-                                        ASR::intentType::Local, nullptr,
-                                        nullptr, ASR::storage_typeType::Default, char_type, nullptr,
-                                        ASR::abiType::Source, ASR::Public, ASR::presenceType::Required, false));
-
-                    if (!current_scope->get_symbol(s2c(al, "temp_string"))) {
-                        current_scope->add_symbol(s2c(al, "temp_string"), str_sym);
-                    }
-                    ASR::symbol_t* temp_str_sym = current_scope->get_symbol("temp_string");
-                    ASR::expr_t* target_str = ASRUtils::EXPR(ASR::make_Var_t(al, loc, temp_str_sym));
-                    ASR::stmt_t* stmt2 = ASRUtils::STMT(ASR::make_Assignment_t(al, loc, target_str,
-                        ASRUtils::EXPR(ASR::make_StringConstant_t(al, loc, s2c(al, ""),
-                        ASRUtils::TYPE(ASR::make_Character_t(al, loc, 1, 0, nullptr)))), nullptr));
-                    pass_result.push_back(al, stmt2);
-
-                    // If statement 1
-                    // Using 17 as the right value of the IntegerCompare node as it represents SYMENGINE_POW through SYMENGINE_ENUM
-                    ASR::expr_t* int_cmp_with_17 = ASRUtils::EXPR(ASR::make_IntegerCompare_t(al, loc, target_int, ASR::cmpopType::Eq,
-                        ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 17, ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)))),
-                        ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)), nullptr));
-                    ASR::ttype_t *str_type_len_3 = ASRUtils::TYPE(ASR::make_Character_t(
-                        al, loc, 1, 3, nullptr));
-                    Vec<ASR::stmt_t*> if_body1;
-                    if_body1.reserve(al, 1);
-                    ASR::stmt_t* stmt3 = ASRUtils::STMT(ASR::make_Assignment_t(al, loc, target_str,
-                        ASRUtils::EXPR(ASR::make_StringConstant_t(al, loc, s2c(al, "Pow"), str_type_len_3)), nullptr));
-                    if_body1.push_back(al, stmt3);
-                    ASR::stmt_t* stmt4 = ASRUtils::STMT(ASR::make_If_t(al, loc, int_cmp_with_17, if_body1.p, if_body1.n, nullptr, 0));
-                    pass_result.push_back(al, stmt4);
-
-                    // If statement 2
-                    // Using 15 as the right value of the IntegerCompare node as it represents SYMENGINE_MUL through SYMENGINE_ENUM
-                    ASR::expr_t* int_cmp_with_15 = ASRUtils::EXPR(ASR::make_IntegerCompare_t(al, loc, target_int, ASR::cmpopType::Eq,
-                        ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 15, ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)))),
-                        ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)), nullptr));
-                    Vec<ASR::stmt_t*> if_body2;
-                    if_body2.reserve(al, 1);
-                    ASR::stmt_t* stmt5 = ASRUtils::STMT(ASR::make_Assignment_t(al, loc, target_str,
-                        ASRUtils::EXPR(ASR::make_StringConstant_t(al, loc, s2c(al, "MUL"), str_type_len_3)), nullptr));
-                    if_body2.push_back(al, stmt5);
-                    ASR::stmt_t* stmt6 = ASRUtils::STMT(ASR::make_If_t(al, loc, int_cmp_with_15, if_body2.p, if_body2.n, nullptr, 0));
-                    pass_result.push_back(al, stmt6);
-
-                    // If statement 3
-                    // Using 16 as the right value of the IntegerCompare node as it represents SYMENGINE_ADD through SYMENGINE_ENUM
-                    ASR::expr_t* int_cmp_with_16 = ASRUtils::EXPR(ASR::make_IntegerCompare_t(al, loc, target_int, ASR::cmpopType::Eq,
-                        ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 16, ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)))),
-                        ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)), nullptr));
-                    Vec<ASR::stmt_t*> if_body3;
-                    if_body3.reserve(al, 1);
-                    ASR::stmt_t* stmt7 = ASRUtils::STMT(ASR::make_Assignment_t(al, loc, target_str,
-                        ASRUtils::EXPR(ASR::make_StringConstant_t(al, loc, s2c(al, "Add"), str_type_len_3)), nullptr));
-                    if_body3.push_back(al, stmt7);
-                    ASR::stmt_t* stmt8 = ASRUtils::STMT(ASR::make_If_t(al, loc, int_cmp_with_16, if_body3.p, if_body3.n, nullptr, 0));
-                    pass_result.push_back(al, stmt8);
-
-                    return target_str;
+                    call_arg2.loc = loc;
+                    call_arg2.m_value = function_call1;
+                    call_args2.push_back(al, call_arg2);
+                    return ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
+                        basic_get_class_from_id_sym, basic_get_class_from_id_sym, call_args2.p, call_args2.n,
+                        ASRUtils::TYPE(ASR::make_Character_t(al, loc, 1, -2, nullptr)), nullptr, nullptr));
                     break;
                 }
                 default: {

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -4791,6 +4791,7 @@ private:
 public:
     ASR::asr_t *asr;
     std::vector<ASR::symbol_t*> do_loop_variables;
+    bool using_func_attr = false;
 
     BodyVisitor(Allocator &al, LocationManager &lm, ASR::asr_t *unit, diag::Diagnostics &diagnostics,
          bool main_module, std::string module_name, std::map<int, ASR::symbol_t*> &ast_overload,
@@ -5991,6 +5992,10 @@ public:
             visit_AttributeUtil(p->m_type, attr_char, t, loc);
         } else if(ASR::is_a<ASR::SymbolicExpression_t>(*type)) {
             std::string attr = attr_char;
+            if (attr == "func") {
+                using_func_attr = true;
+                return;
+            }
             ASR::expr_t *se = ASR::down_cast<ASR::expr_t>(ASR::make_Var_t(al, loc, t));
             Vec<ASR::expr_t*> args;
             args.reserve(al, 0);
@@ -6188,8 +6193,6 @@ public:
     }
 
     void visit_Compare(const AST::Compare_t &x) {
-        this->visit_expr(*x.m_left);
-        ASR::expr_t *left = ASRUtils::EXPR(tmp);
         if (x.n_comparators > 1) {
             diag.add(diag::Diagnostic(
                 "Only one comparison operator is supported for now",
@@ -6200,6 +6203,36 @@ public:
             );
             throw SemanticAbort();
         }
+        this->visit_expr(*x.m_left);
+        if (using_func_attr) {
+            if (AST::is_a<AST::Attribute_t>(*x.m_left) && AST::is_a<AST::Name_t>(*x.m_comparators[0])) {
+                AST::Attribute_t *attr = AST::down_cast<AST::Attribute_t>(x.m_left);
+                AST::Name_t *type_name = AST::down_cast<AST::Name_t>(x.m_comparators[0]);
+                std::string symbolic_type = type_name->m_id;
+                if (AST::is_a<AST::Name_t>(*attr->m_value)) {
+                    AST::Name_t *var_name = AST::down_cast<AST::Name_t>(attr->m_value);
+                    std::string var = var_name->m_id;
+                    ASR::symbol_t *st = current_scope->resolve_symbol(var);
+                    ASR::expr_t *se = ASR::down_cast<ASR::expr_t>(
+                                    ASR::make_Var_t(al, x.base.base.loc, st));
+                    Vec<ASR::expr_t*> args;
+                    args.reserve(al, 0);
+                    if (symbolic_type == "Add") {
+                        handle_symbolic_attribute(se, "is_Add", x.base.base.loc, args);
+                        return;
+                    } else if (symbolic_type == "Mul") {
+                        handle_symbolic_attribute(se, "is_Mul", x.base.base.loc, args);
+                        return;
+                    } else if (symbolic_type == "Pow") {
+                        handle_symbolic_attribute(se, "is_Pow", x.base.base.loc, args);
+                        return;
+                    } else {
+                        throw SemanticError(symbolic_type + " symbolic type not supported yet", x.base.base.loc);
+                    }
+                }
+            }
+        }
+        ASR::expr_t *left = ASRUtils::EXPR(tmp);
         this->visit_expr(*x.m_comparators[0]);
         ASR::expr_t *right = ASRUtils::EXPR(tmp);
 

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6032,13 +6032,13 @@ public:
                     Vec<ASR::expr_t*> args;
                     args.reserve(al, 0);
                     if (symbolic_type == "Add") {
-                        handle_symbolic_attribute(se, "is_Add", x.base.base.loc, args);
+                        tmp = attr_handler.eval_symbolic_is_Add(se, al, x.base.base.loc, args, diag);
                         return;
                     } else if (symbolic_type == "Mul") {
-                        handle_symbolic_attribute(se, "is_Mul", x.base.base.loc, args);
+                        tmp = attr_handler.eval_symbolic_is_Mul(se, al, x.base.base.loc, args, diag);
                         return;
                     } else if (symbolic_type == "Pow") {
-                        handle_symbolic_attribute(se, "is_Pow", x.base.base.loc, args);
+                        tmp = attr_handler.eval_symbolic_is_Pow(se, al, x.base.base.loc, args, diag);
                         return;
                     } else {
                         throw SemanticError(symbolic_type + " symbolic type not supported yet", x.base.base.loc);

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5989,6 +5989,12 @@ public:
         } else if(ASR::is_a<ASR::Pointer_t>(*type)) {
             ASR::Pointer_t* p = ASR::down_cast<ASR::Pointer_t>(type);
             visit_AttributeUtil(p->m_type, attr_char, t, loc);
+        } else if(ASR::is_a<ASR::SymbolicExpression_t>(*type)) {
+            std::string attr = attr_char;
+            ASR::expr_t *se = ASR::down_cast<ASR::expr_t>(ASR::make_Var_t(al, loc, t));
+            Vec<ASR::expr_t*> args;
+            args.reserve(al, 0);
+            handle_symbolic_attribute(se, attr, loc, args);
         } else {
             throw SemanticError(ASRUtils::type_to_str_python(type) + " not supported yet in Attribute.",
                 loc);

--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -46,7 +46,8 @@ struct AttributeHandler {
         symbolic_attribute_map = {
             {"diff", &eval_symbolic_diff},
             {"expand", &eval_symbolic_expand},
-            {"has", &eval_symbolic_has_symbol}
+            {"has", &eval_symbolic_has_symbol},
+            {"func", &eval_symbolic_func}
         };
     }
 
@@ -453,6 +454,20 @@ struct AttributeHandler {
         }
         ASRUtils::create_intrinsic_function create_function =
             ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("has");
+        return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
+                                { throw SemanticError(msg, loc); });
+    }
+
+    static ASR::asr_t* eval_symbolic_func(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &/*diag*/) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("func");
         return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
                                 { throw SemanticError(msg, loc); });
     }

--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -466,7 +466,7 @@ struct AttributeHandler {
             args_with_list.push_back(al, args[i]);
         }
         ASRUtils::create_intrinsic_function create_function =
-            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("is_Add");
+            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("AddQ");
         return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
                                 { throw SemanticError(msg, loc); });
     }
@@ -480,7 +480,7 @@ struct AttributeHandler {
             args_with_list.push_back(al, args[i]);
         }
         ASRUtils::create_intrinsic_function create_function =
-            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("is_Mul");
+            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("MulQ");
         return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
                                 { throw SemanticError(msg, loc); });
     }
@@ -494,7 +494,7 @@ struct AttributeHandler {
             args_with_list.push_back(al, args[i]);
         }
         ASRUtils::create_intrinsic_function create_function =
-            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("is_Pow");
+            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("PowQ");
         return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
                                 { throw SemanticError(msg, loc); });
     }

--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -47,7 +47,9 @@ struct AttributeHandler {
             {"diff", &eval_symbolic_diff},
             {"expand", &eval_symbolic_expand},
             {"has", &eval_symbolic_has_symbol},
-            {"func", &eval_symbolic_func}
+            {"is_Add", &eval_symbolic_is_Add},
+            {"is_Mul", &eval_symbolic_is_Mul},
+            {"is_Pow", &eval_symbolic_is_Pow}
         };
     }
 
@@ -468,6 +470,48 @@ struct AttributeHandler {
         }
         ASRUtils::create_intrinsic_function create_function =
             ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("func");
+        return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
+                                { throw SemanticError(msg, loc); });
+    }
+
+    static ASR::asr_t* eval_symbolic_is_Add(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &/*diag*/) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("is_Add");
+        return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
+                                { throw SemanticError(msg, loc); });
+    }
+
+    static ASR::asr_t* eval_symbolic_is_Mul(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &/*diag*/) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("is_Mul");
+        return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
+                                { throw SemanticError(msg, loc); });
+    }
+
+    static ASR::asr_t* eval_symbolic_is_Pow(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &/*diag*/) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("is_Pow");
         return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
                                 { throw SemanticError(msg, loc); });
     }

--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -47,9 +47,6 @@ struct AttributeHandler {
             {"diff", &eval_symbolic_diff},
             {"expand", &eval_symbolic_expand},
             {"has", &eval_symbolic_has_symbol},
-            {"is_Add", &eval_symbolic_is_Add},
-            {"is_Mul", &eval_symbolic_is_Mul},
-            {"is_Pow", &eval_symbolic_is_Pow}
         };
     }
 
@@ -456,20 +453,6 @@ struct AttributeHandler {
         }
         ASRUtils::create_intrinsic_function create_function =
             ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("has");
-        return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
-                                { throw SemanticError(msg, loc); });
-    }
-
-    static ASR::asr_t* eval_symbolic_func(ASR::expr_t *s, Allocator &al, const Location &loc,
-            Vec<ASR::expr_t*> &args, diag::Diagnostics &/*diag*/) {
-        Vec<ASR::expr_t*> args_with_list;
-        args_with_list.reserve(al, args.size() + 1);
-        args_with_list.push_back(al, s);
-        for(size_t i = 0; i < args.size(); i++) {
-            args_with_list.push_back(al, args[i]);
-        }
-        ASRUtils::create_intrinsic_function create_function =
-            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("func");
         return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
                                 { throw SemanticError(msg, loc); });
     }


### PR DESCRIPTION
This Pr tries to add support for the func attribute. I've used a transform the following python program into this respective C code
```
def main0():
    x: S = pi
    y: S = Symbol("y")
    z: S = y + x
    y = y**x
    print(y.func)
```
```
def main0():
    _x: i64 = i64(0)
    x: CPtr = empty_c_void_p()
    p_c_pointer(pointer(_x, i64), x)
    basic_new_stack(x)
    basic_const_pi(x)
    _y: i64 = i64(0)
    y: CPtr = empty_c_void_p()
    p_c_pointer(pointer(_y, i64), y)
    basic_new_stack(y)
    symbol_set(y, "y")
    basic_pow(y, y, x)
    temp_int : i32 = basic_get_type(y)
    temp_str : str = ""
    if temp_int == 17:
        temp_str = "Pow"
    if temp_int == 15:
        temp_str = "Mul"
    if temp_int == 16:
        temp_str = "Add"
    print(temp_str)

main0()
```
So essentially we do the following 
1) Intorduce `temp_str`, `temp_int` variables and introduce the respective symbols in the symbol table
2) Frame if statements where we compare `temp_int` against integers and update `temp_str` accordingly 