### PR TITLE
Supporting assignment through `basic_assign`

### DIFF
--- a/integration_tests/symbolics_01.py
+++ b/integration_tests/symbolics_01.py
@@ -6,7 +6,10 @@ def main0():
     y: S = Symbol('y')
     x = pi
     z: S = x + y
+    x = z
+    print(x)
     print(z)
+    assert(x == z)
     assert(z == pi + y)
     assert(z != S(2)*pi + y)
 


### PR DESCRIPTION
Addressing comment (https://github.com/lcompilers/lpython/pull/2368#issuecomment-1752019938).
Now all variable to variable assignments take place through `basic_assign` as recommended by symengine's documentation.