### PR TITLE
Implementing symbolic get args method

### DIFF
--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -47,6 +47,7 @@ struct AttributeHandler {
             {"diff", &eval_symbolic_diff},
             {"expand", &eval_symbolic_expand},
             {"has", &eval_symbolic_has_symbol},
+            {"args", &eval_symbolic_get_arguments}
         };
     }
 
@@ -509,6 +510,20 @@ struct AttributeHandler {
         }
         ASRUtils::create_intrinsic_function create_function =
             ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("LogQ");
+        return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
+                                { throw SemanticError(msg, loc); });
+    }
+
+    static ASR::asr_t* eval_symbolic_get_arguments(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &/*diag*/) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("GetArguments");
         return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
                                 { throw SemanticError(msg, loc); });
     }


### PR DESCRIPTION
Trying to execute something like this 
```
(lf) anutosh491@spbhat68:~/lpython/lpython$ cat examples/expr2.py 
from lpython import S
from sympy import pi, Symbol

def main0():
    x: S = Symbol("x")
    y: S = x**pi
    z: list[S] = y.args
    print(z[0], z[1])
```