### PR TITLE
Implementing get argument through design 1

### DIFF
--- a/integration_tests/symbolics_02.py
+++ b/integration_tests/symbolics_02.py
@@ -19,6 +19,8 @@ def test_symbolic_operations():
     else:
         assert False
     assert(z.func == Add)
+    assert(z.args[0] == x or z.args[0] == y)
+    assert(z.args[1] == y or z.args[1] == x)
     print(z)
     
     # Subtraction
@@ -43,6 +45,8 @@ def test_symbolic_operations():
     else:
         assert False
     assert(u.func == Mul)
+    assert(u.args[0] == x)
+    assert(u.args[1] == y)
     print(u)
 
     # Division

--- a/integration_tests/symbolics_05.py
+++ b/integration_tests/symbolics_05.py
@@ -32,5 +32,12 @@ def test_operations():
     assert((sin(x) + cos(x)).diff(x) == S(-1)*c + d)
     assert((sin(x) + cos(x) + exp(x) + pi).diff(x).expand().diff(x) == exp(x) + S(-1)*c + S(-1)*d)
 
+    # test args
+    assert(a.args[0] == x + y)
+    assert(a.args[1] == S(2))
+    assert(b.args[0] == x + y + z)
+    assert(b.args[1] == S(3))
+    assert(c.args[0] == x)
+    assert(d.args[0] == x)
 
 test_operations()

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -569,13 +569,12 @@ public:
 
                 // Define necessary variables
                 ASR::ttype_t* CPtr_type = ASRUtils::TYPE(ASR::make_CPtr_t(al, loc));
+                std::string args_str = current_scope->get_unique_name("_lcompilers_symbolic_argument_container");
                 ASR::symbol_t* args_sym = ASR::down_cast<ASR::symbol_t>(ASR::make_Variable_t(
-                    al, loc, current_scope, s2c(al, "args"), nullptr, 0, ASR::intentType::Local,
+                    al, loc, current_scope, s2c(al, args_str), nullptr, 0, ASR::intentType::Local,
                     nullptr, nullptr, ASR::storage_typeType::Default, CPtr_type, nullptr,
                     ASR::abiType::BindC, ASR::Public, ASR::presenceType::Required, false));
-                //if (!current_scope->get_symbol("args")) {
-                current_scope->add_symbol(s2c(al, "args"), args_sym);
-                //}
+                current_scope->add_symbol(args_str, args_sym);
 
                 // Statement 1
                 ASR::expr_t* args = ASRUtils::EXPR(ASR::make_Var_t(al, loc, args_sym));

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -601,8 +601,6 @@ public:
                 pass_result.push_back(al, stmt2);
 
                 // Statement 3
-                Vec<ASR::stmt_t *> if_body; if_body.reserve(al, 1);
-                Vec<ASR::stmt_t *> else_body; else_body.reserve(al, 1);
                 Vec<ASR::call_arg_t> call_args3;
                 call_args3.reserve(al, 1);
                 ASR::call_arg_t call_arg3;
@@ -612,12 +610,13 @@ public:
                 ASR::expr_t* function_call2 = ASRUtils::EXPR(ASRUtils::make_FunctionCall_t_util(al, loc,
                     vecbasic_size_sym, vecbasic_size_sym, call_args3.p, call_args3.n,
                     ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)), nullptr, nullptr));
-                ASR::expr_t* int_compare = ASRUtils::EXPR(ASR::make_IntegerCompare_t(al, loc, function_call2, ASR::cmpopType::LtE,
+                ASR::expr_t* test = ASRUtils::EXPR(ASR::make_IntegerCompare_t(al, loc, function_call2, ASR::cmpopType::Gt,
                         x->m_args[1], ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)), nullptr));
-                ASR::stmt_t* if_body_stmt = ASRUtils::STMT(ASR::make_ErrorStop_t(al, loc, nullptr));
-                if_body.push_back(al, if_body_stmt);
-                ASR::stmt_t* stmt3 = ASRUtils::STMT(ASR::make_If_t(al, loc, int_compare,
-                    if_body.p, if_body.n, else_body.p, else_body.n));
+                std::string error_str = "tuple index out of range";
+                ASR::ttype_t *str_type = ASRUtils::TYPE(ASR::make_Character_t(al, loc,
+                        1, error_str.size(), nullptr));
+                ASR::expr_t* error = ASRUtils::EXPR(ASR::make_StringConstant_t(al, loc, s2c(al, error_str), str_type));
+                ASR::stmt_t *stmt3 = ASRUtils::STMT(ASR::make_Assert_t(al, loc, test, error));
                 pass_result.push_back(al, stmt3);
 
                 // Statement 4

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -614,7 +614,9 @@ public:
                     ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)), nullptr, nullptr));
                 ASR::expr_t* int_compare = ASRUtils::EXPR(ASR::make_IntegerCompare_t(al, loc, function_call2, ASR::cmpopType::LtE,
                         x->m_args[1], ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)), nullptr));
-                ASR::stmt_t* stmt3 = ASRUtils::STMT(make_If_t(al, loc, int_compare,
+                ASR::stmt_t* if_body_stmt = ASRUtils::STMT(ASR::make_ErrorStop_t(al, loc, nullptr));
+                if_body.push_back(al, if_body_stmt);
+                ASR::stmt_t* stmt3 = ASRUtils::STMT(ASR::make_If_t(al, loc, int_compare,
                     if_body.p, if_body.n, else_body.p, else_body.n));
                 pass_result.push_back(al, stmt3);
 

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -3818,6 +3818,7 @@ public:
                     ASR::expr_t *index = ASRUtils::EXPR(tmp);
                     args.push_back(al, index);
                     tmp = attr_handler.eval_symbolic_get_argument(se, al, x.base.base.loc, args, diag);
+                    using_args_attr = false;
                     return;
                 }
             }

--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -527,6 +527,20 @@ struct AttributeHandler {
                                 { throw SemanticError(msg, loc); });
     }
 
+    static ASR::asr_t* eval_symbolic_get_argument(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &/*diag*/) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicScalarFunctionRegistry::get_create_function("GetArgument");
+        return create_function(al, loc, args_with_list, [&](const std::string &msg, const Location &loc)
+                                { throw SemanticError(msg, loc); });
+    }
+
 }; // AttributeHandler
 
 } // namespace LCompilers::LPython


### PR DESCRIPTION
This pr is essentially trying to achieve the same thing as #2396 through a different design (Design 1 from #2393  which is https://github.com/lcompilers/lpython/issues/2393#issue-1961853101)

So essentially we can do something like the following 
```
(lf) anutosh491@spbhat68:~/lpython/lpython$ cat examples/expr2.py 
from lpython import S
from sympy import Symbol

def main0():
    x: S = Symbol("x")
    y: S = Symbol("y")
    x = x**y
    arg1: S = x.args[1]
    print(arg1)

(lf) anutosh491@spbhat68:~/lpython/lpython$ lpython --enable-symengine examples/expr2.py 
y
```