### PR TITLE
Implementing query method for exp class

### DIFF
--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -83,6 +83,7 @@ enum class IntrinsicScalarFunctions : int64_t {
     SymbolicMulQ,
     SymbolicPowQ,
     SymbolicLogQ,
+    SymbolicExpQ,
     // ...
 };
 
@@ -148,6 +149,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(SymbolicMulQ)
         INTRINSIC_NAME_CASE(SymbolicPowQ)
         INTRINSIC_NAME_CASE(SymbolicLogQ)
+        INTRINSIC_NAME_CASE(SymbolicExpQ)
         default : {
             throw LCompilersException("pickle: intrinsic_id not implemented");
         }
@@ -3149,6 +3151,7 @@ create_symbolic_query_macro(SymbolicAddQ)
 create_symbolic_query_macro(SymbolicMulQ)
 create_symbolic_query_macro(SymbolicPowQ)
 create_symbolic_query_macro(SymbolicLogQ)
+create_symbolic_query_macro(SymbolicExpQ)
 
 
 #define create_symbolic_unary_macro(X)                                                    \
@@ -3312,6 +3315,8 @@ namespace IntrinsicScalarFunctionRegistry {
             {nullptr, &SymbolicPowQ::verify_args}},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicLogQ),
             {nullptr, &SymbolicLogQ::verify_args}},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicExpQ),
+            {nullptr, &SymbolicExpQ::verify_args}},
     };
 
     static const std::map<int64_t, std::string>& intrinsic_function_id_to_name = {
@@ -3424,6 +3429,8 @@ namespace IntrinsicScalarFunctionRegistry {
             "SymbolicPowQ"},
         {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicLogQ),
             "SymbolicLogQ"},
+        {static_cast<int64_t>(IntrinsicScalarFunctions::SymbolicExpQ),
+            "SymbolicExpQ"},
     };
 
 
@@ -3483,6 +3490,7 @@ namespace IntrinsicScalarFunctionRegistry {
                 {"MulQ", {&SymbolicMulQ::create_SymbolicMulQ, &SymbolicMulQ::eval_SymbolicMulQ}},
                 {"PowQ", {&SymbolicPowQ::create_SymbolicPowQ, &SymbolicPowQ::eval_SymbolicPowQ}},
                 {"LogQ", {&SymbolicLogQ::create_SymbolicLogQ, &SymbolicLogQ::eval_SymbolicLogQ}},
+                {"ExpQ", {&SymbolicExpQ::create_SymbolicExpQ, &SymbolicExpQ::eval_SymbolicExpQ}},
     };
 
     static inline bool is_intrinsic_function(const std::string& name) {

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6043,6 +6043,9 @@ public:
                     } else if (symbolic_type == "log") {
                         tmp = attr_handler.eval_symbolic_is_log(se, al, x.base.base.loc, args, diag);
                         return;
+                    } else if (symbolic_type == "exp") {
+                        tmp = attr_handler.eval_symbolic_is_exp(se, al, x.base.base.loc, args, diag);
+                        return;
                     } else {
                         throw SemanticError(symbolic_type + " symbolic type not supported yet", x.base.base.loc);
                     }

--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -513,6 +513,20 @@ struct AttributeHandler {
                                 { throw SemanticError(msg, loc); });
     }
 
+    static ASR::asr_t* eval_symbolic_is_exp(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &/*diag*/) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("ExpQ");
+        return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
+                                { throw SemanticError(msg, loc); });
+    }
+
 }; // AttributeHandler
 
 } // namespace LCompilers::LPython


### PR DESCRIPTION
We start with something like the following in the frontend
```
(lf) anutosh491@spbhat68:~/lpython/lpython$ cat examples/expr2.py 
from lpython import S
from sympy import pi, exp, Pow, Symbol

def main0():
    x: S = Symbol("x")
    y: S = exp(x)
    z: bool = y.func == exp
    print(z)
```
And I think we need to transform this into something like the following through the pass
```
def main0():
    _x: i64 = i64(0)
    x: CPtr = empty_c_void_p()
    p_c_pointer(pointer(_x, i64), x)
    basic_new_stack(x)
    symbol_set(x, "x")
    _y: i64 = i64(0)
    y: CPtr = empty_c_void_p()
    p_c_pointer(pointer(_y, i64), y)
    basic_new_stack(y)
    basic_exp(y, x)
    args: CPtr = vecbasic_new()
    basic_get_args(y, args)
    _base: i64 = i64(0)
    base: CPtr = empty_c_void_p()
    p_c_pointer(pointer(_base, i64), base)
    vecbasic_get(args, 0, base)
    _const: i64 = i64(0)
    const: CPtr = empty_c_void_p()
    p_c_pointer(pointer(_const, i64), const)
    basic_new_stack(const)
    basic_const_E(const)
    z: bool = basic_get_type(y) == 17 and basic_eq(base, const)
    print(z)
```