### PR TITLE
refactor: check for dependency only in parent scope

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -20,9 +20,15 @@
     } \
     SymbolTable* temp_scope = current_scope; \
     if (asr_owner_sym && temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(final_sym)->get_counter() && \
-            !ASR::is_a<ASR::AssociateBlock_t>(*asr_owner_sym) && !ASR::is_a<ASR::ExternalSymbol_t>(*final_sym) && \
-                !ASR::is_a<ASR::Variable_t>(*final_sym)) { \
-        current_function_dependencies.push_back(al, ASRUtils::symbol_name(final_sym)); \
+            !ASR::is_a<ASR::ExternalSymbol_t>(*final_sym) && !ASR::is_a<ASR::Variable_t>(*final_sym)) { \
+        if (ASR::is_a<ASR::AssociateBlock_t>(*asr_owner_sym) || ASR::is_a<ASR::Block_t>(*asr_owner_sym)) { \
+            temp_scope = temp_scope->parent; \
+            if (temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(final_sym)->get_counter()) { \
+                current_function_dependencies.push_back(al, ASRUtils::symbol_name(final_sym)); \
+            } \
+        } else { \
+            current_function_dependencies.push_back(al, ASRUtils::symbol_name(final_sym)); \
+        } \
     } \
 
 #define ADD_ASR_DEPENDENCIES_WITH_NAME(current_scope, final_sym, current_function_dependencies, dep_name) ASR::symbol_t* asr_owner_sym = nullptr; \
@@ -31,9 +37,15 @@
     } \
     SymbolTable* temp_scope = current_scope; \
     if (asr_owner_sym && temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(final_sym)->get_counter() && \
-            !ASR::is_a<ASR::AssociateBlock_t>(*asr_owner_sym) && !ASR::is_a<ASR::ExternalSymbol_t>(*final_sym) && \
-                !ASR::is_a<ASR::Variable_t>(*final_sym)) { \
-        current_function_dependencies.push_back(al, dep_name); \
+            !ASR::is_a<ASR::ExternalSymbol_t>(*final_sym) && !ASR::is_a<ASR::Variable_t>(*final_sym)) { \
+        if (ASR::is_a<ASR::AssociateBlock_t>(*asr_owner_sym) || ASR::is_a<ASR::Block_t>(*asr_owner_sym)) { \
+            temp_scope = temp_scope->parent; \
+            if (temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(final_sym)->get_counter()) { \
+                current_function_dependencies.push_back(al, dep_name); \
+            } \
+        } else { \
+            current_function_dependencies.push_back(al, dep_name); \
+        } \
     } \
 
 namespace LCompilers  {

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -441,15 +441,15 @@ public:
         verify_unique_dependencies(x.m_dependencies, x.n_dependencies,
                                    x.m_name, x.base.base.loc);
 
-        // Get the x symtab.
-        SymbolTable *x_symtab = x.m_symtab;
+        // Get the x parent symtab.
+        SymbolTable *x_parent_symtab = x.m_symtab->parent;
 
         // Dependencies of the function should be from function's parent symbol table.
         for( size_t i = 0; i < x.n_dependencies; i++ ) {
             std::string found_dep = x.m_dependencies[i];
 
             // Get the symbol of the found_dep.
-            ASR::symbol_t* dep_sym = x_symtab->resolve_symbol(found_dep);
+            ASR::symbol_t* dep_sym = x_parent_symtab->resolve_symbol(found_dep);
 
             require(dep_sym != nullptr,
                             "Dependency " + found_dep +  " is inside symbol table " + std::string(x.m_name));

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -891,10 +891,16 @@ public:
 
         SymbolTable* temp_scope = current_symtab;
         
-        if (temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter() &&
-            !ASR::is_a<ASR::AssociateBlock_t>(*asr_owner_sym) && !ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name) &&
-                !ASR::is_a<ASR::Variable_t>(*x.m_name)) {
-            function_dependencies.push_back(std::string(ASRUtils::symbol_name(x.m_name)));
+        if (asr_owner_sym && temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter() &&
+            !ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name) && !ASR::is_a<ASR::Variable_t>(*x.m_name)) {
+            if (ASR::is_a<ASR::AssociateBlock_t>(*asr_owner_sym) || ASR::is_a<ASR::Block_t>(*asr_owner_sym)) {
+                temp_scope = temp_scope->parent;
+                if (temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter()) {
+                    function_dependencies.push_back(std::string(ASRUtils::symbol_name(x.m_name)));
+                }
+            } else {
+                function_dependencies.push_back(std::string(ASRUtils::symbol_name(x.m_name)));
+            }    
         }
 
         if( ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name) ) {
@@ -1037,9 +1043,15 @@ public:
         SymbolTable* temp_scope = current_symtab;
         
         if (asr_owner_sym && temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter() &&
-            !ASR::is_a<ASR::AssociateBlock_t>(*asr_owner_sym) && !ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name) &&
-                !ASR::is_a<ASR::Variable_t>(*x.m_name)) {
-            function_dependencies.push_back(std::string(ASRUtils::symbol_name(x.m_name)));
+            !ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name) && !ASR::is_a<ASR::Variable_t>(*x.m_name)) {
+            if (ASR::is_a<ASR::AssociateBlock_t>(*asr_owner_sym) || ASR::is_a<ASR::Block_t>(*asr_owner_sym)) {
+                temp_scope = temp_scope->parent;
+                if (temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter()) {
+                    function_dependencies.push_back(std::string(ASRUtils::symbol_name(x.m_name)));
+                }
+            } else {
+                function_dependencies.push_back(std::string(ASRUtils::symbol_name(x.m_name)));
+            }    
         }
 
         if( ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name) ) {

--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -341,9 +341,15 @@ namespace LCompilers {
                         SymbolTable* temp_scope = current_scope;
 
                         if (asr_owner_sym && temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter() &&
-                            !ASR::is_a<ASR::AssociateBlock_t>(*asr_owner_sym) && !ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name) &&
-                                !ASR::is_a<ASR::Variable_t>(*x.m_name)) {
-                            function_dependencies.push_back(al, ASRUtils::symbol_name(x.m_name));
+                            !ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name) && !ASR::is_a<ASR::Variable_t>(*x.m_name)) {
+                            if (ASR::is_a<ASR::AssociateBlock_t>(*asr_owner_sym) || ASR::is_a<ASR::Block_t>(*asr_owner_sym)) {
+                                temp_scope = temp_scope->parent;
+                                if (temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter()) {
+                                    function_dependencies.push_back(al, ASRUtils::symbol_name(x.m_name));
+                                }
+                            } else {
+                                function_dependencies.push_back(al, ASRUtils::symbol_name(x.m_name));
+                            }    
                         }
                     }
 
