### PR TITLE
Fixed printing elements from a symbolic list

### DIFF
--- a/integration_tests/symbolics_11.py
+++ b/integration_tests/symbolics_11.py
@@ -14,5 +14,6 @@ def test_extraction_of_elements():
     assert(ele3 == sin(x))
     assert(ele4 == Symbol("y"))
     print(ele1, ele2, ele3, ele4)
+    print(l1[0], l1[1], l1[2], l1[3])
 
 test_extraction_of_elements()

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -1154,6 +1154,24 @@ public:
                         sym, sym, call_args.p, call_args.n, ASRUtils::TYPE(ASR::make_Logical_t(al, x.base.base.loc, 4)), nullptr, nullptr));
                     print_tmp.push_back(function_call);
                 }
+            } else if (ASR::is_a<ASR::ListItem_t>(*val)) {
+                ASR::ListItem_t* list_item = ASR::down_cast<ASR::ListItem_t>(val);
+                if (list_item->m_type->type == ASR::ttypeType::SymbolicExpression) {
+                    ASR::ttype_t *CPtr_type = ASRUtils::TYPE(ASR::make_CPtr_t(al, x.base.base.loc));
+                    ASR::symbol_t* basic_str_sym = declare_basic_str_function(al, x.base.base.loc, module_scope);
+
+                    Vec<ASR::call_arg_t> call_args;
+                    call_args.reserve(al, 1);
+                    ASR::call_arg_t call_arg;
+                    call_arg.loc = x.base.base.loc;
+                    call_arg.m_value = ASRUtils::EXPR(ASR::make_ListItem_t(al, x.base.base.loc, list_item->m_a,
+                        list_item->m_pos, CPtr_type, nullptr));
+                    call_args.push_back(al, call_arg);
+                    ASR::expr_t* function_call = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, x.base.base.loc,
+                        basic_str_sym, basic_str_sym, call_args.p, call_args.n,
+                        ASRUtils::TYPE(ASR::make_Character_t(al, x.base.base.loc, 1, -2, nullptr)), nullptr, nullptr));
+                    print_tmp.push_back(function_call);
+                }
             } else {
                 print_tmp.push_back(x.m_values[i]);
             }


### PR DESCRIPTION
I think we had functionality for extracting elements out from a symbolic list but printing elements directly wasn't supported. Hence this PR fixes that. For eg
```
def main0():
    x: S = Symbol("x")
    args: list[S] = [x, pi]
    print(args[0], args[1])
```