### PR TITLE
changes documentation to represent correct path for lpython on windows machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Please follow the below steps for Windows:
 
   ```bash
   ctest
-  inst\bin\lpython examples\expr2.py
-  inst\bin\lpython examples\expr2.py -o a.out
+  src\bin\lpython examples\expr2.py
+  src\bin\lpython examples\expr2.py -o a.out
   a.out
   ```
 


### PR DESCRIPTION
The documentation had some errors. The path to lpython executable is not correct. This commit reflects the correct path for  the lpython executable on windows.