@@ -367,9 +373,15 @@ namespace LCompilers {
                         SymbolTable* temp_scope = current_scope;
 
                         if (asr_owner_sym && temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter() &&
-                            !ASR::is_a<ASR::AssociateBlock_t>(*asr_owner_sym) && !ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name) &&
-                                !ASR::is_a<ASR::Variable_t>(*x.m_name)) {
-                            function_dependencies.push_back(al, ASRUtils::symbol_name(x.m_name));
+                            !ASR::is_a<ASR::ExternalSymbol_t>(*x.m_name) && !ASR::is_a<ASR::Variable_t>(*x.m_name)) {
+                            if (ASR::is_a<ASR::AssociateBlock_t>(*asr_owner_sym) || ASR::is_a<ASR::Block_t>(*asr_owner_sym)) {
+                                temp_scope = temp_scope->parent;
+                                if (temp_scope->get_counter() != ASRUtils::symbol_parent_symtab(x.m_name)->get_counter()) {
+                                    function_dependencies.push_back(al, ASRUtils::symbol_name(x.m_name));
+                                }
+                            } else {
+                                function_dependencies.push_back(al, ASRUtils::symbol_name(x.m_name));
+                            }    
                         }
                     }
 
@@ -384,10 +396,13 @@ namespace LCompilers {
                 }
 
                 void visit_BlockCall(const ASR::BlockCall_t& x) {
+                    SymbolTable *parent_symtab = current_scope;
                     ASR::Block_t* block = ASR::down_cast<ASR::Block_t>(x.m_m);
+                    current_scope = block->m_symtab;
                     for (size_t i=0; i<block->n_body; i++) {
                         visit_stmt(*(block->m_body[i]));
                     }
+                    current_scope = parent_symtab;
                 }
 
                 void visit_AssociateBlock(const ASR::AssociateBlock_t& x) {


### PR DESCRIPTION
Resolves: https://github.com/lcompilers/lpython/issues/2392