### PR TITLE
Removed redundant return node after processing an ASR through subroutine_from_function pass

### DIFF
--- a/src/libasr/pass/pass_utils.h
+++ b/src/libasr/pass/pass_utils.h
@@ -821,6 +821,14 @@ namespace LCompilers {
                 s_func_type->m_arg_types = arg_types.p;
                 s_func_type->n_arg_types = arg_types.n;
                 s_func_type->m_return_var_type = nullptr;
+
+                Vec<ASR::stmt_t*> func_body;
+                func_body.reserve(al, x->n_body - 1);
+                for (size_t i=0; i< x->n_body - 1; i++) {
+                    func_body.push_back(al, x->m_body[i]);
+                }
+                x->m_body = func_body.p;
+                x->n_body = func_body.n;
             }
         }
         for (auto &item : x->m_symtab->get_scope()) {


### PR DESCRIPTION
Fixes #2420 

As the `return` node would be the last statement in the function body for a function having a return var i.e ( `if (x->m_return_var)` ), we can simply not append it in the function body.
