### PR TITLE
Added support for `visit_Assert` through `basic_eq`

### DIFF
--- a/integration_tests/symbolics_01.py
+++ b/integration_tests/symbolics_01.py
@@ -13,4 +13,10 @@ def main0():
     assert(z == pi + y)
     assert(z != S(2)*pi + y)
 
+    # testing PR 2404
+    p: S = Symbol('pi')
+    print(p)
+    print(p != pi)
+    assert(p != pi)
+
 main0()


### PR DESCRIPTION
Fixes #2401 

Instead of converting the `basic` variables into strings using `basic_str` and doing a string comparison, I think using `basic_eq` works better. This has been addressed through the PR