### PR TITLE
Implement ``str.split()``

### DIFF
--- a/integration_tests/test_str_01.py
+++ b/integration_tests/test_str_01.py
@@ -123,6 +123,28 @@ def test_constant_str_subscript():
     assert "abc"[2] == "c"
     assert "abc"[:2] == "ab"
 
+def test_str_split():
+    a: str = "1,2,3"
+    b: str = "1,2,,3,"
+    c: str = "1and2and3"
+    d: str = "1 2 3"
+    e: str = "   1   2   3   "
+    f: str = "123"
+    res: list[str] = a.split(",")
+    res1: list[str] = b.split(",")
+    res2: list[str] = c.split("and")
+    res3: list[str] = d.split()
+    res4: list[str] = e.split()
+    res5: list[str] = f.split(" ")
+    # res6: list[str] = "".split(" ")
+    assert res == ["1", "2", "3"]
+    assert res1 == ["1", "2", "", "3", ""]
+    assert res2 == ["1", "2", "3"]
+    assert res3 == ["1", "2", "3"]
+    assert res4 == ["1", "2", "3"]
+    assert res5 == ["123"]
+    # assert res6 == [""]
+
 def check():
     f()
     test_str_concat()
@@ -137,5 +159,6 @@ def check():
     test_str_title()
     test_str_istitle()
     test_str_isalpha()
+    test_str_split()
 
 check()

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6761,6 +6761,29 @@ public:
             // Push string and substring argument on top of Vector (or Function Arguments Stack basically)
             fn_args.push_back(al, str);
             fn_args.push_back(al, value);
+        } else if(attr_name == "split") {
+            if(args.size() > 1) {
+                throw SemanticError("str.split() takes at most one argument for now.", loc);
+            }
+            fn_call_name = "_lpython_str_split";
+            ASR::call_arg_t str;
+            str.loc = loc;
+            str.m_value = s_var;
+
+            if (args.size() == 1) {
+                ASR::expr_t *arg_value = args[0].m_value;
+                ASR::ttype_t *arg_value_type = ASRUtils::expr_type(arg_value);
+                if (!ASRUtils::is_character(*arg_value_type)) {
+                    throw SemanticError("str.split() takes one argument of type: str", loc);
+                }
+                ASR::call_arg_t value;
+                value.loc = loc;
+                value.m_value = args[0].m_value;
+                fn_args.push_back(al, str);
+                fn_args.push_back(al, value);
+            } else {
+                fn_args.push_back(al, str);
+            }
         } else if(attr_name.size() > 2 && attr_name[0] == 'i' && attr_name[1] == 's') {
             /*
                 String Validation Methods i.e all "is" based functions are handled here

--- a/src/lpython/semantics/python_comptime_eval.h
+++ b/src/lpython/semantics/python_comptime_eval.h
@@ -88,6 +88,7 @@ struct PythonIntrinsicProcedures {
             {"_lpython_str_rstrip", {m_builtin, &not_implemented}},
             {"_lpython_str_lstrip", {m_builtin, &not_implemented}},
             {"_lpython_str_strip", {m_builtin, &not_implemented}},
+            {"_lpython_str_split", {m_builtin, &not_implemented}},
             {"_lpython_str_swapcase", {m_builtin, &not_implemented}},
             {"_lpython_str_startswith", {m_builtin, &not_implemented}},
             {"_lpython_str_endswith", {m_builtin, &not_implemented}},

--- a/src/runtime/lpython_builtin.py
+++ b/src/runtime/lpython_builtin.py
@@ -822,6 +822,44 @@ def _lpython_str_strip(x: str) -> str:
     return res
 
 @overload
+def _lpython_str_split(x: str) -> list[str]:
+    sep: str = ' '
+    res: list[str] = []
+    start:i32 = 0
+    ind: i32
+    x_strip: str = _lpython_str_strip(x)
+    if (x_strip == ""): 
+        return res
+    while True:
+        while (start < len(x_strip) and x_strip[start] == ' '):
+            start += 1
+        ind = _lpython_str_find(x_strip[start:len(x_strip)], sep)
+        if ind == -1:
+            res.append(x_strip[start:len(x_strip)])
+            break
+        else:
+            res.append(x_strip[start:start + ind])
+            start += ind + len(sep)
+    return res
+    
+@overload
+def _lpython_str_split(x: str, sep:str) -> list[str]:
+    if len(sep) == 0:
+        raise ValueError('empty separator')
+    res: list[str] = []
+    start:i32 = 0
+    ind: i32
+    while True:
+        ind = _lpython_str_find(x[start:len(x)], sep)
+        if ind == -1:
+            res.append(x[start:len(x)])
+            break
+        else:
+            res.append(x[start:start + ind])
+            start += ind + len(sep)
+    return res
+
+@overload
 def _lpython_str_swapcase(s: str) -> str:
     res :str = ""
     cur: str
@@ -870,7 +908,7 @@ def _lpython_str_partition(s:str, sep: str) -> tuple[str, str, str]:
     if len(s) == 0:
         raise ValueError('empty string cannot be partitioned')
     if len(sep) == 0:
-        raise ValueError('empty seperator')
+        raise ValueError('empty separator')
     res : tuple[str, str, str]
     ind : i32
     ind = _lpython_str_find(s, sep)

--- a/tests/reference/asr-array_01_decl-39cf894.json
+++ b/tests/reference/asr-array_01_decl-39cf894.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_01_decl-39cf894.stdout",
-    "stdout_hash": "489d2e6a364cc6020f2942b94738849349928901f1269b975a6e2464",
+    "stdout_hash": "5d4751789e2ddcd882c4d6026f801ba32cfc227fafff7395a788bdd9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_01_decl-39cf894.stdout
+++ b/tests/reference/asr-array_01_decl-39cf894.stdout
@@ -10,11 +10,11 @@
                             ArraySizes:
                                 (EnumType
                                     (SymbolTable
-                                        209
+                                        211
                                         {
                                             SIZE_10:
                                                 (Variable
-                                                    209
+                                                    211
                                                     SIZE_10
                                                     []
                                                     Local
@@ -30,7 +30,7 @@
                                                 ),
                                             SIZE_3:
                                                 (Variable
-                                                    209
+                                                    211
                                                     SIZE_3
                                                     []
                                                     Local
@@ -58,7 +58,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        218
                                         {
                                             
                                         })
@@ -94,11 +94,11 @@
                             accept_f32_array:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    215
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -114,7 +114,7 @@
                                                 ),
                                             xf32:
                                                 (Variable
-                                                    213
+                                                    215
                                                     xf32
                                                     []
                                                     InOut
@@ -155,10 +155,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 xf32)]
+                                    [(Var 215 xf32)]
                                     [(=
                                         (ArrayItem
-                                            (Var 213 xf32)
+                                            (Var 215 xf32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -181,9 +181,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 215 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 213 xf32)
+                                            (Var 215 xf32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -194,7 +194,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 215 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -203,11 +203,11 @@
                             accept_f64_array:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        216
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    214
+                                                    216
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -223,7 +223,7 @@
                                                 ),
                                             xf64:
                                                 (Variable
-                                                    214
+                                                    216
                                                     xf64
                                                     []
                                                     InOut
@@ -264,10 +264,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 xf64)]
+                                    [(Var 216 xf64)]
                                     [(=
                                         (ArrayItem
-                                            (Var 214 xf64)
+                                            (Var 216 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -282,9 +282,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 _lpython_return_variable)
+                                        (Var 216 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 214 xf64)
+                                            (Var 216 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -295,7 +295,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 214 _lpython_return_variable)
+                                    (Var 216 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -304,11 +304,11 @@
                             accept_i16_array:
                                 (Function
                                     (SymbolTable
-                                        210
+                                        212
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    210
+                                                    212
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -324,7 +324,7 @@
                                                 ),
                                             xi16:
                                                 (Variable
-                                                    210
+                                                    212
                                                     xi16
                                                     []
                                                     InOut
@@ -365,10 +365,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 210 xi16)]
+                                    [(Var 212 xi16)]
                                     [(=
                                         (ArrayItem
-                                            (Var 210 xi16)
+                                            (Var 212 xi16)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -385,9 +385,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 210 _lpython_return_variable)
+                                        (Var 212 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 210 xi16)
+                                            (Var 212 xi16)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -398,7 +398,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 210 _lpython_return_variable)
+                                    (Var 212 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -407,11 +407,11 @@
                             accept_i32_array:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    213
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -427,7 +427,7 @@
                                                 ),
                                             xi32:
                                                 (Variable
-                                                    211
+                                                    213
                                                     xi32
                                                     []
                                                     InOut
@@ -468,10 +468,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 xi32)]
+                                    [(Var 213 xi32)]
                                     [(=
                                         (ArrayItem
-                                            (Var 211 xi32)
+                                            (Var 213 xi32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -483,9 +483,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 _lpython_return_variable)
+                                        (Var 213 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 211 xi32)
+                                            (Var 213 xi32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -496,7 +496,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 213 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -505,11 +505,11 @@
                             accept_i64_array:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    212
+                                                    214
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -525,7 +525,7 @@
                                                 ),
                                             xi64:
                                                 (Variable
-                                                    212
+                                                    214
                                                     xi64
                                                     []
                                                     InOut
@@ -566,10 +566,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 xi64)]
+                                    [(Var 214 xi64)]
                                     [(=
                                         (ArrayItem
-                                            (Var 212 xi64)
+                                            (Var 214 xi64)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -586,9 +586,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 _lpython_return_variable)
+                                        (Var 214 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 212 xi64)
+                                            (Var 214 xi64)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -599,7 +599,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 212 _lpython_return_variable)
+                                    (Var 214 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -608,11 +608,11 @@
                             declare_arrays:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        217
                                         {
                                             ac32:
                                                 (Variable
-                                                    215
+                                                    217
                                                     ac32
                                                     []
                                                     Local
@@ -633,7 +633,7 @@
                                                 ),
                                             ac64:
                                                 (Variable
-                                                    215
+                                                    217
                                                     ac64
                                                     []
                                                     Local
@@ -654,7 +654,7 @@
                                                 ),
                                             af32:
                                                 (Variable
-                                                    215
+                                                    217
                                                     af32
                                                     []
                                                     Local
@@ -675,7 +675,7 @@
                                                 ),
                                             af64:
                                                 (Variable
-                                                    215
+                                                    217
                                                     af64
                                                     []
                                                     Local
@@ -696,7 +696,7 @@
                                                 ),
                                             ai16:
                                                 (Variable
-                                                    215
+                                                    217
                                                     ai16
                                                     []
                                                     Local
@@ -717,7 +717,7 @@
                                                 ),
                                             ai32:
                                                 (Variable
-                                                    215
+                                                    217
                                                     ai32
                                                     []
                                                     Local
@@ -738,7 +738,7 @@
                                                 ),
                                             ai64:
                                                 (Variable
-                                                    215
+                                                    217
                                                     ai64
                                                     []
                                                     Local
@@ -780,7 +780,7 @@
                                     accept_f64_array]
                                     []
                                     [(=
-                                        (Var 215 ai16)
+                                        (Var 217 ai16)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -794,7 +794,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 ai32)
+                                        (Var 217 ai32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -808,7 +808,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 ai64)
+                                        (Var 217 ai64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -822,7 +822,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 af32)
+                                        (Var 217 af32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -836,7 +836,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 af64)
+                                        (Var 217 af64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -850,7 +850,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 ac32)
+                                        (Var 217 ac32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -864,7 +864,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 ac64)
+                                        (Var 217 ac64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -882,7 +882,7 @@
                                             2 accept_i16_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 ai16)
+                                                (Var 217 ai16)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -905,7 +905,7 @@
                                             2 accept_i32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 ai32)
+                                                (Var 217 ai32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -928,7 +928,7 @@
                                             2 accept_i64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 ai64)
+                                                (Var 217 ai64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -951,7 +951,7 @@
                                             2 accept_f32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 af32)
+                                                (Var 217 af32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -974,7 +974,7 @@
                                             2 accept_f64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 af64)
+                                                (Var 217 af64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -1009,11 +1009,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        217
+                        219
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    217
+                                    219
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1025,7 +1025,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        217 __main__global_stmts
+                        219 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-array_02_decl-e8f6874.json
+++ b/tests/reference/asr-array_02_decl-e8f6874.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_02_decl-e8f6874.stdout",
-    "stdout_hash": "51a219ffb9a2c93f90e7a7c2928ef6f229796a81c72b03208be94602",
+    "stdout_hash": "b75476498ff1c6620f1cdafe5c25e26006b5e47e3ad06663d288feb5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_02_decl-e8f6874.stdout
+++ b/tests/reference/asr-array_02_decl-e8f6874.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        216
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             accept_multidim_f32_array:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    213
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -66,7 +66,7 @@
                                                 ),
                                             xf32:
                                                 (Variable
-                                                    211
+                                                    213
                                                     xf32
                                                     []
                                                     InOut
@@ -107,11 +107,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 xf32)]
+                                    [(Var 213 xf32)]
                                     [(=
-                                        (Var 211 _lpython_return_variable)
+                                        (Var 213 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 211 xf32)
+                                            (Var 213 xf32)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -122,7 +122,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 213 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -131,11 +131,11 @@
                             accept_multidim_f64_array:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    212
+                                                    214
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -151,7 +151,7 @@
                                                 ),
                                             xf64:
                                                 (Variable
-                                                    212
+                                                    214
                                                     xf64
                                                     []
                                                     InOut
@@ -196,11 +196,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 xf64)]
+                                    [(Var 214 xf64)]
                                     [(=
-                                        (Var 212 _lpython_return_variable)
+                                        (Var 214 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 212 xf64)
+                                            (Var 214 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -214,7 +214,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 212 _lpython_return_variable)
+                                    (Var 214 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -223,11 +223,11 @@
                             accept_multidim_i32_array:
                                 (Function
                                     (SymbolTable
-                                        209
+                                        211
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    209
+                                                    211
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -243,7 +243,7 @@
                                                 ),
                                             xi32:
                                                 (Variable
-                                                    209
+                                                    211
                                                     xi32
                                                     []
                                                     InOut
@@ -288,11 +288,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 209 xi32)]
+                                    [(Var 211 xi32)]
                                     [(=
-                                        (Var 209 _lpython_return_variable)
+                                        (Var 211 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 209 xi32)
+                                            (Var 211 xi32)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -306,7 +306,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 209 _lpython_return_variable)
+                                    (Var 211 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -315,11 +315,11 @@
                             accept_multidim_i64_array:
                                 (Function
                                     (SymbolTable
-                                        210
+                                        212
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    210
+                                                    212
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -335,7 +335,7 @@
                                                 ),
                                             xi64:
                                                 (Variable
-                                                    210
+                                                    212
                                                     xi64
                                                     []
                                                     InOut
@@ -384,11 +384,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 210 xi64)]
+                                    [(Var 212 xi64)]
                                     [(=
-                                        (Var 210 _lpython_return_variable)
+                                        (Var 212 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 210 xi64)
+                                            (Var 212 xi64)
                                             [(()
                                             (IntegerConstant 9 (Integer 4))
                                             ())
@@ -405,7 +405,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 210 _lpython_return_variable)
+                                    (Var 212 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -414,11 +414,11 @@
                             declare_arrays:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             ac32:
                                                 (Variable
-                                                    213
+                                                    215
                                                     ac32
                                                     []
                                                     Local
@@ -443,7 +443,7 @@
                                                 ),
                                             ac64:
                                                 (Variable
-                                                    213
+                                                    215
                                                     ac64
                                                     []
                                                     Local
@@ -470,7 +470,7 @@
                                                 ),
                                             af32:
                                                 (Variable
-                                                    213
+                                                    215
                                                     af32
                                                     []
                                                     Local
@@ -491,7 +491,7 @@
                                                 ),
                                             af64:
                                                 (Variable
-                                                    213
+                                                    215
                                                     af64
                                                     []
                                                     Local
@@ -514,7 +514,7 @@
                                                 ),
                                             ai32:
                                                 (Variable
-                                                    213
+                                                    215
                                                     ai32
                                                     []
                                                     Local
@@ -537,7 +537,7 @@
                                                 ),
                                             ai64:
                                                 (Variable
-                                                    213
+                                                    215
                                                     ai64
                                                     []
                                                     Local
@@ -582,7 +582,7 @@
                                     accept_multidim_f64_array]
                                     []
                                     [(=
-                                        (Var 213 ai32)
+                                        (Var 215 ai32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -598,7 +598,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 ai64)
+                                        (Var 215 ai64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -616,7 +616,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 af32)
+                                        (Var 215 af32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -630,7 +630,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 af64)
+                                        (Var 215 af64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -646,7 +646,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 ac32)
+                                        (Var 215 ac32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -664,7 +664,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 ac64)
+                                        (Var 215 ac64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -688,7 +688,7 @@
                                             2 accept_multidim_i32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 213 ai32)
+                                                (Var 215 ai32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -713,7 +713,7 @@
                                             2 accept_multidim_i64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 213 ai64)
+                                                (Var 215 ai64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -740,7 +740,7 @@
                                             2 accept_multidim_f32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 213 af32)
+                                                (Var 215 af32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -763,7 +763,7 @@
                                             2 accept_multidim_f64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 213 af64)
+                                                (Var 215 af64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -800,11 +800,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        215
+                        217
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    215
+                                    217
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -816,7 +816,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        215 __main__global_stmts
+                        217 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-bindc_02-bc1a7ea.json
+++ b/tests/reference/asr-bindc_02-bc1a7ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-bindc_02-bc1a7ea.stdout",
-    "stdout_hash": "96d620a26be932ce9f2bcddc31e7f6bebefc49f82923c3605b9b828c",
+    "stdout_hash": "b0061b776455e9077daa9d47fecc543d08c919c9dad365ad2c3f6b33",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-bindc_02-bc1a7ea.stdout
+++ b/tests/reference/asr-bindc_02-bc1a7ea.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        210
+                                        212
                                         {
                                             
                                         })
@@ -76,11 +76,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        209
+                                        211
                                         {
                                             y:
                                                 (Variable
-                                                    209
+                                                    211
                                                     y
                                                     []
                                                     Local
@@ -101,7 +101,7 @@
                                                 ),
                                             yptr1:
                                                 (Variable
-                                                    209
+                                                    211
                                                     yptr1
                                                     []
                                                     Local
@@ -124,7 +124,7 @@
                                                 ),
                                             yq:
                                                 (Variable
-                                                    209
+                                                    211
                                                     yq
                                                     []
                                                     Local
@@ -157,14 +157,14 @@
                                     []
                                     []
                                     [(=
-                                        (Var 209 yq)
+                                        (Var 211 yq)
                                         (PointerNullConstant
                                             (CPtr)
                                         )
                                         ()
                                     )
                                     (=
-                                        (Var 209 y)
+                                        (Var 211 y)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -179,7 +179,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 209 y)
+                                            (Var 211 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -197,7 +197,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 209 y)
+                                            (Var 211 y)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -214,9 +214,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 209 yptr1)
+                                        (Var 211 yptr1)
                                         (GetPointer
-                                            (Var 209 y)
+                                            (Var 211 y)
                                             (Pointer
                                                 (Array
                                                     (Integer 2)
@@ -231,7 +231,7 @@
                                     )
                                     (Print
                                         [(GetPointer
-                                            (Var 209 y)
+                                            (Var 211 y)
                                             (Pointer
                                                 (Array
                                                     (Integer 2)
@@ -242,13 +242,13 @@
                                             )
                                             ()
                                         )
-                                        (Var 209 yptr1)]
+                                        (Var 211 yptr1)]
                                         ()
                                         ()
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 209 yptr1)
+                                            (Var 211 yptr1)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -257,7 +257,7 @@
                                             ()
                                         )
                                         (ArrayItem
-                                            (Var 209 yptr1)
+                                            (Var 211 yptr1)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -271,7 +271,7 @@
                                     (Assert
                                         (IntegerCompare
                                             (ArrayItem
-                                                (Var 209 yptr1)
+                                                (Var 211 yptr1)
                                                 [(()
                                                 (IntegerConstant 0 (Integer 4))
                                                 ())]
@@ -294,7 +294,7 @@
                                     (Assert
                                         (IntegerCompare
                                             (ArrayItem
-                                                (Var 209 yptr1)
+                                                (Var 211 yptr1)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -315,8 +315,8 @@
                                         ()
                                     )
                                     (CPtrToPointer
-                                        (Var 209 yq)
-                                        (Var 209 yptr1)
+                                        (Var 211 yq)
+                                        (Var 211 yptr1)
                                         (ArrayConstant
                                             [(IntegerConstant 2 (Integer 4))]
                                             (Array
@@ -339,8 +339,8 @@
                                         )
                                     )
                                     (Print
-                                        [(Var 209 yq)
-                                        (Var 209 yptr1)]
+                                        [(Var 211 yq)
+                                        (Var 211 yptr1)]
                                         ()
                                         ()
                                     )]
@@ -404,11 +404,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        211
+                        213
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    211
+                                    213
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -420,7 +420,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        211 __main__global_stmts
+                        213 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-cast-435c233.json
+++ b/tests/reference/asr-cast-435c233.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-cast-435c233.stdout",
-    "stdout_hash": "7706a2702e0eaf323a113deb332715ff149affcc6f3e3558160ad4c7",
+    "stdout_hash": "da51ce5078b2a34b978ae26fc76fb325b261a218555466a38aeeec6a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-cast-435c233.stdout
+++ b/tests/reference/asr-cast-435c233.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        127
+                                        129
                                         {
                                             
                                         })
@@ -285,11 +285,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        128
+                        130
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    128
+                                    130
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -301,7 +301,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        128 __main__global_stmts
+                        130 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-complex1-f26c460.json
+++ b/tests/reference/asr-complex1-f26c460.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-complex1-f26c460.stdout",
-    "stdout_hash": "b4eca9e059405fb89e3d02ac8e4e22fa3e40efdac4f91c696afdebaa",
+    "stdout_hash": "7c3f0d1d66094c100e19a8b2b83c3589ece73fc7224de1e618a4f4c2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-complex1-f26c460.stdout
+++ b/tests/reference/asr-complex1-f26c460.stdout
@@ -776,7 +776,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        128
+                        130
                         {
                             
                         })

--- a/tests/reference/asr-constants1-5828e8a.json
+++ b/tests/reference/asr-constants1-5828e8a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-constants1-5828e8a.stdout",
-    "stdout_hash": "2ac6a82a6b1fd28fc9f55f49af5ab2019948547619b8ef7a60c3bf70",
+    "stdout_hash": "417211efafb2f2d5bb5defcc9f4de14b6e4c0945c52c0a5f53c75d49",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-constants1-5828e8a.stdout
+++ b/tests/reference/asr-constants1-5828e8a.stdout
@@ -1778,7 +1778,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        136
+                        138
                         {
                             
                         })

--- a/tests/reference/asr-elemental_01-b58df26.json
+++ b/tests/reference/asr-elemental_01-b58df26.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-elemental_01-b58df26.stdout",
-    "stdout_hash": "6555dc71f6d6443676246f628d0c911e5bb0759afc1f67ae8e815e09",
+    "stdout_hash": "f6657ff256291caa10a0681ae7c5ad89f5c103725e44318d42b1445e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-elemental_01-b58df26.stdout
+++ b/tests/reference/asr-elemental_01-b58df26.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        242
+                                        244
                                         {
                                             
                                         })
@@ -84,11 +84,11 @@
                             elemental_cos:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        219
                                         {
                                             array2d:
                                                 (Variable
-                                                    217
+                                                    219
                                                     array2d
                                                     []
                                                     Local
@@ -111,7 +111,7 @@
                                                 ),
                                             cos2d:
                                                 (Variable
-                                                    217
+                                                    219
                                                     cos2d
                                                     []
                                                     Local
@@ -134,7 +134,7 @@
                                                 ),
                                             cos@__lpython_overloaded_0__cos:
                                                 (ExternalSymbol
-                                                    217
+                                                    219
                                                     cos@__lpython_overloaded_0__cos
                                                     3 __lpython_overloaded_0__cos
                                                     numpy
@@ -144,7 +144,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    217
+                                                    219
                                                     i
                                                     []
                                                     Local
@@ -160,7 +160,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    217
+                                                    219
                                                     j
                                                     []
                                                     Local
@@ -193,7 +193,7 @@
                                     [verify2d]
                                     []
                                     [(=
-                                        (Var 217 array2d)
+                                        (Var 219 array2d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -209,7 +209,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 cos2d)
+                                        (Var 219 cos2d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -226,7 +226,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 217 i)
+                                        ((Var 219 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -238,7 +238,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 217 j)
+                                            ((Var 219 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 64 (Integer 4))
@@ -250,12 +250,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 217 array2d)
+                                                    (Var 219 array2d)
                                                     [(()
-                                                    (Var 217 i)
+                                                    (Var 219 i)
                                                     ())
                                                     (()
-                                                    (Var 217 j)
+                                                    (Var 219 j)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -263,9 +263,9 @@
                                                 )
                                                 (Cast
                                                     (IntegerBinOp
-                                                        (Var 217 i)
+                                                        (Var 219 i)
                                                         Add
-                                                        (Var 217 j)
+                                                        (Var 219 j)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -278,12 +278,12 @@
                                         )]
                                     )
                                     (=
-                                        (Var 217 cos2d)
+                                        (Var 219 cos2d)
                                         (RealBinOp
                                             (FunctionCall
-                                                217 cos@__lpython_overloaded_0__cos
+                                                219 cos@__lpython_overloaded_0__cos
                                                 2 cos
-                                                [((Var 217 array2d))]
+                                                [((Var 219 array2d))]
                                                 (Array
                                                     (Real 8)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -316,7 +316,7 @@
                                         2 verify2d
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 217 array2d)
+                                            (Var 219 array2d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -330,7 +330,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 217 cos2d)
+                                            (Var 219 cos2d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -356,11 +356,11 @@
                             elemental_mul:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        217
                                         {
                                             array_a:
                                                 (Variable
-                                                    215
+                                                    217
                                                     array_a
                                                     []
                                                     Local
@@ -381,7 +381,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    215
+                                                    217
                                                     array_b
                                                     []
                                                     Local
@@ -402,7 +402,7 @@
                                                 ),
                                             array_c:
                                                 (Variable
-                                                    215
+                                                    217
                                                     array_c
                                                     []
                                                     Local
@@ -423,7 +423,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    215
+                                                    217
                                                     i
                                                     []
                                                     Local
@@ -439,7 +439,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    215
+                                                    217
                                                     j
                                                     []
                                                     Local
@@ -455,7 +455,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    215
+                                                    217
                                                     k
                                                     []
                                                     Local
@@ -488,7 +488,7 @@
                                     [verify1d_mul]
                                     []
                                     [(=
-                                        (Var 215 array_a)
+                                        (Var 217 array_a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -502,7 +502,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 array_b)
+                                        (Var 217 array_b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -516,7 +516,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 array_c)
+                                        (Var 217 array_c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -531,7 +531,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 215 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -543,16 +543,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 215 array_a)
+                                                (Var 217 array_a)
                                                 [(()
-                                                (Var 215 i)
+                                                (Var 217 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 215 i)
+                                                (Var 217 i)
                                                 IntegerToReal
                                                 (Real 8)
                                                 ()
@@ -562,7 +562,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 215 j)
+                                        ((Var 217 j)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -574,9 +574,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 215 array_b)
+                                                (Var 217 array_b)
                                                 [(()
-                                                (Var 215 j)
+                                                (Var 217 j)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -584,7 +584,7 @@
                                             )
                                             (Cast
                                                 (IntegerBinOp
-                                                    (Var 215 j)
+                                                    (Var 217 j)
                                                     Add
                                                     (IntegerConstant 5 (Integer 4))
                                                     (Integer 4)
@@ -598,11 +598,11 @@
                                         )]
                                     )
                                     (=
-                                        (Var 215 array_c)
+                                        (Var 217 array_c)
                                         (RealBinOp
                                             (RealBinOp
                                                 (RealBinOp
-                                                    (Var 215 array_a)
+                                                    (Var 217 array_a)
                                                     Pow
                                                     (RealConstant
                                                         2.000000
@@ -631,7 +631,7 @@
                                             )
                                             Mul
                                             (RealBinOp
-                                                (Var 215 array_b)
+                                                (Var 217 array_b)
                                                 Pow
                                                 (RealConstant
                                                     3.000000
@@ -659,7 +659,7 @@
                                         2 verify1d_mul
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 215 array_a)
+                                            (Var 217 array_a)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -671,7 +671,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 215 array_b)
+                                            (Var 217 array_b)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -683,7 +683,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 215 array_c)
+                                            (Var 217 array_c)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -706,11 +706,11 @@
                             elemental_sin:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        218
                                         {
                                             array1d:
                                                 (Variable
-                                                    216
+                                                    218
                                                     array1d
                                                     []
                                                     Local
@@ -731,7 +731,7 @@
                                                 ),
                                             arraynd:
                                                 (Variable
-                                                    216
+                                                    218
                                                     arraynd
                                                     []
                                                     Local
@@ -756,7 +756,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    216
+                                                    218
                                                     i
                                                     []
                                                     Local
@@ -772,7 +772,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    216
+                                                    218
                                                     j
                                                     []
                                                     Local
@@ -788,7 +788,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    216
+                                                    218
                                                     k
                                                     []
                                                     Local
@@ -804,7 +804,7 @@
                                                 ),
                                             sin1d:
                                                 (Variable
-                                                    216
+                                                    218
                                                     sin1d
                                                     []
                                                     Local
@@ -825,7 +825,7 @@
                                                 ),
                                             sin@__lpython_overloaded_0__sin:
                                                 (ExternalSymbol
-                                                    216
+                                                    218
                                                     sin@__lpython_overloaded_0__sin
                                                     3 __lpython_overloaded_0__sin
                                                     numpy
@@ -835,7 +835,7 @@
                                                 ),
                                             sin@__lpython_overloaded_1__sin:
                                                 (ExternalSymbol
-                                                    216
+                                                    218
                                                     sin@__lpython_overloaded_1__sin
                                                     3 __lpython_overloaded_1__sin
                                                     numpy
@@ -845,7 +845,7 @@
                                                 ),
                                             sinnd:
                                                 (Variable
-                                                    216
+                                                    218
                                                     sinnd
                                                     []
                                                     Local
@@ -888,7 +888,7 @@
                                     verifynd]
                                     []
                                     [(=
-                                        (Var 216 array1d)
+                                        (Var 218 array1d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -902,7 +902,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 216 sin1d)
+                                        (Var 218 sin1d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -917,7 +917,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 216 i)
+                                        ((Var 218 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -929,16 +929,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 216 array1d)
+                                                (Var 218 array1d)
                                                 [(()
-                                                (Var 216 i)
+                                                (Var 218 i)
                                                 ())]
                                                 (Real 4)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 216 i)
+                                                (Var 218 i)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -947,14 +947,14 @@
                                         )]
                                     )
                                     (=
-                                        (Var 216 sin1d)
+                                        (Var 218 sin1d)
                                         (FunctionCall
-                                            216 sin@__lpython_overloaded_1__sin
+                                            218 sin@__lpython_overloaded_1__sin
                                             2 sin
                                             [((FunctionCall
-                                                216 sin@__lpython_overloaded_1__sin
+                                                218 sin@__lpython_overloaded_1__sin
                                                 2 sin
-                                                [((Var 216 array1d))]
+                                                [((Var 218 array1d))]
                                                 (Array
                                                     (Real 4)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -979,7 +979,7 @@
                                         2 verify1d
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 216 array1d)
+                                            (Var 218 array1d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -991,7 +991,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 216 sin1d)
+                                            (Var 218 sin1d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1006,7 +1006,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 216 arraynd)
+                                        (Var 218 arraynd)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1024,7 +1024,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 216 sinnd)
+                                        (Var 218 sinnd)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1043,7 +1043,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 216 i)
+                                        ((Var 218 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -1055,7 +1055,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 216 j)
+                                            ((Var 218 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 64 (Integer 4))
@@ -1067,7 +1067,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 216 k)
+                                                ((Var 218 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 16 (Integer 4))
@@ -1079,15 +1079,15 @@
                                                 (IntegerConstant 1 (Integer 4)))
                                                 [(=
                                                     (ArrayItem
-                                                        (Var 216 arraynd)
+                                                        (Var 218 arraynd)
                                                         [(()
-                                                        (Var 216 i)
+                                                        (Var 218 i)
                                                         ())
                                                         (()
-                                                        (Var 216 j)
+                                                        (Var 218 j)
                                                         ())
                                                         (()
-                                                        (Var 216 k)
+                                                        (Var 218 k)
                                                         ())]
                                                         (Real 8)
                                                         RowMajor
@@ -1096,14 +1096,14 @@
                                                     (Cast
                                                         (IntegerBinOp
                                                             (IntegerBinOp
-                                                                (Var 216 i)
+                                                                (Var 218 i)
                                                                 Add
-                                                                (Var 216 j)
+                                                                (Var 218 j)
                                                                 (Integer 4)
                                                                 ()
                                                             )
                                                             Add
-                                                            (Var 216 k)
+                                                            (Var 218 k)
                                                             (Integer 4)
                                                             ()
                                                         )
@@ -1117,12 +1117,12 @@
                                         )]
                                     )
                                     (=
-                                        (Var 216 sinnd)
+                                        (Var 218 sinnd)
                                         (RealBinOp
                                             (FunctionCall
-                                                216 sin@__lpython_overloaded_0__sin
+                                                218 sin@__lpython_overloaded_0__sin
                                                 2 sin
-                                                [((Var 216 arraynd))]
+                                                [((Var 218 arraynd))]
                                                 (Array
                                                     (Real 8)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -1159,7 +1159,7 @@
                                         2 verifynd
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 216 arraynd)
+                                            (Var 218 arraynd)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1175,7 +1175,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 216 sinnd)
+                                            (Var 218 sinnd)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1204,11 +1204,11 @@
                             elemental_sum:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        216
                                         {
                                             array_a:
                                                 (Variable
-                                                    214
+                                                    216
                                                     array_a
                                                     []
                                                     Local
@@ -1229,7 +1229,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    214
+                                                    216
                                                     array_b
                                                     []
                                                     Local
@@ -1250,7 +1250,7 @@
                                                 ),
                                             array_c:
                                                 (Variable
-                                                    214
+                                                    216
                                                     array_c
                                                     []
                                                     Local
@@ -1271,7 +1271,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    214
+                                                    216
                                                     i
                                                     []
                                                     Local
@@ -1287,7 +1287,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    214
+                                                    216
                                                     j
                                                     []
                                                     Local
@@ -1303,7 +1303,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    214
+                                                    216
                                                     k
                                                     []
                                                     Local
@@ -1336,7 +1336,7 @@
                                     [verify1d_sum]
                                     []
                                     [(=
-                                        (Var 214 array_a)
+                                        (Var 216 array_a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1350,7 +1350,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 array_b)
+                                        (Var 216 array_b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1364,7 +1364,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 array_c)
+                                        (Var 216 array_c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1379,7 +1379,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 214 i)
+                                        ((Var 216 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -1391,16 +1391,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 214 array_a)
+                                                (Var 216 array_a)
                                                 [(()
-                                                (Var 214 i)
+                                                (Var 216 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 214 i)
+                                                (Var 216 i)
                                                 IntegerToReal
                                                 (Real 8)
                                                 ()
@@ -1410,7 +1410,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 214 j)
+                                        ((Var 216 j)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -1422,9 +1422,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 214 array_b)
+                                                (Var 216 array_b)
                                                 [(()
-                                                (Var 214 j)
+                                                (Var 216 j)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -1432,7 +1432,7 @@
                                             )
                                             (Cast
                                                 (IntegerBinOp
-                                                    (Var 214 j)
+                                                    (Var 216 j)
                                                     Add
                                                     (IntegerConstant 5 (Integer 4))
                                                     (Integer 4)
@@ -1446,10 +1446,10 @@
                                         )]
                                     )
                                     (=
-                                        (Var 214 array_c)
+                                        (Var 216 array_c)
                                         (RealBinOp
                                             (RealBinOp
-                                                (Var 214 array_a)
+                                                (Var 216 array_a)
                                                 Pow
                                                 (RealConstant
                                                     2.000000
@@ -1471,7 +1471,7 @@
                                                 )
                                                 Mul
                                                 (RealBinOp
-                                                    (Var 214 array_b)
+                                                    (Var 216 array_b)
                                                     Pow
                                                     (RealConstant
                                                         3.000000
@@ -1507,7 +1507,7 @@
                                         2 verify1d_sum
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 214 array_a)
+                                            (Var 216 array_a)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1519,7 +1519,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 214 array_b)
+                                            (Var 216 array_b)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1531,7 +1531,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 214 array_c)
+                                            (Var 216 array_c)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1554,11 +1554,11 @@
                             elemental_trig_identity:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        220
                                         {
                                             arraynd:
                                                 (Variable
-                                                    218
+                                                    220
                                                     arraynd
                                                     []
                                                     Local
@@ -1585,7 +1585,7 @@
                                                 ),
                                             cos@__lpython_overloaded_1__cos:
                                                 (ExternalSymbol
-                                                    218
+                                                    220
                                                     cos@__lpython_overloaded_1__cos
                                                     3 __lpython_overloaded_1__cos
                                                     numpy
@@ -1595,7 +1595,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    218
+                                                    220
                                                     eps
                                                     []
                                                     Local
@@ -1611,7 +1611,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    218
+                                                    220
                                                     i
                                                     []
                                                     Local
@@ -1627,7 +1627,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    218
+                                                    220
                                                     j
                                                     []
                                                     Local
@@ -1643,7 +1643,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    218
+                                                    220
                                                     k
                                                     []
                                                     Local
@@ -1659,7 +1659,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    218
+                                                    220
                                                     l
                                                     []
                                                     Local
@@ -1675,7 +1675,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    218
+                                                    220
                                                     newshape
                                                     []
                                                     Local
@@ -1696,7 +1696,7 @@
                                                 ),
                                             observed:
                                                 (Variable
-                                                    218
+                                                    220
                                                     observed
                                                     []
                                                     Local
@@ -1723,7 +1723,7 @@
                                                 ),
                                             observed1d:
                                                 (Variable
-                                                    218
+                                                    220
                                                     observed1d
                                                     []
                                                     Local
@@ -1744,7 +1744,7 @@
                                                 ),
                                             sin@__lpython_overloaded_1__sin:
                                                 (ExternalSymbol
-                                                    218
+                                                    220
                                                     sin@__lpython_overloaded_1__sin
                                                     3 __lpython_overloaded_1__sin
                                                     numpy
@@ -1771,7 +1771,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 218 eps)
+                                        (Var 220 eps)
                                         (Cast
                                             (RealConstant
                                                 0.000001
@@ -1787,7 +1787,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 arraynd)
+                                        (Var 220 arraynd)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1807,7 +1807,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 observed)
+                                        (Var 220 observed)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1827,7 +1827,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 observed1d)
+                                        (Var 220 observed1d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1842,7 +1842,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 218 i)
+                                        ((Var 220 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 64 (Integer 4))
@@ -1854,7 +1854,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 218 j)
+                                            ((Var 220 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 32 (Integer 4))
@@ -1866,7 +1866,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 218 k)
+                                                ((Var 220 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 8 (Integer 4))
@@ -1878,7 +1878,7 @@
                                                 (IntegerConstant 1 (Integer 4)))
                                                 [(DoLoop
                                                     ()
-                                                    ((Var 218 l)
+                                                    ((Var 220 l)
                                                     (IntegerConstant 0 (Integer 4))
                                                     (IntegerBinOp
                                                         (IntegerConstant 4 (Integer 4))
@@ -1890,18 +1890,18 @@
                                                     (IntegerConstant 1 (Integer 4)))
                                                     [(=
                                                         (ArrayItem
-                                                            (Var 218 arraynd)
+                                                            (Var 220 arraynd)
                                                             [(()
-                                                            (Var 218 i)
+                                                            (Var 220 i)
                                                             ())
                                                             (()
-                                                            (Var 218 j)
+                                                            (Var 220 j)
                                                             ())
                                                             (()
-                                                            (Var 218 k)
+                                                            (Var 220 k)
                                                             ())
                                                             (()
-                                                            (Var 218 l)
+                                                            (Var 220 l)
                                                             ())]
                                                             (Real 4)
                                                             RowMajor
@@ -1911,19 +1911,19 @@
                                                             (IntegerBinOp
                                                                 (IntegerBinOp
                                                                     (IntegerBinOp
-                                                                        (Var 218 i)
+                                                                        (Var 220 i)
                                                                         Add
-                                                                        (Var 218 j)
+                                                                        (Var 220 j)
                                                                         (Integer 4)
                                                                         ()
                                                                     )
                                                                     Add
-                                                                    (Var 218 k)
+                                                                    (Var 220 k)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
                                                                 Add
-                                                                (Var 218 l)
+                                                                (Var 220 l)
                                                                 (Integer 4)
                                                                 ()
                                                             )
@@ -1938,13 +1938,13 @@
                                         )]
                                     )
                                     (=
-                                        (Var 218 observed)
+                                        (Var 220 observed)
                                         (RealBinOp
                                             (RealBinOp
                                                 (FunctionCall
-                                                    218 sin@__lpython_overloaded_1__sin
+                                                    220 sin@__lpython_overloaded_1__sin
                                                     2 sin
-                                                    [((Var 218 arraynd))]
+                                                    [((Var 220 arraynd))]
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
@@ -1987,9 +1987,9 @@
                                             Add
                                             (RealBinOp
                                                 (FunctionCall
-                                                    218 cos@__lpython_overloaded_1__cos
+                                                    220 cos@__lpython_overloaded_1__cos
                                                     2 cos
-                                                    [((Var 218 arraynd))]
+                                                    [((Var 220 arraynd))]
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
@@ -2046,7 +2046,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 newshape)
+                                        (Var 220 newshape)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -2061,7 +2061,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 218 newshape)
+                                            (Var 220 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -2073,11 +2073,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 observed1d)
+                                        (Var 220 observed1d)
                                         (ArrayReshape
-                                            (Var 218 observed)
+                                            (Var 220 observed)
                                             (ArrayPhysicalCast
-                                                (Var 218 newshape)
+                                                (Var 220 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -2100,7 +2100,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 218 i)
+                                        ((Var 220 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 65536 (Integer 4))
@@ -2116,9 +2116,9 @@
                                                     Abs
                                                     [(RealBinOp
                                                         (ArrayItem
-                                                            (Var 218 observed1d)
+                                                            (Var 220 observed1d)
                                                             [(()
-                                                            (Var 218 i)
+                                                            (Var 220 i)
                                                             ())]
                                                             (Real 4)
                                                             RowMajor
@@ -2145,7 +2145,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 218 eps)
+                                                (Var 220 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2171,11 +2171,11 @@
                             verify1d:
                                 (Function
                                     (SymbolTable
-                                        209
+                                        211
                                         {
                                             array:
                                                 (Variable
-                                                    209
+                                                    211
                                                     array
                                                     []
                                                     InOut
@@ -2197,11 +2197,11 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        219
+                                                        221
                                                         {
                                                             sin@__lpython_overloaded_1__sin:
                                                                 (ExternalSymbol
-                                                                    219
+                                                                    221
                                                                     sin@__lpython_overloaded_1__sin
                                                                     3 __lpython_overloaded_1__sin
                                                                     numpy
@@ -2217,15 +2217,15 @@
                                                                 Abs
                                                                 [(RealBinOp
                                                                     (FunctionCall
-                                                                        219 sin@__lpython_overloaded_1__sin
+                                                                        221 sin@__lpython_overloaded_1__sin
                                                                         2 sin
                                                                         [((FunctionCall
-                                                                            219 sin@__lpython_overloaded_1__sin
+                                                                            221 sin@__lpython_overloaded_1__sin
                                                                             2 sin
                                                                             [((ArrayItem
-                                                                                (Var 209 array)
+                                                                                (Var 211 array)
                                                                                 [(()
-                                                                                (Var 209 i)
+                                                                                (Var 211 i)
                                                                                 ())]
                                                                                 (Real 4)
                                                                                 RowMajor
@@ -2241,9 +2241,9 @@
                                                                     )
                                                                     Sub
                                                                     (ArrayItem
-                                                                        (Var 209 result)
+                                                                        (Var 211 result)
                                                                         [(()
-                                                                        (Var 209 i)
+                                                                        (Var 211 i)
                                                                         ())]
                                                                         (Real 4)
                                                                         RowMajor
@@ -2257,7 +2257,7 @@
                                                                 ()
                                                             )
                                                             LtE
-                                                            (Var 209 eps)
+                                                            (Var 211 eps)
                                                             (Logical 4)
                                                             ()
                                                         )
@@ -2266,7 +2266,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    209
+                                                    211
                                                     eps
                                                     []
                                                     Local
@@ -2282,7 +2282,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    209
+                                                    211
                                                     i
                                                     []
                                                     Local
@@ -2298,7 +2298,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    209
+                                                    211
                                                     result
                                                     []
                                                     InOut
@@ -2319,7 +2319,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    209
+                                                    211
                                                     size
                                                     []
                                                     In
@@ -2362,11 +2362,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 209 array)
-                                    (Var 209 result)
-                                    (Var 209 size)]
+                                    [(Var 211 array)
+                                    (Var 211 result)
+                                    (Var 211 size)]
                                     [(=
-                                        (Var 209 eps)
+                                        (Var 211 eps)
                                         (Cast
                                             (RealConstant
                                                 0.000001
@@ -2383,10 +2383,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 209 i)
+                                        ((Var 211 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 209 size)
+                                            (Var 211 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2395,7 +2395,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            209 block
+                                            211 block
                                         )]
                                     )]
                                     ()
@@ -2407,11 +2407,11 @@
                             verify1d_mul:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             array_a:
                                                 (Variable
-                                                    213
+                                                    215
                                                     array_a
                                                     []
                                                     InOut
@@ -2432,7 +2432,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    213
+                                                    215
                                                     array_b
                                                     []
                                                     InOut
@@ -2453,7 +2453,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    213
+                                                    215
                                                     eps
                                                     []
                                                     Local
@@ -2469,7 +2469,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    213
+                                                    215
                                                     i
                                                     []
                                                     Local
@@ -2485,7 +2485,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    213
+                                                    215
                                                     result
                                                     []
                                                     InOut
@@ -2506,7 +2506,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    213
+                                                    215
                                                     size
                                                     []
                                                     In
@@ -2555,12 +2555,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 array_a)
-                                    (Var 213 array_b)
-                                    (Var 213 result)
-                                    (Var 213 size)]
+                                    [(Var 215 array_a)
+                                    (Var 215 array_b)
+                                    (Var 215 result)
+                                    (Var 215 size)]
                                     [(=
-                                        (Var 213 eps)
+                                        (Var 215 eps)
                                         (RealConstant
                                             0.000010
                                             (Real 8)
@@ -2569,10 +2569,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 i)
+                                        ((Var 215 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 213 size)
+                                            (Var 215 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2588,9 +2588,9 @@
                                                             (RealBinOp
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 213 array_a)
+                                                                        (Var 215 array_a)
                                                                         [(()
-                                                                        (Var 213 i)
+                                                                        (Var 215 i)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -2615,9 +2615,9 @@
                                                             Mul
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 213 array_b)
+                                                                    (Var 215 array_b)
                                                                     [(()
-                                                                    (Var 213 i)
+                                                                    (Var 215 i)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -2636,9 +2636,9 @@
                                                         )
                                                         Sub
                                                         (ArrayItem
-                                                            (Var 213 result)
+                                                            (Var 215 result)
                                                             [(()
-                                                            (Var 213 i)
+                                                            (Var 215 i)
                                                             ())]
                                                             (Real 8)
                                                             RowMajor
@@ -2652,7 +2652,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 213 eps)
+                                                (Var 215 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2668,11 +2668,11 @@
                             verify1d_sum:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             array_a:
                                                 (Variable
-                                                    212
+                                                    214
                                                     array_a
                                                     []
                                                     InOut
@@ -2693,7 +2693,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    212
+                                                    214
                                                     array_b
                                                     []
                                                     InOut
@@ -2714,7 +2714,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    212
+                                                    214
                                                     eps
                                                     []
                                                     Local
@@ -2730,7 +2730,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    212
+                                                    214
                                                     i
                                                     []
                                                     Local
@@ -2746,7 +2746,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    212
+                                                    214
                                                     result
                                                     []
                                                     InOut
@@ -2767,7 +2767,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    212
+                                                    214
                                                     size
                                                     []
                                                     In
@@ -2816,12 +2816,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 array_a)
-                                    (Var 212 array_b)
-                                    (Var 212 result)
-                                    (Var 212 size)]
+                                    [(Var 214 array_a)
+                                    (Var 214 array_b)
+                                    (Var 214 result)
+                                    (Var 214 size)]
                                     [(=
-                                        (Var 212 eps)
+                                        (Var 214 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -2830,10 +2830,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 212 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 212 size)
+                                            (Var 214 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2848,9 +2848,9 @@
                                                         (RealBinOp
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 212 array_a)
+                                                                    (Var 214 array_a)
                                                                     [(()
-                                                                    (Var 212 i)
+                                                                    (Var 214 i)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -2873,9 +2873,9 @@
                                                                 Mul
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 212 array_b)
+                                                                        (Var 214 array_b)
                                                                         [(()
-                                                                        (Var 212 i)
+                                                                        (Var 214 i)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -2897,9 +2897,9 @@
                                                         )
                                                         Sub
                                                         (ArrayItem
-                                                            (Var 212 result)
+                                                            (Var 214 result)
                                                             [(()
-                                                            (Var 212 i)
+                                                            (Var 214 i)
                                                             ())]
                                                             (Real 8)
                                                             RowMajor
@@ -2913,7 +2913,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 212 eps)
+                                                (Var 214 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2929,11 +2929,11 @@
                             verify2d:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             array:
                                                 (Variable
-                                                    211
+                                                    213
                                                     array
                                                     []
                                                     InOut
@@ -2957,16 +2957,16 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        223
+                                                        225
                                                         {
                                                             block:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        224
+                                                                        226
                                                                         {
                                                                             cos@__lpython_overloaded_0__cos:
                                                                                 (ExternalSymbol
-                                                                                    224
+                                                                                    226
                                                                                     cos@__lpython_overloaded_0__cos
                                                                                     3 __lpython_overloaded_0__cos
                                                                                     numpy
@@ -2983,15 +2983,15 @@
                                                                                 [(RealBinOp
                                                                                     (RealBinOp
                                                                                         (FunctionCall
-                                                                                            224 cos@__lpython_overloaded_0__cos
+                                                                                            226 cos@__lpython_overloaded_0__cos
                                                                                             2 cos
                                                                                             [((ArrayItem
-                                                                                                (Var 211 array)
+                                                                                                (Var 213 array)
                                                                                                 [(()
-                                                                                                (Var 211 i)
+                                                                                                (Var 213 i)
                                                                                                 ())
                                                                                                 (()
-                                                                                                (Var 211 j)
+                                                                                                (Var 213 j)
                                                                                                 ())]
                                                                                                 (Real 8)
                                                                                                 RowMajor
@@ -3011,12 +3011,12 @@
                                                                                     )
                                                                                     Sub
                                                                                     (ArrayItem
-                                                                                        (Var 211 result)
+                                                                                        (Var 213 result)
                                                                                         [(()
-                                                                                        (Var 211 i)
+                                                                                        (Var 213 i)
                                                                                         ())
                                                                                         (()
-                                                                                        (Var 211 j)
+                                                                                        (Var 213 j)
                                                                                         ())]
                                                                                         (Real 8)
                                                                                         RowMajor
@@ -3030,7 +3030,7 @@
                                                                                 ()
                                                                             )
                                                                             LtE
-                                                                            (Var 211 eps)
+                                                                            (Var 213 eps)
                                                                             (Logical 4)
                                                                             ()
                                                                         )
@@ -3041,10 +3041,10 @@
                                                     block
                                                     [(DoLoop
                                                         ()
-                                                        ((Var 211 j)
+                                                        ((Var 213 j)
                                                         (IntegerConstant 0 (Integer 4))
                                                         (IntegerBinOp
-                                                            (Var 211 size2)
+                                                            (Var 213 size2)
                                                             Sub
                                                             (IntegerConstant 1 (Integer 4))
                                                             (Integer 4)
@@ -3053,13 +3053,13 @@
                                                         (IntegerConstant 1 (Integer 4)))
                                                         [(BlockCall
                                                             -1
-                                                            223 block
+                                                            225 block
                                                         )]
                                                     )]
                                                 ),
                                             eps:
                                                 (Variable
-                                                    211
+                                                    213
                                                     eps
                                                     []
                                                     Local
@@ -3075,7 +3075,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    211
+                                                    213
                                                     i
                                                     []
                                                     Local
@@ -3091,7 +3091,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    211
+                                                    213
                                                     j
                                                     []
                                                     Local
@@ -3107,7 +3107,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    211
+                                                    213
                                                     result
                                                     []
                                                     InOut
@@ -3130,7 +3130,7 @@
                                                 ),
                                             size1:
                                                 (Variable
-                                                    211
+                                                    213
                                                     size1
                                                     []
                                                     In
@@ -3146,7 +3146,7 @@
                                                 ),
                                             size2:
                                                 (Variable
-                                                    211
+                                                    213
                                                     size2
                                                     []
                                                     In
@@ -3194,12 +3194,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 array)
-                                    (Var 211 result)
-                                    (Var 211 size1)
-                                    (Var 211 size2)]
+                                    [(Var 213 array)
+                                    (Var 213 result)
+                                    (Var 213 size1)
+                                    (Var 213 size2)]
                                     [(=
-                                        (Var 211 eps)
+                                        (Var 213 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -3208,10 +3208,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 213 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 211 size1)
+                                            (Var 213 size1)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -3220,7 +3220,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            211 block
+                                            213 block
                                         )]
                                     )]
                                     ()
@@ -3232,11 +3232,11 @@
                             verifynd:
                                 (Function
                                     (SymbolTable
-                                        210
+                                        212
                                         {
                                             array:
                                                 (Variable
-                                                    210
+                                                    212
                                                     array
                                                     []
                                                     InOut
@@ -3262,21 +3262,21 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        220
+                                                        222
                                                         {
                                                             block:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        221
+                                                                        223
                                                                         {
                                                                             block:
                                                                                 (Block
                                                                                     (SymbolTable
-                                                                                        222
+                                                                                        224
                                                                                         {
                                                                                             sin@__lpython_overloaded_0__sin:
                                                                                                 (ExternalSymbol
-                                                                                                    222
+                                                                                                    224
                                                                                                     sin@__lpython_overloaded_0__sin
                                                                                                     3 __lpython_overloaded_0__sin
                                                                                                     numpy
@@ -3293,18 +3293,18 @@
                                                                                                 [(RealBinOp
                                                                                                     (RealBinOp
                                                                                                         (FunctionCall
-                                                                                                            222 sin@__lpython_overloaded_0__sin
+                                                                                                            224 sin@__lpython_overloaded_0__sin
                                                                                                             2 sin
                                                                                                             [((ArrayItem
-                                                                                                                (Var 210 array)
+                                                                                                                (Var 212 array)
                                                                                                                 [(()
-                                                                                                                (Var 210 i)
+                                                                                                                (Var 212 i)
                                                                                                                 ())
                                                                                                                 (()
-                                                                                                                (Var 210 j)
+                                                                                                                (Var 212 j)
                                                                                                                 ())
                                                                                                                 (()
-                                                                                                                (Var 210 k)
+                                                                                                                (Var 212 k)
                                                                                                                 ())]
                                                                                                                 (Real 8)
                                                                                                                 RowMajor
@@ -3324,15 +3324,15 @@
                                                                                                     )
                                                                                                     Sub
                                                                                                     (ArrayItem
-                                                                                                        (Var 210 result)
+                                                                                                        (Var 212 result)
                                                                                                         [(()
-                                                                                                        (Var 210 i)
+                                                                                                        (Var 212 i)
                                                                                                         ())
                                                                                                         (()
-                                                                                                        (Var 210 j)
+                                                                                                        (Var 212 j)
                                                                                                         ())
                                                                                                         (()
-                                                                                                        (Var 210 k)
+                                                                                                        (Var 212 k)
                                                                                                         ())]
                                                                                                         (Real 8)
                                                                                                         RowMajor
@@ -3346,7 +3346,7 @@
                                                                                                 ()
                                                                                             )
                                                                                             LtE
-                                                                                            (Var 210 eps)
+                                                                                            (Var 212 eps)
                                                                                             (Logical 4)
                                                                                             ()
                                                                                         )
@@ -3357,10 +3357,10 @@
                                                                     block
                                                                     [(DoLoop
                                                                         ()
-                                                                        ((Var 210 k)
+                                                                        ((Var 212 k)
                                                                         (IntegerConstant 0 (Integer 4))
                                                                         (IntegerBinOp
-                                                                            (Var 210 size3)
+                                                                            (Var 212 size3)
                                                                             Sub
                                                                             (IntegerConstant 1 (Integer 4))
                                                                             (Integer 4)
@@ -3369,7 +3369,7 @@
                                                                         (IntegerConstant 1 (Integer 4)))
                                                                         [(BlockCall
                                                                             -1
-                                                                            221 block
+                                                                            223 block
                                                                         )]
                                                                     )]
                                                                 )
@@ -3377,10 +3377,10 @@
                                                     block
                                                     [(DoLoop
                                                         ()
-                                                        ((Var 210 j)
+                                                        ((Var 212 j)
                                                         (IntegerConstant 0 (Integer 4))
                                                         (IntegerBinOp
-                                                            (Var 210 size2)
+                                                            (Var 212 size2)
                                                             Sub
                                                             (IntegerConstant 1 (Integer 4))
                                                             (Integer 4)
@@ -3389,13 +3389,13 @@
                                                         (IntegerConstant 1 (Integer 4)))
                                                         [(BlockCall
                                                             -1
-                                                            220 block
+                                                            222 block
                                                         )]
                                                     )]
                                                 ),
                                             eps:
                                                 (Variable
-                                                    210
+                                                    212
                                                     eps
                                                     []
                                                     Local
@@ -3411,7 +3411,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    210
+                                                    212
                                                     i
                                                     []
                                                     Local
@@ -3427,7 +3427,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    210
+                                                    212
                                                     j
                                                     []
                                                     Local
@@ -3443,7 +3443,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    210
+                                                    212
                                                     k
                                                     []
                                                     Local
@@ -3459,7 +3459,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    210
+                                                    212
                                                     result
                                                     []
                                                     InOut
@@ -3484,7 +3484,7 @@
                                                 ),
                                             size1:
                                                 (Variable
-                                                    210
+                                                    212
                                                     size1
                                                     []
                                                     In
@@ -3500,7 +3500,7 @@
                                                 ),
                                             size2:
                                                 (Variable
-                                                    210
+                                                    212
                                                     size2
                                                     []
                                                     In
@@ -3516,7 +3516,7 @@
                                                 ),
                                             size3:
                                                 (Variable
-                                                    210
+                                                    212
                                                     size3
                                                     []
                                                     In
@@ -3569,13 +3569,13 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 210 array)
-                                    (Var 210 result)
-                                    (Var 210 size1)
-                                    (Var 210 size2)
-                                    (Var 210 size3)]
+                                    [(Var 212 array)
+                                    (Var 212 result)
+                                    (Var 212 size1)
+                                    (Var 212 size2)
+                                    (Var 212 size3)]
                                     [(=
-                                        (Var 210 eps)
+                                        (Var 212 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -3584,10 +3584,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 210 i)
+                                        ((Var 212 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 210 size1)
+                                            (Var 212 size1)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -3596,7 +3596,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            210 block
+                                            212 block
                                         )]
                                     )]
                                     ()
@@ -3616,11 +3616,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        243
+                        245
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    243
+                                    245
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -3632,7 +3632,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        243 __main__global_stmts
+                        245 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-expr10-efcbb1b.json
+++ b/tests/reference/asr-expr10-efcbb1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr10-efcbb1b.stdout",
-    "stdout_hash": "c5ed7ae39603a5bd33ffdf01f65d4b6a4c9b2048ae68b147a8822a61",
+    "stdout_hash": "e5af4d07e688e5d3f0fa40058fe7d249ce5675929b44d2858d9ac6fa",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr10-efcbb1b.stdout
+++ b/tests/reference/asr-expr10-efcbb1b.stdout
@@ -440,7 +440,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        127
+                        129
                         {
                             
                         })

--- a/tests/reference/asr-expr13-81bdb5a.json
+++ b/tests/reference/asr-expr13-81bdb5a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr13-81bdb5a.stdout",
-    "stdout_hash": "52fbcfcf2affa3cdaedd2221c4cc552b0d6f9656dccb3c40f294d5d4",
+    "stdout_hash": "3faa0920151f2cb40d38e75757bf51817410141b1d74fb55da4215e6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr13-81bdb5a.stdout
+++ b/tests/reference/asr-expr13-81bdb5a.stdout
@@ -459,7 +459,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        127
+                        129
                         {
                             
                         })

--- a/tests/reference/asr-expr7-480ba2f.json
+++ b/tests/reference/asr-expr7-480ba2f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr7-480ba2f.stdout",
-    "stdout_hash": "80d1d0b83919300e41f4130929820d827d95ec1e37c11b61e1118c60",
+    "stdout_hash": "eadbba4703440765da070a31d868859432c562349c5c2552222b70fc",
     "stderr": "asr-expr7-480ba2f.stderr",
     "stderr_hash": "6e9790ac88db1a9ead8f64a91ba8a6605de67167037908a74b77be0c",
     "returncode": 0

--- a/tests/reference/asr-expr7-480ba2f.stdout
+++ b/tests/reference/asr-expr7-480ba2f.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        131
                                         {
                                             
                                         })
@@ -344,11 +344,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        132
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    132
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -360,7 +360,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        132 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-expr_05-3a37324.json
+++ b/tests/reference/asr-expr_05-3a37324.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr_05-3a37324.stdout",
-    "stdout_hash": "f51978a9f1e69972ca659433fe4f3f262bd8ea9765963728e3cf48b9",
+    "stdout_hash": "a83c0f670181262a752f1ed741cb5d1f075b8bca5d6d4d7ae4c9c15c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr_05-3a37324.stdout
+++ b/tests/reference/asr-expr_05-3a37324.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        131
                                         {
                                             
                                         })
@@ -1612,11 +1612,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        132
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    132
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1628,7 +1628,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        132 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_01-682b1b2.json
+++ b/tests/reference/asr-generics_array_01-682b1b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_01-682b1b2.stdout",
-    "stdout_hash": "858b2887abdfb47daeedb1ee5531d6f9ae087561445413eb1b68e343",
+    "stdout_hash": "c4e52ae547d6c1e2d120fe108b5c332d2ec5155a275fc76da9dee893",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_01-682b1b2.stdout
+++ b/tests/reference/asr-generics_array_01-682b1b2.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_f_0:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    213
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -48,7 +48,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    211
+                                                    213
                                                     i
                                                     []
                                                     In
@@ -64,7 +64,7 @@
                                                 ),
                                             lst:
                                                 (Variable
-                                                    211
+                                                    213
                                                     lst
                                                     []
                                                     InOut
@@ -106,11 +106,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 lst)
-                                    (Var 211 i)]
+                                    [(Var 213 lst)
+                                    (Var 213 i)]
                                     [(=
                                         (ArrayItem
-                                            (Var 211 lst)
+                                            (Var 213 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -118,13 +118,13 @@
                                             RowMajor
                                             ()
                                         )
-                                        (Var 211 i)
+                                        (Var 213 i)
                                         ()
                                     )
                                     (=
-                                        (Var 211 _lpython_return_variable)
+                                        (Var 213 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 211 lst)
+                                            (Var 213 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -135,7 +135,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 213 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -144,7 +144,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             
                                         })
@@ -180,11 +180,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        209
+                                        211
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    209
+                                                    211
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -202,7 +202,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    209
+                                                    211
                                                     i
                                                     []
                                                     In
@@ -220,7 +220,7 @@
                                                 ),
                                             lst:
                                                 (Variable
-                                                    209
+                                                    211
                                                     lst
                                                     []
                                                     InOut
@@ -270,11 +270,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 209 lst)
-                                    (Var 209 i)]
+                                    [(Var 211 lst)
+                                    (Var 211 i)]
                                     [(=
                                         (ArrayItem
-                                            (Var 209 lst)
+                                            (Var 211 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -284,13 +284,13 @@
                                             RowMajor
                                             ()
                                         )
-                                        (Var 209 i)
+                                        (Var 211 i)
                                         ()
                                     )
                                     (=
-                                        (Var 209 _lpython_return_variable)
+                                        (Var 211 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 209 lst)
+                                            (Var 211 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -303,7 +303,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 209 _lpython_return_variable)
+                                    (Var 211 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -312,11 +312,11 @@
                             use_array:
                                 (Function
                                     (SymbolTable
-                                        210
+                                        212
                                         {
                                             array:
                                                 (Variable
-                                                    210
+                                                    212
                                                     array
                                                     []
                                                     Local
@@ -337,7 +337,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    210
+                                                    212
                                                     x
                                                     []
                                                     Local
@@ -370,7 +370,7 @@
                                     [__asr_generic_f_0]
                                     []
                                     [(=
-                                        (Var 210 array)
+                                        (Var 212 array)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -384,7 +384,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 210 x)
+                                        (Var 212 x)
                                         (IntegerConstant 69 (Integer 4))
                                         ()
                                     )
@@ -393,7 +393,7 @@
                                             2 __asr_generic_f_0
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 210 array)
+                                                (Var 212 array)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -404,7 +404,7 @@
                                                 )
                                                 ()
                                             ))
-                                            ((Var 210 x))]
+                                            ((Var 212 x))]
                                             (Integer 4)
                                             ()
                                             ()
@@ -429,11 +429,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        213
+                        215
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    213
+                                    215
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -445,7 +445,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        213 __main__global_stmts
+                        215 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_02-22c8dc1.json
+++ b/tests/reference/asr-generics_array_02-22c8dc1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_02-22c8dc1.stdout",
-    "stdout_hash": "136bafcd31760375183cb6455e98e71ed996dbb03069e24f86e253ed",
+    "stdout_hash": "75ccb4ee0e075aa0ed2e7da482eb1afe58c4bd1028306f083047014d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_02-22c8dc1.stdout
+++ b/tests/reference/asr-generics_array_02-22c8dc1.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_g_0:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        217
                                         {
                                             a:
                                                 (Variable
-                                                    215
+                                                    217
                                                     a
                                                     [n]
                                                     InOut
@@ -42,7 +42,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 215 n))]
+                                                        (Var 217 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -53,7 +53,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    215
+                                                    217
                                                     b
                                                     [n]
                                                     InOut
@@ -63,7 +63,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 215 n))]
+                                                        (Var 217 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -74,7 +74,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    215
+                                                    217
                                                     i
                                                     []
                                                     Local
@@ -90,7 +90,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    215
+                                                    217
                                                     n
                                                     []
                                                     In
@@ -106,7 +106,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    215
+                                                    217
                                                     r
                                                     [n]
                                                     Local
@@ -116,7 +116,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 215 n))]
+                                                        (Var 217 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -162,17 +162,17 @@
                                         .false.
                                     )
                                     [add_integer]
-                                    [(Var 215 n)
-                                    (Var 215 a)
-                                    (Var 215 b)]
+                                    [(Var 217 n)
+                                    (Var 217 a)
+                                    (Var 217 b)]
                                     [(=
-                                        (Var 215 r)
+                                        (Var 217 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Integer 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 215 n))]
+                                                (Var 217 n))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -181,10 +181,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 215 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 215 n)
+                                            (Var 217 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -193,9 +193,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 215 r)
+                                                (Var 217 r)
                                                 [(()
-                                                (Var 215 i)
+                                                (Var 217 i)
                                                 ())]
                                                 (Integer 4)
                                                 RowMajor
@@ -205,18 +205,18 @@
                                                 2 add_integer
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 215 a)
+                                                    (Var 217 a)
                                                     [(()
-                                                    (Var 215 i)
+                                                    (Var 217 i)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 215 b)
+                                                    (Var 217 b)
                                                     [(()
-                                                    (Var 215 i)
+                                                    (Var 217 i)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
@@ -231,7 +231,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 215 r)
+                                            (Var 217 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -251,11 +251,11 @@
                             __asr_generic_g_1:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        218
                                         {
                                             a:
                                                 (Variable
-                                                    216
+                                                    218
                                                     a
                                                     [n]
                                                     InOut
@@ -265,7 +265,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))]
+                                                        (Var 218 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -276,7 +276,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    216
+                                                    218
                                                     b
                                                     [n]
                                                     InOut
@@ -286,7 +286,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))]
+                                                        (Var 218 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -297,7 +297,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    216
+                                                    218
                                                     i
                                                     []
                                                     Local
@@ -313,7 +313,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    216
+                                                    218
                                                     n
                                                     []
                                                     In
@@ -329,7 +329,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    216
+                                                    218
                                                     r
                                                     [n]
                                                     Local
@@ -339,7 +339,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))]
+                                                        (Var 218 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -385,17 +385,17 @@
                                         .false.
                                     )
                                     [add_float]
-                                    [(Var 216 n)
-                                    (Var 216 a)
-                                    (Var 216 b)]
+                                    [(Var 218 n)
+                                    (Var 218 a)
+                                    (Var 218 b)]
                                     [(=
-                                        (Var 216 r)
+                                        (Var 218 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Real 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 216 n))]
+                                                (Var 218 n))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -404,10 +404,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 216 i)
+                                        ((Var 218 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 216 n)
+                                            (Var 218 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -416,9 +416,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 216 r)
+                                                (Var 218 r)
                                                 [(()
-                                                (Var 216 i)
+                                                (Var 218 i)
                                                 ())]
                                                 (Real 4)
                                                 RowMajor
@@ -428,18 +428,18 @@
                                                 2 add_float
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 216 a)
+                                                    (Var 218 a)
                                                     [(()
-                                                    (Var 216 i)
+                                                    (Var 218 i)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 216 b)
+                                                    (Var 218 b)
                                                     [(()
-                                                    (Var 216 i)
+                                                    (Var 218 i)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
@@ -454,7 +454,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 216 r)
+                                            (Var 218 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -474,7 +474,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        219
                                         {
                                             
                                         })
@@ -510,11 +510,11 @@
                             add:
                                 (Function
                                     (SymbolTable
-                                        209
+                                        211
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    209
+                                                    211
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -532,7 +532,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    209
+                                                    211
                                                     x
                                                     []
                                                     In
@@ -550,7 +550,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    209
+                                                    211
                                                     y
                                                     []
                                                     In
@@ -590,10 +590,10 @@
                                         .true.
                                     )
                                     []
-                                    [(Var 209 x)
-                                    (Var 209 y)]
+                                    [(Var 211 x)
+                                    (Var 211 y)]
                                     []
-                                    (Var 209 _lpython_return_variable)
+                                    (Var 211 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -602,11 +602,11 @@
                             add_float:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    213
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -622,7 +622,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    211
+                                                    213
                                                     x
                                                     []
                                                     In
@@ -638,7 +638,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    211
+                                                    213
                                                     y
                                                     []
                                                     In
@@ -670,21 +670,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 x)
-                                    (Var 211 y)]
+                                    [(Var 213 x)
+                                    (Var 213 y)]
                                     [(=
-                                        (Var 211 _lpython_return_variable)
+                                        (Var 213 _lpython_return_variable)
                                         (RealBinOp
-                                            (Var 211 x)
+                                            (Var 213 x)
                                             Add
-                                            (Var 211 y)
+                                            (Var 213 y)
                                             (Real 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 213 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -693,11 +693,11 @@
                             add_integer:
                                 (Function
                                     (SymbolTable
-                                        210
+                                        212
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    210
+                                                    212
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -713,7 +713,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    210
+                                                    212
                                                     x
                                                     []
                                                     In
@@ -729,7 +729,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    210
+                                                    212
                                                     y
                                                     []
                                                     In
@@ -761,21 +761,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 210 x)
-                                    (Var 210 y)]
+                                    [(Var 212 x)
+                                    (Var 212 y)]
                                     [(=
-                                        (Var 210 _lpython_return_variable)
+                                        (Var 212 _lpython_return_variable)
                                         (IntegerBinOp
-                                            (Var 210 x)
+                                            (Var 212 x)
                                             Add
-                                            (Var 210 y)
+                                            (Var 212 y)
                                             (Integer 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 210 _lpython_return_variable)
+                                    (Var 212 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -784,11 +784,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             a:
                                                 (Variable
-                                                    212
+                                                    214
                                                     a
                                                     [n]
                                                     InOut
@@ -800,7 +800,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 212 n))]
+                                                        (Var 214 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -811,7 +811,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    212
+                                                    214
                                                     b
                                                     [n]
                                                     InOut
@@ -823,7 +823,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 212 n))]
+                                                        (Var 214 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -834,7 +834,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    212
+                                                    214
                                                     i
                                                     []
                                                     Local
@@ -850,7 +850,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    212
+                                                    214
                                                     n
                                                     []
                                                     In
@@ -866,7 +866,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    212
+                                                    214
                                                     r
                                                     [n]
                                                     Local
@@ -878,7 +878,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 212 n))]
+                                                        (Var 214 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -928,11 +928,11 @@
                                         .false.
                                     )
                                     [add]
-                                    [(Var 212 n)
-                                    (Var 212 a)
-                                    (Var 212 b)]
+                                    [(Var 214 n)
+                                    (Var 214 a)
+                                    (Var 214 b)]
                                     [(=
-                                        (Var 212 r)
+                                        (Var 214 r)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -940,7 +940,7 @@
                                                     T
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 212 n))]
+                                                (Var 214 n))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -949,10 +949,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 212 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 212 n)
+                                            (Var 214 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -961,9 +961,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 212 r)
+                                                (Var 214 r)
                                                 [(()
-                                                (Var 212 i)
+                                                (Var 214 i)
                                                 ())]
                                                 (TypeParameter
                                                     T
@@ -975,9 +975,9 @@
                                                 2 add
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 212 a)
+                                                    (Var 214 a)
                                                     [(()
-                                                    (Var 212 i)
+                                                    (Var 214 i)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -986,9 +986,9 @@
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 212 b)
+                                                    (Var 214 b)
                                                     [(()
-                                                    (Var 212 i)
+                                                    (Var 214 i)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -1007,7 +1007,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 212 r)
+                                            (Var 214 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1029,11 +1029,11 @@
                             main:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             a_float:
                                                 (Variable
-                                                    213
+                                                    215
                                                     a_float
                                                     []
                                                     Local
@@ -1054,7 +1054,7 @@
                                                 ),
                                             a_int:
                                                 (Variable
-                                                    213
+                                                    215
                                                     a_int
                                                     []
                                                     Local
@@ -1075,7 +1075,7 @@
                                                 ),
                                             b_float:
                                                 (Variable
-                                                    213
+                                                    215
                                                     b_float
                                                     []
                                                     Local
@@ -1096,7 +1096,7 @@
                                                 ),
                                             b_int:
                                                 (Variable
-                                                    213
+                                                    215
                                                     b_int
                                                     []
                                                     Local
@@ -1135,7 +1135,7 @@
                                     __asr_generic_g_1]
                                     []
                                     [(=
-                                        (Var 213 a_int)
+                                        (Var 215 a_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1150,7 +1150,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 a_int)
+                                            (Var 215 a_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1162,7 +1162,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 b_int)
+                                        (Var 215 b_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1177,7 +1177,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 b_int)
+                                            (Var 215 b_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1193,7 +1193,7 @@
                                         ()
                                         [((IntegerConstant 1 (Integer 4)))
                                         ((ArrayPhysicalCast
-                                            (Var 213 a_int)
+                                            (Var 215 a_int)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1205,7 +1205,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 213 b_int)
+                                            (Var 215 b_int)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1219,7 +1219,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 a_float)
+                                        (Var 215 a_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1234,7 +1234,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 a_float)
+                                            (Var 215 a_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1257,7 +1257,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 b_float)
+                                        (Var 215 b_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1272,7 +1272,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 b_float)
+                                            (Var 215 b_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1299,7 +1299,7 @@
                                         ()
                                         [((IntegerConstant 1 (Integer 4)))
                                         ((ArrayPhysicalCast
-                                            (Var 213 a_float)
+                                            (Var 215 a_float)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1311,7 +1311,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 213 b_float)
+                                            (Var 215 b_float)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1359,11 +1359,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        218
+                        220
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    218
+                                    220
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1375,7 +1375,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        218 __main__global_stmts
+                        220 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_03-fb3706c.json
+++ b/tests/reference/asr-generics_array_03-fb3706c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_03-fb3706c.stdout",
-    "stdout_hash": "a8ed7b10746a478772e6795a5279e47d05361eb198507bf5537ee92b",
+    "stdout_hash": "604160a697a7d9fb44eb61417d9f9363a16563e903f31c861a5e7bf6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_03-fb3706c.stdout
+++ b/tests/reference/asr-generics_array_03-fb3706c.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_g_0:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        218
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    216
+                                                    218
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -43,9 +43,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))
+                                                        (Var 218 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 m))]
+                                                        (Var 218 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -56,7 +56,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    216
+                                                    218
                                                     a
                                                     [n
                                                     m]
@@ -67,9 +67,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))
+                                                        (Var 218 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 m))]
+                                                        (Var 218 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -80,7 +80,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    216
+                                                    218
                                                     b
                                                     [n
                                                     m]
@@ -91,9 +91,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))
+                                                        (Var 218 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 m))]
+                                                        (Var 218 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -104,7 +104,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    216
+                                                    218
                                                     i
                                                     []
                                                     Local
@@ -120,7 +120,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    216
+                                                    218
                                                     j
                                                     []
                                                     Local
@@ -136,7 +136,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    216
+                                                    218
                                                     m
                                                     []
                                                     In
@@ -152,7 +152,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    216
+                                                    218
                                                     n
                                                     []
                                                     In
@@ -168,7 +168,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    216
+                                                    218
                                                     r
                                                     [n
                                                     m]
@@ -179,9 +179,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))
+                                                        (Var 218 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 m))]
+                                                        (Var 218 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -255,20 +255,20 @@
                                         .false.
                                     )
                                     [add_integer]
-                                    [(Var 216 n)
-                                    (Var 216 m)
-                                    (Var 216 a)
-                                    (Var 216 b)]
+                                    [(Var 218 n)
+                                    (Var 218 m)
+                                    (Var 218 a)
+                                    (Var 218 b)]
                                     [(=
-                                        (Var 216 r)
+                                        (Var 218 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Integer 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 216 n))
+                                                (Var 218 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 216 m))]
+                                                (Var 218 m))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -277,10 +277,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 216 i)
+                                        ((Var 218 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 216 n)
+                                            (Var 218 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -289,10 +289,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 216 j)
+                                            ((Var 218 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 216 m)
+                                                (Var 218 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -301,12 +301,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 216 r)
+                                                    (Var 218 r)
                                                     [(()
-                                                    (Var 216 i)
+                                                    (Var 218 i)
                                                     ())
                                                     (()
-                                                    (Var 216 j)
+                                                    (Var 218 j)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
@@ -316,24 +316,24 @@
                                                     2 add_integer
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 216 a)
+                                                        (Var 218 a)
                                                         [(()
-                                                        (Var 216 i)
+                                                        (Var 218 i)
                                                         ())
                                                         (()
-                                                        (Var 216 j)
+                                                        (Var 218 j)
                                                         ())]
                                                         (Integer 4)
                                                         RowMajor
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 216 b)
+                                                        (Var 218 b)
                                                         [(()
-                                                        (Var 216 i)
+                                                        (Var 218 i)
                                                         ())
                                                         (()
-                                                        (Var 216 j)
+                                                        (Var 218 j)
                                                         ())]
                                                         (Integer 4)
                                                         RowMajor
@@ -349,7 +349,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 216 r)
+                                            (Var 218 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -363,7 +363,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 216 _lpython_return_variable)
+                                    (Var 218 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -372,11 +372,11 @@
                             __asr_generic_g_1:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        219
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    217
+                                                    219
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -387,9 +387,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 n))
+                                                        (Var 219 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 m))]
+                                                        (Var 219 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -400,7 +400,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    217
+                                                    219
                                                     a
                                                     [n
                                                     m]
@@ -411,9 +411,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 n))
+                                                        (Var 219 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 m))]
+                                                        (Var 219 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -424,7 +424,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    217
+                                                    219
                                                     b
                                                     [n
                                                     m]
@@ -435,9 +435,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 n))
+                                                        (Var 219 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 m))]
+                                                        (Var 219 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -448,7 +448,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    217
+                                                    219
                                                     i
                                                     []
                                                     Local
@@ -464,7 +464,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    217
+                                                    219
                                                     j
                                                     []
                                                     Local
@@ -480,7 +480,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    217
+                                                    219
                                                     m
                                                     []
                                                     In
@@ -496,7 +496,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    217
+                                                    219
                                                     n
                                                     []
                                                     In
@@ -512,7 +512,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    217
+                                                    219
                                                     r
                                                     [n
                                                     m]
@@ -523,9 +523,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 n))
+                                                        (Var 219 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 m))]
+                                                        (Var 219 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -599,20 +599,20 @@
                                         .false.
                                     )
                                     [add_float]
-                                    [(Var 217 n)
-                                    (Var 217 m)
-                                    (Var 217 a)
-                                    (Var 217 b)]
+                                    [(Var 219 n)
+                                    (Var 219 m)
+                                    (Var 219 a)
+                                    (Var 219 b)]
                                     [(=
-                                        (Var 217 r)
+                                        (Var 219 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Real 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 217 n))
+                                                (Var 219 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 217 m))]
+                                                (Var 219 m))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -621,10 +621,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 217 i)
+                                        ((Var 219 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 217 n)
+                                            (Var 219 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -633,10 +633,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 217 j)
+                                            ((Var 219 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 217 m)
+                                                (Var 219 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -645,12 +645,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 217 r)
+                                                    (Var 219 r)
                                                     [(()
-                                                    (Var 217 i)
+                                                    (Var 219 i)
                                                     ())
                                                     (()
-                                                    (Var 217 j)
+                                                    (Var 219 j)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
@@ -660,24 +660,24 @@
                                                     2 add_float
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 217 a)
+                                                        (Var 219 a)
                                                         [(()
-                                                        (Var 217 i)
+                                                        (Var 219 i)
                                                         ())
                                                         (()
-                                                        (Var 217 j)
+                                                        (Var 219 j)
                                                         ())]
                                                         (Real 4)
                                                         RowMajor
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 217 b)
+                                                        (Var 219 b)
                                                         [(()
-                                                        (Var 217 i)
+                                                        (Var 219 i)
                                                         ())
                                                         (()
-                                                        (Var 217 j)
+                                                        (Var 219 j)
                                                         ())]
                                                         (Real 4)
                                                         RowMajor
@@ -693,7 +693,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 217 r)
+                                            (Var 219 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -707,7 +707,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 217 _lpython_return_variable)
+                                    (Var 219 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -716,7 +716,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        220
                                         {
                                             
                                         })
@@ -752,11 +752,11 @@
                             add:
                                 (Function
                                     (SymbolTable
-                                        209
+                                        211
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    209
+                                                    211
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -774,7 +774,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    209
+                                                    211
                                                     x
                                                     []
                                                     In
@@ -792,7 +792,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    209
+                                                    211
                                                     y
                                                     []
                                                     In
@@ -832,10 +832,10 @@
                                         .true.
                                     )
                                     []
-                                    [(Var 209 x)
-                                    (Var 209 y)]
+                                    [(Var 211 x)
+                                    (Var 211 y)]
                                     []
-                                    (Var 209 _lpython_return_variable)
+                                    (Var 211 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -844,11 +844,11 @@
                             add_float:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    213
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -864,7 +864,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    211
+                                                    213
                                                     x
                                                     []
                                                     In
@@ -880,7 +880,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    211
+                                                    213
                                                     y
                                                     []
                                                     In
@@ -912,21 +912,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 x)
-                                    (Var 211 y)]
+                                    [(Var 213 x)
+                                    (Var 213 y)]
                                     [(=
-                                        (Var 211 _lpython_return_variable)
+                                        (Var 213 _lpython_return_variable)
                                         (RealBinOp
-                                            (Var 211 x)
+                                            (Var 213 x)
                                             Add
-                                            (Var 211 y)
+                                            (Var 213 y)
                                             (Real 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 213 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -935,11 +935,11 @@
                             add_integer:
                                 (Function
                                     (SymbolTable
-                                        210
+                                        212
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    210
+                                                    212
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -955,7 +955,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    210
+                                                    212
                                                     x
                                                     []
                                                     In
@@ -971,7 +971,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    210
+                                                    212
                                                     y
                                                     []
                                                     In
@@ -1003,21 +1003,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 210 x)
-                                    (Var 210 y)]
+                                    [(Var 212 x)
+                                    (Var 212 y)]
                                     [(=
-                                        (Var 210 _lpython_return_variable)
+                                        (Var 212 _lpython_return_variable)
                                         (IntegerBinOp
-                                            (Var 210 x)
+                                            (Var 212 x)
                                             Add
-                                            (Var 210 y)
+                                            (Var 212 y)
                                             (Integer 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 210 _lpython_return_variable)
+                                    (Var 212 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -1026,11 +1026,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    212
+                                                    214
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -1043,9 +1043,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 212 n))
+                                                        (Var 214 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 212 m))]
+                                                        (Var 214 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1056,7 +1056,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    212
+                                                    214
                                                     a
                                                     [n
                                                     m]
@@ -1069,9 +1069,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 212 n))
+                                                        (Var 214 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 212 m))]
+                                                        (Var 214 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1082,7 +1082,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    212
+                                                    214
                                                     b
                                                     [n
                                                     m]
@@ -1095,9 +1095,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 212 n))
+                                                        (Var 214 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 212 m))]
+                                                        (Var 214 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1108,7 +1108,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    212
+                                                    214
                                                     i
                                                     []
                                                     Local
@@ -1124,7 +1124,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    212
+                                                    214
                                                     j
                                                     []
                                                     Local
@@ -1140,7 +1140,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    212
+                                                    214
                                                     m
                                                     []
                                                     In
@@ -1156,7 +1156,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    212
+                                                    214
                                                     n
                                                     []
                                                     In
@@ -1172,7 +1172,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    212
+                                                    214
                                                     r
                                                     [n
                                                     m]
@@ -1185,9 +1185,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 212 n))
+                                                        (Var 214 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 212 m))]
+                                                        (Var 214 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1267,12 +1267,12 @@
                                         .false.
                                     )
                                     [add]
-                                    [(Var 212 n)
-                                    (Var 212 m)
-                                    (Var 212 a)
-                                    (Var 212 b)]
+                                    [(Var 214 n)
+                                    (Var 214 m)
+                                    (Var 214 a)
+                                    (Var 214 b)]
                                     [(=
-                                        (Var 212 r)
+                                        (Var 214 r)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1280,9 +1280,9 @@
                                                     T
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 212 n))
+                                                (Var 214 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 212 m))]
+                                                (Var 214 m))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -1291,10 +1291,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 212 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 212 n)
+                                            (Var 214 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -1303,10 +1303,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 212 j)
+                                            ((Var 214 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 212 m)
+                                                (Var 214 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -1315,12 +1315,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 212 r)
+                                                    (Var 214 r)
                                                     [(()
-                                                    (Var 212 i)
+                                                    (Var 214 i)
                                                     ())
                                                     (()
-                                                    (Var 212 j)
+                                                    (Var 214 j)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -1332,12 +1332,12 @@
                                                     2 add
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 212 a)
+                                                        (Var 214 a)
                                                         [(()
-                                                        (Var 212 i)
+                                                        (Var 214 i)
                                                         ())
                                                         (()
-                                                        (Var 212 j)
+                                                        (Var 214 j)
                                                         ())]
                                                         (TypeParameter
                                                             T
@@ -1346,12 +1346,12 @@
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 212 b)
+                                                        (Var 214 b)
                                                         [(()
-                                                        (Var 212 i)
+                                                        (Var 214 i)
                                                         ())
                                                         (()
-                                                        (Var 212 j)
+                                                        (Var 214 j)
                                                         ())]
                                                         (TypeParameter
                                                             T
@@ -1371,7 +1371,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 212 r)
+                                            (Var 214 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1387,7 +1387,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 212 _lpython_return_variable)
+                                    (Var 214 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -1414,11 +1414,11 @@
                             main:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             __lcompilers_dummy:
                                                 (Variable
-                                                    213
+                                                    215
                                                     __lcompilers_dummy
                                                     []
                                                     Local
@@ -1441,7 +1441,7 @@
                                                 ),
                                             __lcompilers_dummy1:
                                                 (Variable
-                                                    213
+                                                    215
                                                     __lcompilers_dummy1
                                                     []
                                                     Local
@@ -1464,7 +1464,7 @@
                                                 ),
                                             a_float:
                                                 (Variable
-                                                    213
+                                                    215
                                                     a_float
                                                     []
                                                     Local
@@ -1487,7 +1487,7 @@
                                                 ),
                                             a_int:
                                                 (Variable
-                                                    213
+                                                    215
                                                     a_int
                                                     []
                                                     Local
@@ -1510,7 +1510,7 @@
                                                 ),
                                             b_float:
                                                 (Variable
-                                                    213
+                                                    215
                                                     b_float
                                                     []
                                                     Local
@@ -1533,7 +1533,7 @@
                                                 ),
                                             b_int:
                                                 (Variable
-                                                    213
+                                                    215
                                                     b_int
                                                     []
                                                     Local
@@ -1574,7 +1574,7 @@
                                     __asr_generic_g_1]
                                     []
                                     [(=
-                                        (Var 213 a_int)
+                                        (Var 215 a_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1591,7 +1591,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 a_int)
+                                            (Var 215 a_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1606,7 +1606,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 b_int)
+                                        (Var 215 b_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1623,7 +1623,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 b_int)
+                                            (Var 215 b_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1638,14 +1638,14 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 __lcompilers_dummy)
+                                        (Var 215 __lcompilers_dummy)
                                         (FunctionCall
                                             2 __asr_generic_g_0
                                             ()
                                             [((IntegerConstant 1 (Integer 4)))
                                             ((IntegerConstant 1 (Integer 4)))
                                             ((ArrayPhysicalCast
-                                                (Var 213 a_int)
+                                                (Var 215 a_int)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1659,7 +1659,7 @@
                                                 ()
                                             ))
                                             ((ArrayPhysicalCast
-                                                (Var 213 b_int)
+                                                (Var 215 b_int)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1686,7 +1686,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 a_float)
+                                        (Var 215 a_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1703,7 +1703,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 a_float)
+                                            (Var 215 a_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1726,7 +1726,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 b_float)
+                                        (Var 215 b_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1743,7 +1743,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 b_float)
+                                            (Var 215 b_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1766,14 +1766,14 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 __lcompilers_dummy1)
+                                        (Var 215 __lcompilers_dummy1)
                                         (FunctionCall
                                             2 __asr_generic_g_1
                                             ()
                                             [((IntegerConstant 1 (Integer 4)))
                                             ((IntegerConstant 1 (Integer 4)))
                                             ((ArrayPhysicalCast
-                                                (Var 213 a_float)
+                                                (Var 215 a_float)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1787,7 +1787,7 @@
                                                 ()
                                             ))
                                             ((ArrayPhysicalCast
-                                                (Var 213 b_float)
+                                                (Var 215 b_float)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1848,11 +1848,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        219
+                        221
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    219
+                                    221
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1864,7 +1864,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        219 __main__global_stmts
+                        221 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-structs_05-fa98307.json
+++ b/tests/reference/asr-structs_05-fa98307.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_05-fa98307.stdout",
-    "stdout_hash": "9b4fef9f6e93aea69930c332d9b721428eecb719572b37abe43c8f16",
+    "stdout_hash": "370ee356dca208792b4f44a5657e7f2ce3da67e9ec213d3664139c70",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_05-fa98307.stdout
+++ b/tests/reference/asr-structs_05-fa98307.stdout
@@ -10,11 +10,11 @@
                             A:
                                 (StructType
                                     (SymbolTable
-                                        209
+                                        211
                                         {
                                             a:
                                                 (Variable
-                                                    209
+                                                    211
                                                     a
                                                     []
                                                     Local
@@ -30,7 +30,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    209
+                                                    211
                                                     b
                                                     []
                                                     Local
@@ -46,7 +46,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    209
+                                                    211
                                                     c
                                                     []
                                                     Local
@@ -62,7 +62,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    209
+                                                    211
                                                     d
                                                     []
                                                     Local
@@ -78,7 +78,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    209
+                                                    211
                                                     x
                                                     []
                                                     Local
@@ -94,7 +94,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    209
+                                                    211
                                                     y
                                                     []
                                                     Local
@@ -110,7 +110,7 @@
                                                 ),
                                             z:
                                                 (Variable
-                                                    209
+                                                    211
                                                     z
                                                     []
                                                     Local
@@ -151,7 +151,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        217
                                         {
                                             
                                         })
@@ -187,11 +187,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             y:
                                                 (Variable
-                                                    213
+                                                    215
                                                     y
                                                     []
                                                     Local
@@ -233,7 +233,7 @@
                                     update_2]
                                     []
                                     [(=
-                                        (Var 213 y)
+                                        (Var 215 y)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -250,7 +250,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 y)
+                                            (Var 215 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -310,7 +310,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 y)
+                                            (Var 215 y)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -372,7 +372,7 @@
                                         2 verify
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 213 y)
+                                            (Var 215 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -401,7 +401,7 @@
                                         2 update_1
                                         ()
                                         [((ArrayItem
-                                            (Var 213 y)
+                                            (Var 215 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -417,7 +417,7 @@
                                         2 update_2
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 213 y)
+                                            (Var 215 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -436,7 +436,7 @@
                                         2 verify
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 213 y)
+                                            (Var 215 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -470,11 +470,11 @@
                             update_1:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             s:
                                                 (Variable
-                                                    211
+                                                    213
                                                     s
                                                     []
                                                     InOut
@@ -509,11 +509,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 s)]
+                                    [(Var 213 s)]
                                     [(=
                                         (StructInstanceMember
-                                            (Var 211 s)
-                                            209 x
+                                            (Var 213 s)
+                                            211 x
                                             (Integer 4)
                                             ()
                                         )
@@ -522,8 +522,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 211 s)
-                                            209 y
+                                            (Var 213 s)
+                                            211 y
                                             (Real 8)
                                             ()
                                         )
@@ -535,8 +535,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 211 s)
-                                            209 z
+                                            (Var 213 s)
+                                            211 z
                                             (Integer 8)
                                             ()
                                         )
@@ -550,8 +550,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 211 s)
-                                            209 a
+                                            (Var 213 s)
+                                            211 a
                                             (Real 4)
                                             ()
                                         )
@@ -571,8 +571,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 211 s)
-                                            209 b
+                                            (Var 213 s)
+                                            211 b
                                             (Integer 2)
                                             ()
                                         )
@@ -586,8 +586,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 211 s)
-                                            209 c
+                                            (Var 213 s)
+                                            211 c
                                             (Integer 1)
                                             ()
                                         )
@@ -608,11 +608,11 @@
                             update_2:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             s:
                                                 (Variable
-                                                    212
+                                                    214
                                                     s
                                                     []
                                                     InOut
@@ -657,11 +657,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 s)]
+                                    [(Var 214 s)]
                                     [(=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 212 s)
+                                                (Var 214 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -671,7 +671,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            209 x
+                                            211 x
                                             (Integer 4)
                                             ()
                                         )
@@ -681,7 +681,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 212 s)
+                                                (Var 214 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -691,7 +691,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            209 y
+                                            211 y
                                             (Real 8)
                                             ()
                                         )
@@ -704,7 +704,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 212 s)
+                                                (Var 214 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -714,7 +714,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            209 z
+                                            211 z
                                             (Integer 8)
                                             ()
                                         )
@@ -729,7 +729,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 212 s)
+                                                (Var 214 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -739,7 +739,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            209 a
+                                            211 a
                                             (Real 4)
                                             ()
                                         )
@@ -760,7 +760,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 212 s)
+                                                (Var 214 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -770,7 +770,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            209 b
+                                            211 b
                                             (Integer 2)
                                             ()
                                         )
@@ -785,7 +785,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 212 s)
+                                                (Var 214 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -795,7 +795,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            209 c
+                                            211 c
                                             (Integer 1)
                                             ()
                                         )
@@ -816,11 +816,11 @@
                             verify:
                                 (Function
                                     (SymbolTable
-                                        210
+                                        212
                                         {
                                             eps:
                                                 (Variable
-                                                    210
+                                                    212
                                                     eps
                                                     []
                                                     Local
@@ -836,7 +836,7 @@
                                                 ),
                                             s:
                                                 (Variable
-                                                    210
+                                                    212
                                                     s
                                                     []
                                                     InOut
@@ -859,7 +859,7 @@
                                                 ),
                                             s0:
                                                 (Variable
-                                                    210
+                                                    212
                                                     s0
                                                     []
                                                     Local
@@ -877,7 +877,7 @@
                                                 ),
                                             s1:
                                                 (Variable
-                                                    210
+                                                    212
                                                     s1
                                                     []
                                                     Local
@@ -895,7 +895,7 @@
                                                 ),
                                             x1:
                                                 (Variable
-                                                    210
+                                                    212
                                                     x1
                                                     []
                                                     In
@@ -911,7 +911,7 @@
                                                 ),
                                             x2:
                                                 (Variable
-                                                    210
+                                                    212
                                                     x2
                                                     []
                                                     In
@@ -927,7 +927,7 @@
                                                 ),
                                             y1:
                                                 (Variable
-                                                    210
+                                                    212
                                                     y1
                                                     []
                                                     In
@@ -943,7 +943,7 @@
                                                 ),
                                             y2:
                                                 (Variable
-                                                    210
+                                                    212
                                                     y2
                                                     []
                                                     In
@@ -985,13 +985,13 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 210 s)
-                                    (Var 210 x1)
-                                    (Var 210 y1)
-                                    (Var 210 x2)
-                                    (Var 210 y2)]
+                                    [(Var 212 s)
+                                    (Var 212 x1)
+                                    (Var 212 y1)
+                                    (Var 212 x2)
+                                    (Var 212 y2)]
                                     [(=
-                                        (Var 210 eps)
+                                        (Var 212 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -999,9 +999,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 210 s0)
+                                        (Var 212 s0)
                                         (ArrayItem
-                                            (Var 210 s)
+                                            (Var 212 s)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1015,44 +1015,44 @@
                                     )
                                     (Print
                                         [(StructInstanceMember
-                                            (Var 210 s0)
-                                            209 x
+                                            (Var 212 s0)
+                                            211 x
                                             (Integer 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 210 s0)
-                                            209 y
+                                            (Var 212 s0)
+                                            211 y
                                             (Real 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 210 s0)
-                                            209 z
+                                            (Var 212 s0)
+                                            211 z
                                             (Integer 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 210 s0)
-                                            209 a
+                                            (Var 212 s0)
+                                            211 a
                                             (Real 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 210 s0)
-                                            209 b
+                                            (Var 212 s0)
+                                            211 b
                                             (Integer 2)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 210 s0)
-                                            209 c
+                                            (Var 212 s0)
+                                            211 c
                                             (Integer 1)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 210 s0)
-                                            209 d
+                                            (Var 212 s0)
+                                            211 d
                                             (Logical 4)
                                             ()
                                         )]
@@ -1062,13 +1062,13 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 210 s0)
-                                                209 x
+                                                (Var 212 s0)
+                                                211 x
                                                 (Integer 4)
                                                 ()
                                             )
                                             Eq
-                                            (Var 210 x1)
+                                            (Var 212 x1)
                                             (Logical 4)
                                             ()
                                         )
@@ -1080,13 +1080,13 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 210 s0)
-                                                        209 y
+                                                        (Var 212 s0)
+                                                        211 y
                                                         (Real 8)
                                                         ()
                                                     )
                                                     Sub
-                                                    (Var 210 y1)
+                                                    (Var 212 y1)
                                                     (Real 8)
                                                     ()
                                                 )]
@@ -1095,7 +1095,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 210 eps)
+                                            (Var 212 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -1104,14 +1104,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 210 s0)
-                                                209 z
+                                                (Var 212 s0)
+                                                211 z
                                                 (Integer 8)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 210 x1)
+                                                (Var 212 x1)
                                                 IntegerToInteger
                                                 (Integer 8)
                                                 ()
@@ -1127,14 +1127,14 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 210 s0)
-                                                        209 a
+                                                        (Var 212 s0)
+                                                        211 a
                                                         (Real 4)
                                                         ()
                                                     )
                                                     Sub
                                                     (Cast
-                                                        (Var 210 y1)
+                                                        (Var 212 y1)
                                                         RealToReal
                                                         (Real 4)
                                                         ()
@@ -1167,14 +1167,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 210 s0)
-                                                209 b
+                                                (Var 212 s0)
+                                                211 b
                                                 (Integer 2)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 210 x1)
+                                                (Var 212 x1)
                                                 IntegerToInteger
                                                 (Integer 2)
                                                 ()
@@ -1187,14 +1187,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 210 s0)
-                                                209 c
+                                                (Var 212 s0)
+                                                211 c
                                                 (Integer 1)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 210 x1)
+                                                (Var 212 x1)
                                                 IntegerToInteger
                                                 (Integer 1)
                                                 ()
@@ -1206,17 +1206,17 @@
                                     )
                                     (Assert
                                         (StructInstanceMember
-                                            (Var 210 s0)
-                                            209 d
+                                            (Var 212 s0)
+                                            211 d
                                             (Logical 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (=
-                                        (Var 210 s1)
+                                        (Var 212 s1)
                                         (ArrayItem
-                                            (Var 210 s)
+                                            (Var 212 s)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -1230,44 +1230,44 @@
                                     )
                                     (Print
                                         [(StructInstanceMember
-                                            (Var 210 s1)
-                                            209 x
+                                            (Var 212 s1)
+                                            211 x
                                             (Integer 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 210 s1)
-                                            209 y
+                                            (Var 212 s1)
+                                            211 y
                                             (Real 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 210 s1)
-                                            209 z
+                                            (Var 212 s1)
+                                            211 z
                                             (Integer 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 210 s1)
-                                            209 a
+                                            (Var 212 s1)
+                                            211 a
                                             (Real 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 210 s1)
-                                            209 b
+                                            (Var 212 s1)
+                                            211 b
                                             (Integer 2)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 210 s1)
-                                            209 c
+                                            (Var 212 s1)
+                                            211 c
                                             (Integer 1)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 210 s1)
-                                            209 d
+                                            (Var 212 s1)
+                                            211 d
                                             (Logical 4)
                                             ()
                                         )]
@@ -1277,13 +1277,13 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 210 s1)
-                                                209 x
+                                                (Var 212 s1)
+                                                211 x
                                                 (Integer 4)
                                                 ()
                                             )
                                             Eq
-                                            (Var 210 x2)
+                                            (Var 212 x2)
                                             (Logical 4)
                                             ()
                                         )
@@ -1295,13 +1295,13 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 210 s1)
-                                                        209 y
+                                                        (Var 212 s1)
+                                                        211 y
                                                         (Real 8)
                                                         ()
                                                     )
                                                     Sub
-                                                    (Var 210 y2)
+                                                    (Var 212 y2)
                                                     (Real 8)
                                                     ()
                                                 )]
@@ -1310,7 +1310,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 210 eps)
+                                            (Var 212 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -1319,14 +1319,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 210 s1)
-                                                209 z
+                                                (Var 212 s1)
+                                                211 z
                                                 (Integer 8)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 210 x2)
+                                                (Var 212 x2)
                                                 IntegerToInteger
                                                 (Integer 8)
                                                 ()
@@ -1342,14 +1342,14 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 210 s1)
-                                                        209 a
+                                                        (Var 212 s1)
+                                                        211 a
                                                         (Real 4)
                                                         ()
                                                     )
                                                     Sub
                                                     (Cast
-                                                        (Var 210 y2)
+                                                        (Var 212 y2)
                                                         RealToReal
                                                         (Real 4)
                                                         ()
@@ -1382,14 +1382,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 210 s1)
-                                                209 b
+                                                (Var 212 s1)
+                                                211 b
                                                 (Integer 2)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 210 x2)
+                                                (Var 212 x2)
                                                 IntegerToInteger
                                                 (Integer 2)
                                                 ()
@@ -1402,14 +1402,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 210 s1)
-                                                209 c
+                                                (Var 212 s1)
+                                                211 c
                                                 (Integer 1)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 210 x2)
+                                                (Var 212 x2)
                                                 IntegerToInteger
                                                 (Integer 1)
                                                 ()
@@ -1421,8 +1421,8 @@
                                     )
                                     (Assert
                                         (StructInstanceMember
-                                            (Var 210 s1)
-                                            209 d
+                                            (Var 212 s1)
+                                            211 d
                                             (Logical 4)
                                             ()
                                         )
@@ -1445,11 +1445,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        216
+                        218
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    216
+                                    218
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1461,7 +1461,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        216 __main__global_stmts
+                        218 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_bin-52ba9fa.json
+++ b/tests/reference/asr-test_builtin_bin-52ba9fa.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_bin-52ba9fa.stdout",
-    "stdout_hash": "5d3860eec54d8b3d02d591fac9218c8a82507da0fe5f1ab9a5001563",
+    "stdout_hash": "8fd060dd84db4f7c18de2d216cefcccc5515af6e6f5a770f65c1b71a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_bin-52ba9fa.stdout
+++ b/tests/reference/asr-test_builtin_bin-52ba9fa.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        127
+                                        129
                                         {
                                             
                                         })
@@ -244,11 +244,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        128
+                        130
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    128
+                                    130
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -260,7 +260,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        128 __main__global_stmts
+                        130 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_bool-330223a.json
+++ b/tests/reference/asr-test_builtin_bool-330223a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_bool-330223a.stdout",
-    "stdout_hash": "98f3a326f1d3e8ad110b1d3452036ecca9cd4b347d66d9d876029f92",
+    "stdout_hash": "e98ced1a47246ef02452991e9ceaa2d49b9120834fe8092966fe015e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_bool-330223a.stdout
+++ b/tests/reference/asr-test_builtin_bool-330223a.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        127
+                                        129
                                         {
                                             
                                         })
@@ -868,11 +868,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        128
+                        130
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    128
+                                    130
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -884,7 +884,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        128 __main__global_stmts
+                        130 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_hex-64bd268.json
+++ b/tests/reference/asr-test_builtin_hex-64bd268.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_hex-64bd268.stdout",
-    "stdout_hash": "68d17e2bc0d604fef0be0c0c170c4bf27b20195008467579affd682e",
+    "stdout_hash": "6e6192771598830edbd7d8a833184396f040b182b9004af5ffb3c599",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_hex-64bd268.stdout
+++ b/tests/reference/asr-test_builtin_hex-64bd268.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        127
+                                        129
                                         {
                                             
                                         })
@@ -219,11 +219,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        128
+                        130
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    128
+                                    130
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -235,7 +235,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        128 __main__global_stmts
+                        130 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_oct-20b9066.json
+++ b/tests/reference/asr-test_builtin_oct-20b9066.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_oct-20b9066.stdout",
-    "stdout_hash": "0c387ee657c68e4b0dfa88365ef68b8f5b41e86b46ba8c6c64bbc405",
+    "stdout_hash": "a3b3f11d9cbcb6f57d5b23e364c26ced7b915e8c72eded358f01d9cd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_oct-20b9066.stdout
+++ b/tests/reference/asr-test_builtin_oct-20b9066.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        127
+                                        129
                                         {
                                             
                                         })
@@ -219,11 +219,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        128
+                        130
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    128
+                                    130
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -235,7 +235,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        128 __main__global_stmts
+                        130 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_pow-f02fcda.json
+++ b/tests/reference/asr-test_builtin_pow-f02fcda.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_pow-f02fcda.stdout",
-    "stdout_hash": "c543a298dce8076489dd47f639245a3766604167d487d6371b87f30b",
+    "stdout_hash": "b0aa9ff1f31769b515e2aedd650656b6a53676d5bf276e6b9a4b12b9",
     "stderr": "asr-test_builtin_pow-f02fcda.stderr",
     "stderr_hash": "859ce76c74748f2d32c7eab92cfbba789a78d4cbf5818646b99806ea",
     "returncode": 0

--- a/tests/reference/asr-test_builtin_pow-f02fcda.stdout
+++ b/tests/reference/asr-test_builtin_pow-f02fcda.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        127
+                                        129
                                         {
                                             
                                         })
@@ -1880,11 +1880,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        128
+                        130
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    128
+                                    130
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1896,7 +1896,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        128 __main__global_stmts
+                        130 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_round-7417a21.json
+++ b/tests/reference/asr-test_builtin_round-7417a21.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_round-7417a21.stdout",
-    "stdout_hash": "daa107175f28069c0297bd7cc86b989667df02426dfecb6c114a46e0",
+    "stdout_hash": "9fcfa25b2101c8a11d06e0ae473edee98c3c76beeb20fceb1e5f528d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_round-7417a21.stdout
+++ b/tests/reference/asr-test_builtin_round-7417a21.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        127
+                                        129
                                         {
                                             
                                         })
@@ -886,11 +886,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        128
+                        130
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    128
+                                    130
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -902,7 +902,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        128 __main__global_stmts
+                        130 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_complex_01-a6def58.json
+++ b/tests/reference/asr-test_complex_01-a6def58.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_complex_01-a6def58.stdout",
-    "stdout_hash": "413be8dda53bafec80f0a34ea2c1cfbf54a68748cfc4c621a297f7e9",
+    "stdout_hash": "f0bab05549d2ee9805936995e3f111a308efc78a61ce593d2c765339",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_complex_01-a6def58.stdout
+++ b/tests/reference/asr-test_complex_01-a6def58.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        131
+                                        133
                                         {
                                             
                                         })
@@ -1975,11 +1975,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        132
+                        134
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    132
+                                    134
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1991,7 +1991,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        132 __main__global_stmts
+                        134 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_complex_02-782ba2d.json
+++ b/tests/reference/asr-test_complex_02-782ba2d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_complex_02-782ba2d.stdout",
-    "stdout_hash": "a045cd28e792ea5970e5e9cd8d26f16bbe9116222e257c5891881bc4",
+    "stdout_hash": "8855f80a3c24a954dd0d003ef093368456a95c20b7d723ddd8a01c81",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_complex_02-782ba2d.stdout
+++ b/tests/reference/asr-test_complex_02-782ba2d.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        130
+                                        132
                                         {
                                             
                                         })
@@ -691,11 +691,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        131
+                        133
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    131
+                                    133
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -707,7 +707,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        131 __main__global_stmts
+                        133 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_max_min-3c2fc51.json
+++ b/tests/reference/asr-test_max_min-3c2fc51.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_max_min-3c2fc51.stdout",
-    "stdout_hash": "96ed5fcfc8bdf6ce1767b4c129e97164760147f3dc1f9bcae482f1ac",
+    "stdout_hash": "e67150b066db479e51b74178342475bc51b3e56bc715d5c4b4495693",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_max_min-3c2fc51.stdout
+++ b/tests/reference/asr-test_max_min-3c2fc51.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        131
+                                        133
                                         {
                                             
                                         })
@@ -785,11 +785,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        132
+                        134
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    132
+                                    134
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -801,7 +801,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        132 __main__global_stmts
+                        134 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_numpy_03-e600a49.json
+++ b/tests/reference/asr-test_numpy_03-e600a49.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_03-e600a49.stdout",
-    "stdout_hash": "670ab328536003e6558e9b2eb7cfa7e20faad72daed6ea34e201321d",
+    "stdout_hash": "7f77da6be087aeb05ea730aeac6010a55558cfde8497bbbda2940736",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_03-e600a49.stdout
+++ b/tests/reference/asr-test_numpy_03-e600a49.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        226
+                                        228
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             test_1d_to_nd:
                                 (Function
                                     (SymbolTable
-                                        210
+                                        212
                                         {
                                             a:
                                                 (Variable
-                                                    210
+                                                    212
                                                     a
                                                     []
                                                     Local
@@ -73,7 +73,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    210
+                                                    212
                                                     b
                                                     []
                                                     Local
@@ -94,7 +94,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    210
+                                                    212
                                                     c
                                                     []
                                                     Local
@@ -119,7 +119,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    210
+                                                    212
                                                     d
                                                     []
                                                     InOut
@@ -140,7 +140,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    210
+                                                    212
                                                     eps
                                                     []
                                                     Local
@@ -156,7 +156,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    210
+                                                    212
                                                     i
                                                     []
                                                     Local
@@ -172,7 +172,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    210
+                                                    212
                                                     j
                                                     []
                                                     Local
@@ -188,7 +188,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    210
+                                                    212
                                                     k
                                                     []
                                                     Local
@@ -204,7 +204,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    210
+                                                    212
                                                     l
                                                     []
                                                     Local
@@ -220,7 +220,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    210
+                                                    212
                                                     newshape
                                                     []
                                                     Local
@@ -241,7 +241,7 @@
                                                 ),
                                             newshape1:
                                                 (Variable
-                                                    210
+                                                    212
                                                     newshape1
                                                     []
                                                     Local
@@ -282,9 +282,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 210 d)]
+                                    [(Var 212 d)]
                                     [(=
-                                        (Var 210 eps)
+                                        (Var 212 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -292,7 +292,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 210 b)
+                                        (Var 212 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -307,7 +307,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 210 k)
+                                        ((Var 212 k)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -318,10 +318,10 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
-                                            (Var 210 i)
+                                            (Var 212 i)
                                             (IntrinsicScalarFunction
                                                 FloorDiv
-                                                [(Var 210 k)
+                                                [(Var 212 k)
                                                 (IntegerConstant 16 (Integer 4))]
                                                 0
                                                 (Integer 4)
@@ -330,12 +330,12 @@
                                             ()
                                         )
                                         (=
-                                            (Var 210 j)
+                                            (Var 212 j)
                                             (IntegerBinOp
-                                                (Var 210 k)
+                                                (Var 212 k)
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 210 i)
+                                                    (Var 212 i)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -348,9 +348,9 @@
                                         )
                                         (=
                                             (ArrayItem
-                                                (Var 210 b)
+                                                (Var 212 b)
                                                 [(()
-                                                (Var 210 k)
+                                                (Var 212 k)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -359,9 +359,9 @@
                                             (RealBinOp
                                                 (Cast
                                                     (IntegerBinOp
-                                                        (Var 210 i)
+                                                        (Var 212 i)
                                                         Add
-                                                        (Var 210 j)
+                                                        (Var 212 j)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -381,7 +381,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 210 a)
+                                        (Var 212 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -397,7 +397,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 210 newshape)
+                                        (Var 212 newshape)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -412,7 +412,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 210 newshape)
+                                            (Var 212 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -425,7 +425,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 210 newshape)
+                                            (Var 212 newshape)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -437,11 +437,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 210 a)
+                                        (Var 212 a)
                                         (ArrayReshape
-                                            (Var 210 b)
+                                            (Var 212 b)
                                             (ArrayPhysicalCast
-                                                (Var 210 newshape)
+                                                (Var 212 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -464,7 +464,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 210 i)
+                                        ((Var 212 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -476,7 +476,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 210 j)
+                                            ((Var 212 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -493,12 +493,12 @@
                                                         [(RealBinOp
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 210 a)
+                                                                    (Var 212 a)
                                                                     [(()
-                                                                    (Var 210 i)
+                                                                    (Var 212 i)
                                                                     ())
                                                                     (()
-                                                                    (Var 210 j)
+                                                                    (Var 212 j)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -507,9 +507,9 @@
                                                                 Sub
                                                                 (Cast
                                                                     (IntegerBinOp
-                                                                        (Var 210 i)
+                                                                        (Var 212 i)
                                                                         Add
-                                                                        (Var 210 j)
+                                                                        (Var 212 j)
                                                                         (Integer 4)
                                                                         ()
                                                                     )
@@ -533,7 +533,7 @@
                                                         ()
                                                     )
                                                     LtE
-                                                    (Var 210 eps)
+                                                    (Var 212 eps)
                                                     (Logical 4)
                                                     ()
                                                 )
@@ -542,7 +542,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 210 c)
+                                        (Var 212 c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -560,7 +560,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 210 newshape1)
+                                        (Var 212 newshape1)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -575,7 +575,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 210 newshape1)
+                                            (Var 212 newshape1)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -588,7 +588,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 210 newshape1)
+                                            (Var 212 newshape1)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -601,7 +601,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 210 newshape1)
+                                            (Var 212 newshape1)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -613,11 +613,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 210 c)
+                                        (Var 212 c)
                                         (ArrayReshape
-                                            (Var 210 d)
+                                            (Var 212 d)
                                             (ArrayPhysicalCast
-                                                (Var 210 newshape1)
+                                                (Var 212 newshape1)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -640,7 +640,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 210 i)
+                                        ((Var 212 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -652,7 +652,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 210 j)
+                                            ((Var 212 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -664,7 +664,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 210 k)
+                                                ((Var 212 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 16 (Integer 4))
@@ -681,15 +681,15 @@
                                                             [(RealBinOp
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 210 c)
+                                                                        (Var 212 c)
                                                                         [(()
-                                                                        (Var 210 i)
+                                                                        (Var 212 i)
                                                                         ())
                                                                         (()
-                                                                        (Var 210 j)
+                                                                        (Var 212 j)
                                                                         ())
                                                                         (()
-                                                                        (Var 210 k)
+                                                                        (Var 212 k)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -699,14 +699,14 @@
                                                                     (Cast
                                                                         (IntegerBinOp
                                                                             (IntegerBinOp
-                                                                                (Var 210 i)
+                                                                                (Var 212 i)
                                                                                 Add
-                                                                                (Var 210 j)
+                                                                                (Var 212 j)
                                                                                 (Integer 4)
                                                                                 ()
                                                                             )
                                                                             Add
-                                                                            (Var 210 k)
+                                                                            (Var 212 k)
                                                                             (Integer 4)
                                                                             ()
                                                                         )
@@ -730,7 +730,7 @@
                                                             ()
                                                         )
                                                         LtE
-                                                        (Var 210 eps)
+                                                        (Var 212 eps)
                                                         (Logical 4)
                                                         ()
                                                     )
@@ -748,11 +748,11 @@
                             test_nd_to_1d:
                                 (Function
                                     (SymbolTable
-                                        209
+                                        211
                                         {
                                             a:
                                                 (Variable
-                                                    209
+                                                    211
                                                     a
                                                     []
                                                     InOut
@@ -775,7 +775,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    209
+                                                    211
                                                     b
                                                     []
                                                     Local
@@ -796,7 +796,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    209
+                                                    211
                                                     c
                                                     []
                                                     Local
@@ -821,7 +821,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    209
+                                                    211
                                                     d
                                                     []
                                                     Local
@@ -842,7 +842,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    209
+                                                    211
                                                     eps
                                                     []
                                                     Local
@@ -858,7 +858,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    209
+                                                    211
                                                     i
                                                     []
                                                     Local
@@ -874,7 +874,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    209
+                                                    211
                                                     j
                                                     []
                                                     Local
@@ -890,7 +890,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    209
+                                                    211
                                                     k
                                                     []
                                                     Local
@@ -906,7 +906,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    209
+                                                    211
                                                     l
                                                     []
                                                     Local
@@ -922,7 +922,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    209
+                                                    211
                                                     newshape
                                                     []
                                                     Local
@@ -943,7 +943,7 @@
                                                 ),
                                             newshape1:
                                                 (Variable
-                                                    209
+                                                    211
                                                     newshape1
                                                     []
                                                     Local
@@ -986,9 +986,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 209 a)]
+                                    [(Var 211 a)]
                                     [(=
-                                        (Var 209 eps)
+                                        (Var 211 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -996,7 +996,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 209 b)
+                                        (Var 211 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1010,7 +1010,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 209 newshape)
+                                        (Var 211 newshape)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1025,7 +1025,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 209 newshape)
+                                            (Var 211 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1037,11 +1037,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 209 b)
+                                        (Var 211 b)
                                         (ArrayReshape
-                                            (Var 209 a)
+                                            (Var 211 a)
                                             (ArrayPhysicalCast
-                                                (Var 209 newshape)
+                                                (Var 211 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -1064,7 +1064,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 209 k)
+                                        ((Var 211 k)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -1075,10 +1075,10 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
-                                            (Var 209 i)
+                                            (Var 211 i)
                                             (IntrinsicScalarFunction
                                                 FloorDiv
-                                                [(Var 209 k)
+                                                [(Var 211 k)
                                                 (IntegerConstant 16 (Integer 4))]
                                                 0
                                                 (Integer 4)
@@ -1087,12 +1087,12 @@
                                             ()
                                         )
                                         (=
-                                            (Var 209 j)
+                                            (Var 211 j)
                                             (IntegerBinOp
-                                                (Var 209 k)
+                                                (Var 211 k)
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 209 i)
+                                                    (Var 211 i)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -1110,9 +1110,9 @@
                                                     [(RealBinOp
                                                         (RealBinOp
                                                             (ArrayItem
-                                                                (Var 209 b)
+                                                                (Var 211 b)
                                                                 [(()
-                                                                (Var 209 k)
+                                                                (Var 211 k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
@@ -1121,9 +1121,9 @@
                                                             Sub
                                                             (Cast
                                                                 (IntegerBinOp
-                                                                    (Var 209 i)
+                                                                    (Var 211 i)
                                                                     Add
-                                                                    (Var 209 j)
+                                                                    (Var 211 j)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
@@ -1147,7 +1147,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 209 eps)
+                                                (Var 211 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -1155,7 +1155,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 209 c)
+                                        (Var 211 c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1173,7 +1173,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 209 c)
+                                        (Var 211 c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1181,462 +1181,6 @@
                                                 [((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 16 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 16 (Integer 4)))
-                                                ((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 16 (Integer 4)))]
-                                                FixedSizeArray
-                                            )
-                                            RowMajor
-                                        )
-                                        ()
-                                    )
-                                    (DoLoop
-                                        ()
-                                        ((Var 209 i)
-                                        (IntegerConstant 0 (Integer 4))
-                                        (IntegerBinOp
-                                            (IntegerConstant 16 (Integer 4))
-                                            Sub
-                                            (IntegerConstant 1 (Integer 4))
-                                            (Integer 4)
-                                            (IntegerConstant 15 (Integer 4))
-                                        )
-                                        (IntegerConstant 1 (Integer 4)))
-                                        [(DoLoop
-                                            ()
-                                            ((Var 209 j)
-                                            (IntegerConstant 0 (Integer 4))
-                                            (IntegerBinOp
-                                                (IntegerConstant 16 (Integer 4))
-                                                Sub
-                                                (IntegerConstant 1 (Integer 4))
-                                                (Integer 4)
-                                                (IntegerConstant 15 (Integer 4))
-                                            )
-                                            (IntegerConstant 1 (Integer 4)))
-                                            [(DoLoop
-                                                ()
-                                                ((Var 209 k)
-                                                (IntegerConstant 0 (Integer 4))
-                                                (IntegerBinOp
-                                                    (IntegerConstant 16 (Integer 4))
-                                                    Sub
-                                                    (IntegerConstant 1 (Integer 4))
-                                                    (Integer 4)
-                                                    (IntegerConstant 15 (Integer 4))
-                                                )
-                                                (IntegerConstant 1 (Integer 4)))
-                                                [(=
-                                                    (ArrayItem
-                                                        (Var 209 c)
-                                                        [(()
-                                                        (Var 209 i)
-                                                        ())
-                                                        (()
-                                                        (Var 209 j)
-                                                        ())
-                                                        (()
-                                                        (Var 209 k)
-                                                        ())]
-                                                        (Real 8)
-                                                        RowMajor
-                                                        ()
-                                                    )
-                                                    (RealBinOp
-                                                        (Cast
-                                                            (IntegerBinOp
-                                                                (IntegerBinOp
-                                                                    (Var 209 i)
-                                                                    Add
-                                                                    (Var 209 j)
-                                                                    (Integer 4)
-                                                                    ()
-                                                                )
-                                                                Add
-                                                                (Var 209 k)
-                                                                (Integer 4)
-                                                                ()
-                                                            )
-                                                            IntegerToReal
-                                                            (Real 8)
-                                                            ()
-                                                        )
-                                                        Add
-                                                        (RealConstant
-                                                            0.500000
-                                                            (Real 8)
-                                                        )
-                                                        (Real 8)
-                                                        ()
-                                                    )
-                                                    ()
-                                                )]
-                                            )]
-                                        )]
-                                    )
-                                    (=
-                                        (Var 209 d)
-                                        (ArrayConstant
-                                            []
-                                            (Array
-                                                (Real 8)
-                                                [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 4096 (Integer 4)))]
-                                                FixedSizeArray
-                                            )
-                                            RowMajor
-                                        )
-                                        ()
-                                    )
-                                    (=
-                                        (Var 209 newshape1)
-                                        (ArrayConstant
-                                            []
-                                            (Array
-                                                (Integer 4)
-                                                [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 1 (Integer 4)))]
-                                                FixedSizeArray
-                                            )
-                                            RowMajor
-                                        )
-                                        ()
-                                    )
-                                    (=
-                                        (ArrayItem
-                                            (Var 209 newshape1)
-                                            [(()
-                                            (IntegerConstant 0 (Integer 4))
-                                            ())]
-                                            (Integer 4)
-                                            RowMajor
-                                            ()
-                                        )
-                                        (IntegerConstant 4096 (Integer 4))
-                                        ()
-                                    )
-                                    (=
-                                        (Var 209 d)
-                                        (ArrayReshape
-                                            (Var 209 c)
-                                            (ArrayPhysicalCast
-                                                (Var 209 newshape1)
-                                                FixedSizeArray
-                                                DescriptorArray
-                                                (Array
-                                                    (Integer 4)
-                                                    [((IntegerConstant 0 (Integer 4))
-                                                    (IntegerConstant 1 (Integer 4)))]
-                                                    DescriptorArray
-                                                )
-                                                ()
-                                            )
-                                            (Array
-                                                (Real 8)
-                                                [(()
-                                                ())]
-                                                FixedSizeArray
-                                            )
-                                            ()
-                                        )
-                                        ()
-                                    )
-                                    (DoLoop
-                                        ()
-                                        ((Var 209 l)
-                                        (IntegerConstant 0 (Integer 4))
-                                        (IntegerBinOp
-                                            (IntegerConstant 4096 (Integer 4))
-                                            Sub
-                                            (IntegerConstant 1 (Integer 4))
-                                            (Integer 4)
-                                            (IntegerConstant 4095 (Integer 4))
-                                        )
-                                        (IntegerConstant 1 (Integer 4)))
-                                        [(=
-                                            (Var 209 i)
-                                            (Cast
-                                                (RealBinOp
-                                                    (Cast
-                                                        (Var 209 l)
-                                                        IntegerToReal
-                                                        (Real 8)
-                                                        ()
-                                                    )
-                                                    Div
-                                                    (Cast
-                                                        (IntegerConstant 256 (Integer 4))
-                                                        IntegerToReal
-                                                        (Real 8)
-                                                        (RealConstant
-                                                            256.000000
-                                                            (Real 8)
-                                                        )
-                                                    )
-                                                    (Real 8)
-                                                    ()
-                                                )
-                                                RealToInteger
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            ()
-                                        )
-                                        (=
-                                            (Var 209 j)
-                                            (IntrinsicScalarFunction
-                                                FloorDiv
-                                                [(IntegerBinOp
-                                                    (Var 209 l)
-                                                    Sub
-                                                    (IntegerBinOp
-                                                        (Var 209 i)
-                                                        Mul
-                                                        (IntegerConstant 256 (Integer 4))
-                                                        (Integer 4)
-                                                        ()
-                                                    )
-                                                    (Integer 4)
-                                                    ()
-                                                )
-                                                (IntegerConstant 16 (Integer 4))]
-                                                0
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            ()
-                                        )
-                                        (=
-                                            (Var 209 k)
-                                            (IntegerBinOp
-                                                (IntegerBinOp
-                                                    (Var 209 l)
-                                                    Sub
-                                                    (IntegerBinOp
-                                                        (Var 209 i)
-                                                        Mul
-                                                        (IntegerConstant 256 (Integer 4))
-                                                        (Integer 4)
-                                                        ()
-                                                    )
-                                                    (Integer 4)
-                                                    ()
-                                                )
-                                                Sub
-                                                (IntegerBinOp
-                                                    (Var 209 j)
-                                                    Mul
-                                                    (IntegerConstant 16 (Integer 4))
-                                                    (Integer 4)
-                                                    ()
-                                                )
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            ()
-                                        )
-                                        (Assert
-                                            (RealCompare
-                                                (IntrinsicScalarFunction
-                                                    Abs
-                                                    [(RealBinOp
-                                                        (RealBinOp
-                                                            (ArrayItem
-                                                                (Var 209 d)
-                                                                [(()
-                                                                (Var 209 l)
-                                                                ())]
-                                                                (Real 8)
-                                                                RowMajor
-                                                                ()
-                                                            )
-                                                            Sub
-                                                            (Cast
-                                                                (IntegerBinOp
-                                                                    (IntegerBinOp
-                                                                        (Var 209 i)
-                                                                        Add
-                                                                        (Var 209 j)
-                                                                        (Integer 4)
-                                                                        ()
-                                                                    )
-                                                                    Add
-                                                                    (Var 209 k)
-                                                                    (Integer 4)
-                                                                    ()
-                                                                )
-                                                                IntegerToReal
-                                                                (Real 8)
-                                                                ()
-                                                            )
-                                                            (Real 8)
-                                                            ()
-                                                        )
-                                                        Sub
-                                                        (RealConstant
-                                                            0.500000
-                                                            (Real 8)
-                                                        )
-                                                        (Real 8)
-                                                        ()
-                                                    )]
-                                                    0
-                                                    (Real 8)
-                                                    ()
-                                                )
-                                                LtE
-                                                (Var 209 eps)
-                                                (Logical 4)
-                                                ()
-                                            )
-                                            ()
-                                        )]
-                                    )]
-                                    ()
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            test_reshape_with_argument:
-                                (Function
-                                    (SymbolTable
-                                        211
-                                        {
-                                            a:
-                                                (Variable
-                                                    211
-                                                    a
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Array
-                                                        (Real 8)
-                                                        [((IntegerConstant 0 (Integer 4))
-                                                        (IntegerConstant 16 (Integer 4)))
-                                                        ((IntegerConstant 0 (Integer 4))
-                                                        (IntegerConstant 16 (Integer 4)))]
-                                                        FixedSizeArray
-                                                    )
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            d:
-                                                (Variable
-                                                    211
-                                                    d
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Array
-                                                        (Real 8)
-                                                        [((IntegerConstant 0 (Integer 4))
-                                                        (IntegerConstant 4096 (Integer 4)))]
-                                                        FixedSizeArray
-                                                    )
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            i:
-                                                (Variable
-                                                    211
-                                                    i
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            j:
-                                                (Variable
-                                                    211
-                                                    j
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            k:
-                                                (Variable
-                                                    211
-                                                    k
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            l:
-                                                (Variable
-                                                    211
-                                                    l
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                )
-                                        })
-                                    test_reshape_with_argument
-                                    (FunctionType
-                                        []
-                                        ()
-                                        Source
-                                        Implementation
-                                        ()
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        []
-                                        .false.
-                                    )
-                                    [test_nd_to_1d
-                                    test_1d_to_nd]
-                                    []
-                                    [(=
-                                        (Var 211 a)
-                                        (ArrayConstant
-                                            []
-                                            (Array
-                                                (Real 8)
-                                                [((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 16 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 16 (Integer 4)))]
@@ -1670,62 +1214,65 @@
                                                 (IntegerConstant 15 (Integer 4))
                                             )
                                             (IntegerConstant 1 (Integer 4)))
-                                            [(=
-                                                (ArrayItem
-                                                    (Var 211 a)
-                                                    [(()
-                                                    (Var 211 i)
-                                                    ())
-                                                    (()
-                                                    (Var 211 j)
-                                                    ())]
-                                                    (Real 8)
-                                                    RowMajor
-                                                    ()
+                                            [(DoLoop
+                                                ()
+                                                ((Var 211 k)
+                                                (IntegerConstant 0 (Integer 4))
+                                                (IntegerBinOp
+                                                    (IntegerConstant 16 (Integer 4))
+                                                    Sub
+                                                    (IntegerConstant 1 (Integer 4))
+                                                    (Integer 4)
+                                                    (IntegerConstant 15 (Integer 4))
                                                 )
-                                                (RealBinOp
-                                                    (Cast
-                                                        (IntegerBinOp
-                                                            (Var 211 i)
-                                                            Add
-                                                            (Var 211 j)
-                                                            (Integer 4)
+                                                (IntegerConstant 1 (Integer 4)))
+                                                [(=
+                                                    (ArrayItem
+                                                        (Var 211 c)
+                                                        [(()
+                                                        (Var 211 i)
+                                                        ())
+                                                        (()
+                                                        (Var 211 j)
+                                                        ())
+                                                        (()
+                                                        (Var 211 k)
+                                                        ())]
+                                                        (Real 8)
+                                                        RowMajor
+                                                        ()
+                                                    )
+                                                    (RealBinOp
+                                                        (Cast
+                                                            (IntegerBinOp
+                                                                (IntegerBinOp
+                                                                    (Var 211 i)
+                                                                    Add
+                                                                    (Var 211 j)
+                                                                    (Integer 4)
+                                                                    ()
+                                                                )
+                                                                Add
+                                                                (Var 211 k)
+                                                                (Integer 4)
+                                                                ()
+                                                            )
+                                                            IntegerToReal
+                                                            (Real 8)
                                                             ()
                                                         )
-                                                        IntegerToReal
+                                                        Add
+                                                        (RealConstant
+                                                            0.500000
+                                                            (Real 8)
+                                                        )
                                                         (Real 8)
                                                         ()
                                                     )
-                                                    Add
-                                                    (RealConstant
-                                                        0.500000
-                                                        (Real 8)
-                                                    )
-                                                    (Real 8)
                                                     ()
-                                                )
-                                                ()
+                                                )]
                                             )]
                                         )]
-                                    )
-                                    (SubroutineCall
-                                        2 test_nd_to_1d
-                                        ()
-                                        [((ArrayPhysicalCast
-                                            (Var 211 a)
-                                            FixedSizeArray
-                                            DescriptorArray
-                                            (Array
-                                                (Real 8)
-                                                [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 16 (Integer 4)))
-                                                ((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 16 (Integer 4)))]
-                                                DescriptorArray
-                                            )
-                                            ()
-                                        ))]
-                                        ()
                                     )
                                     (=
                                         (Var 211 d)
@@ -1738,6 +1285,59 @@
                                                 FixedSizeArray
                                             )
                                             RowMajor
+                                        )
+                                        ()
+                                    )
+                                    (=
+                                        (Var 211 newshape1)
+                                        (ArrayConstant
+                                            []
+                                            (Array
+                                                (Integer 4)
+                                                [((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 1 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            RowMajor
+                                        )
+                                        ()
+                                    )
+                                    (=
+                                        (ArrayItem
+                                            (Var 211 newshape1)
+                                            [(()
+                                            (IntegerConstant 0 (Integer 4))
+                                            ())]
+                                            (Integer 4)
+                                            RowMajor
+                                            ()
+                                        )
+                                        (IntegerConstant 4096 (Integer 4))
+                                        ()
+                                    )
+                                    (=
+                                        (Var 211 d)
+                                        (ArrayReshape
+                                            (Var 211 c)
+                                            (ArrayPhysicalCast
+                                                (Var 211 newshape1)
+                                                FixedSizeArray
+                                                DescriptorArray
+                                                (Array
+                                                    (Integer 4)
+                                                    [((IntegerConstant 0 (Integer 4))
+                                                    (IntegerConstant 1 (Integer 4)))]
+                                                    DescriptorArray
+                                                )
+                                                ()
+                                            )
+                                            (Array
+                                                (Real 8)
+                                                [(()
+                                                ())]
+                                                FixedSizeArray
+                                            )
+                                            ()
                                         )
                                         ()
                                     )
@@ -1835,11 +1435,411 @@
                                             )
                                             ()
                                         )
+                                        (Assert
+                                            (RealCompare
+                                                (IntrinsicScalarFunction
+                                                    Abs
+                                                    [(RealBinOp
+                                                        (RealBinOp
+                                                            (ArrayItem
+                                                                (Var 211 d)
+                                                                [(()
+                                                                (Var 211 l)
+                                                                ())]
+                                                                (Real 8)
+                                                                RowMajor
+                                                                ()
+                                                            )
+                                                            Sub
+                                                            (Cast
+                                                                (IntegerBinOp
+                                                                    (IntegerBinOp
+                                                                        (Var 211 i)
+                                                                        Add
+                                                                        (Var 211 j)
+                                                                        (Integer 4)
+                                                                        ()
+                                                                    )
+                                                                    Add
+                                                                    (Var 211 k)
+                                                                    (Integer 4)
+                                                                    ()
+                                                                )
+                                                                IntegerToReal
+                                                                (Real 8)
+                                                                ()
+                                                            )
+                                                            (Real 8)
+                                                            ()
+                                                        )
+                                                        Sub
+                                                        (RealConstant
+                                                            0.500000
+                                                            (Real 8)
+                                                        )
+                                                        (Real 8)
+                                                        ()
+                                                    )]
+                                                    0
+                                                    (Real 8)
+                                                    ()
+                                                )
+                                                LtE
+                                                (Var 211 eps)
+                                                (Logical 4)
+                                                ()
+                                            )
+                                            ()
+                                        )]
+                                    )]
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            test_reshape_with_argument:
+                                (Function
+                                    (SymbolTable
+                                        213
+                                        {
+                                            a:
+                                                (Variable
+                                                    213
+                                                    a
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 8)
+                                                        [((IntegerConstant 0 (Integer 4))
+                                                        (IntegerConstant 16 (Integer 4)))
+                                                        ((IntegerConstant 0 (Integer 4))
+                                                        (IntegerConstant 16 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            d:
+                                                (Variable
+                                                    213
+                                                    d
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 8)
+                                                        [((IntegerConstant 0 (Integer 4))
+                                                        (IntegerConstant 4096 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            i:
+                                                (Variable
+                                                    213
+                                                    i
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            j:
+                                                (Variable
+                                                    213
+                                                    j
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            k:
+                                                (Variable
+                                                    213
+                                                    k
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            l:
+                                                (Variable
+                                                    213
+                                                    l
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    test_reshape_with_argument
+                                    (FunctionType
+                                        []
+                                        ()
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    [test_nd_to_1d
+                                    test_1d_to_nd]
+                                    []
+                                    [(=
+                                        (Var 213 a)
+                                        (ArrayConstant
+                                            []
+                                            (Array
+                                                (Real 8)
+                                                [((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 16 (Integer 4)))
+                                                ((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 16 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            RowMajor
+                                        )
+                                        ()
+                                    )
+                                    (DoLoop
+                                        ()
+                                        ((Var 213 i)
+                                        (IntegerConstant 0 (Integer 4))
+                                        (IntegerBinOp
+                                            (IntegerConstant 16 (Integer 4))
+                                            Sub
+                                            (IntegerConstant 1 (Integer 4))
+                                            (Integer 4)
+                                            (IntegerConstant 15 (Integer 4))
+                                        )
+                                        (IntegerConstant 1 (Integer 4)))
+                                        [(DoLoop
+                                            ()
+                                            ((Var 213 j)
+                                            (IntegerConstant 0 (Integer 4))
+                                            (IntegerBinOp
+                                                (IntegerConstant 16 (Integer 4))
+                                                Sub
+                                                (IntegerConstant 1 (Integer 4))
+                                                (Integer 4)
+                                                (IntegerConstant 15 (Integer 4))
+                                            )
+                                            (IntegerConstant 1 (Integer 4)))
+                                            [(=
+                                                (ArrayItem
+                                                    (Var 213 a)
+                                                    [(()
+                                                    (Var 213 i)
+                                                    ())
+                                                    (()
+                                                    (Var 213 j)
+                                                    ())]
+                                                    (Real 8)
+                                                    RowMajor
+                                                    ()
+                                                )
+                                                (RealBinOp
+                                                    (Cast
+                                                        (IntegerBinOp
+                                                            (Var 213 i)
+                                                            Add
+                                                            (Var 213 j)
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        IntegerToReal
+                                                        (Real 8)
+                                                        ()
+                                                    )
+                                                    Add
+                                                    (RealConstant
+                                                        0.500000
+                                                        (Real 8)
+                                                    )
+                                                    (Real 8)
+                                                    ()
+                                                )
+                                                ()
+                                            )]
+                                        )]
+                                    )
+                                    (SubroutineCall
+                                        2 test_nd_to_1d
+                                        ()
+                                        [((ArrayPhysicalCast
+                                            (Var 213 a)
+                                            FixedSizeArray
+                                            DescriptorArray
+                                            (Array
+                                                (Real 8)
+                                                [((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 16 (Integer 4)))
+                                                ((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 16 (Integer 4)))]
+                                                DescriptorArray
+                                            )
+                                            ()
+                                        ))]
+                                        ()
+                                    )
+                                    (=
+                                        (Var 213 d)
+                                        (ArrayConstant
+                                            []
+                                            (Array
+                                                (Real 8)
+                                                [((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 4096 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            RowMajor
+                                        )
+                                        ()
+                                    )
+                                    (DoLoop
+                                        ()
+                                        ((Var 213 l)
+                                        (IntegerConstant 0 (Integer 4))
+                                        (IntegerBinOp
+                                            (IntegerConstant 4096 (Integer 4))
+                                            Sub
+                                            (IntegerConstant 1 (Integer 4))
+                                            (Integer 4)
+                                            (IntegerConstant 4095 (Integer 4))
+                                        )
+                                        (IntegerConstant 1 (Integer 4)))
+                                        [(=
+                                            (Var 213 i)
+                                            (Cast
+                                                (RealBinOp
+                                                    (Cast
+                                                        (Var 213 l)
+                                                        IntegerToReal
+                                                        (Real 8)
+                                                        ()
+                                                    )
+                                                    Div
+                                                    (Cast
+                                                        (IntegerConstant 256 (Integer 4))
+                                                        IntegerToReal
+                                                        (Real 8)
+                                                        (RealConstant
+                                                            256.000000
+                                                            (Real 8)
+                                                        )
+                                                    )
+                                                    (Real 8)
+                                                    ()
+                                                )
+                                                RealToInteger
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            ()
+                                        )
+                                        (=
+                                            (Var 213 j)
+                                            (IntrinsicScalarFunction
+                                                FloorDiv
+                                                [(IntegerBinOp
+                                                    (Var 213 l)
+                                                    Sub
+                                                    (IntegerBinOp
+                                                        (Var 213 i)
+                                                        Mul
+                                                        (IntegerConstant 256 (Integer 4))
+                                                        (Integer 4)
+                                                        ()
+                                                    )
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (IntegerConstant 16 (Integer 4))]
+                                                0
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            ()
+                                        )
+                                        (=
+                                            (Var 213 k)
+                                            (IntegerBinOp
+                                                (IntegerBinOp
+                                                    (Var 213 l)
+                                                    Sub
+                                                    (IntegerBinOp
+                                                        (Var 213 i)
+                                                        Mul
+                                                        (IntegerConstant 256 (Integer 4))
+                                                        (Integer 4)
+                                                        ()
+                                                    )
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                Sub
+                                                (IntegerBinOp
+                                                    (Var 213 j)
+                                                    Mul
+                                                    (IntegerConstant 16 (Integer 4))
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            ()
+                                        )
                                         (=
                                             (ArrayItem
-                                                (Var 211 d)
+                                                (Var 213 d)
                                                 [(()
-                                                (Var 211 l)
+                                                (Var 213 l)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -1849,14 +1849,14 @@
                                                 (Cast
                                                     (IntegerBinOp
                                                         (IntegerBinOp
-                                                            (Var 211 i)
+                                                            (Var 213 i)
                                                             Add
-                                                            (Var 211 j)
+                                                            (Var 213 j)
                                                             (Integer 4)
                                                             ()
                                                         )
                                                         Add
-                                                        (Var 211 k)
+                                                        (Var 213 k)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -1879,7 +1879,7 @@
                                         2 test_1d_to_nd
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 211 d)
+                                            (Var 213 d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1909,11 +1909,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        227
+                        229
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    227
+                                    229
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1925,7 +1925,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        227 __main__global_stmts
+                        229 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_numpy_04-ecbb614.json
+++ b/tests/reference/asr-test_numpy_04-ecbb614.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_04-ecbb614.stdout",
-    "stdout_hash": "4459d81753e360904daeb7fc1ea171c39abe1c8f06522bf0c1f4887f",
+    "stdout_hash": "1da36df6cdd76caa08790fe22f8bff306736f6f61ca8c0e9535528ed",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_04-ecbb614.stdout
+++ b/tests/reference/asr-test_numpy_04-ecbb614.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             
                                         })
@@ -46,7 +46,7 @@
                             check:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             
                                         })
@@ -89,11 +89,11 @@
                             test_array_01:
                                 (Function
                                     (SymbolTable
-                                        209
+                                        211
                                         {
                                             eps:
                                                 (Variable
-                                                    209
+                                                    211
                                                     eps
                                                     []
                                                     Local
@@ -109,7 +109,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    209
+                                                    211
                                                     x
                                                     []
                                                     Local
@@ -147,7 +147,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 209 x)
+                                        (Var 211 x)
                                         (ArrayConstant
                                             [(RealConstant
                                                 1.000000
@@ -172,7 +172,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 209 eps)
+                                        (Var 211 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -185,7 +185,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 209 x)
+                                                        (Var 211 x)
                                                         [(()
                                                         (IntegerConstant 0 (Integer 4))
                                                         ())]
@@ -206,7 +206,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 209 eps)
+                                            (Var 211 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -218,7 +218,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 209 x)
+                                                        (Var 211 x)
                                                         [(()
                                                         (IntegerConstant 1 (Integer 4))
                                                         ())]
@@ -239,7 +239,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 209 eps)
+                                            (Var 211 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -251,7 +251,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 209 x)
+                                                        (Var 211 x)
                                                         [(()
                                                         (IntegerConstant 2 (Integer 4))
                                                         ())]
@@ -272,7 +272,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 209 eps)
+                                            (Var 211 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -287,11 +287,11 @@
                             test_array_02:
                                 (Function
                                     (SymbolTable
-                                        210
+                                        212
                                         {
                                             eps:
                                                 (Variable
-                                                    210
+                                                    212
                                                     eps
                                                     []
                                                     Local
@@ -307,7 +307,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    210
+                                                    212
                                                     x
                                                     []
                                                     Local
@@ -345,7 +345,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 210 x)
+                                        (Var 212 x)
                                         (ArrayConstant
                                             [(IntegerConstant 1 (Integer 4))
                                             (IntegerConstant 2 (Integer 4))
@@ -361,7 +361,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 210 eps)
+                                        (Var 212 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -375,7 +375,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 210 x)
+                                                            (Var 212 x)
                                                             [(()
                                                             (IntegerConstant 0 (Integer 4))
                                                             ())]
@@ -397,7 +397,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 210 eps)
+                                            (Var 212 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -410,7 +410,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 210 x)
+                                                            (Var 212 x)
                                                             [(()
                                                             (IntegerConstant 1 (Integer 4))
                                                             ())]
@@ -432,7 +432,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 210 eps)
+                                            (Var 212 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -445,7 +445,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 210 x)
+                                                            (Var 212 x)
                                                             [(()
                                                             (IntegerConstant 2 (Integer 4))
                                                             ())]
@@ -467,7 +467,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 210 eps)
+                                            (Var 212 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -490,11 +490,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        213
+                        215
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    213
+                                    215
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -506,7 +506,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        213 __main__global_stmts
+                        215 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_pow-3f5d550.json
+++ b/tests/reference/asr-test_pow-3f5d550.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_pow-3f5d550.stdout",
-    "stdout_hash": "89ec94014873b239802f9b3a2d41a39176158472e40f8610d6befa1b",
+    "stdout_hash": "2e9aa5421687f0dc2a5b8aba48d887cef6c04c3d8e28569637396212",
     "stderr": "asr-test_pow-3f5d550.stderr",
     "stderr_hash": "3d950301563cce75654f28bf41f6f53428ed1f5ae997774345f374a3",
     "returncode": 0

--- a/tests/reference/asr-test_pow-3f5d550.stdout
+++ b/tests/reference/asr-test_pow-3f5d550.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        127
+                                        129
                                         {
                                             
                                         })
@@ -130,11 +130,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        128
+                        130
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    128
+                                    130
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -146,7 +146,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        128 __main__global_stmts
+                        130 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-vec_01-66ac423.json
+++ b/tests/reference/asr-vec_01-66ac423.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-vec_01-66ac423.stdout",
-    "stdout_hash": "84be4809b0edd01c29a2edddd0b356f186892eee7483820b8da22e24",
+    "stdout_hash": "2e2b41cdaa38cabb5b6dee642fdbade4259561a9ab1b06f21dce79f4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-vec_01-66ac423.stdout
+++ b/tests/reference/asr-vec_01-66ac423.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             loop_vec:
                                 (Function
                                     (SymbolTable
-                                        209
+                                        211
                                         {
                                             a:
                                                 (Variable
-                                                    209
+                                                    211
                                                     a
                                                     []
                                                     Local
@@ -71,7 +71,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    209
+                                                    211
                                                     b
                                                     []
                                                     Local
@@ -92,7 +92,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    209
+                                                    211
                                                     i
                                                     []
                                                     Local
@@ -125,7 +125,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 209 a)
+                                        (Var 211 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -139,7 +139,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 209 b)
+                                        (Var 211 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -154,7 +154,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 209 i)
+                                        ((Var 211 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -166,9 +166,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 209 b)
+                                                (Var 211 b)
                                                 [(()
-                                                (Var 209 i)
+                                                (Var 211 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -183,7 +183,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 209 i)
+                                        ((Var 211 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -195,18 +195,18 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 209 a)
+                                                (Var 211 a)
                                                 [(()
-                                                (Var 209 i)
+                                                (Var 211 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (ArrayItem
-                                                (Var 209 b)
+                                                (Var 211 b)
                                                 [(()
-                                                (Var 209 i)
+                                                (Var 211 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -217,7 +217,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 209 i)
+                                        ((Var 211 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -230,9 +230,9 @@
                                         [(Assert
                                             (RealCompare
                                                 (ArrayItem
-                                                    (Var 209 a)
+                                                    (Var 211 a)
                                                     [(()
-                                                    (Var 209 i)
+                                                    (Var 211 i)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -266,11 +266,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        214
+                        216
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    214
+                                    216
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -282,7 +282,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        214 __main__global_stmts
+                        216 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/pass_loop_vectorise-vec_01-be9985e.json
+++ b/tests/reference/pass_loop_vectorise-vec_01-be9985e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_loop_vectorise-vec_01-be9985e.stdout",
-    "stdout_hash": "00276d79d08a473e1e39d5a40747ec12d8111ae29d6ab0e90a19ca1f",
+    "stdout_hash": "20734037fd1fecf92e8421c6b558117fc0a2831ddbcbd1b2877485d4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_loop_vectorise-vec_01-be9985e.stdout
+++ b/tests/reference/pass_loop_vectorise-vec_01-be9985e.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             loop_vec:
                                 (Function
                                     (SymbolTable
-                                        209
+                                        211
                                         {
                                             a:
                                                 (Variable
-                                                    209
+                                                    211
                                                     a
                                                     []
                                                     Local
@@ -71,7 +71,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    209
+                                                    211
                                                     b
                                                     []
                                                     Local
@@ -92,7 +92,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    209
+                                                    211
                                                     i
                                                     []
                                                     Local
@@ -109,11 +109,11 @@
                                             vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization:
                                                 (Function
                                                     (SymbolTable
-                                                        215
+                                                        217
                                                         {
                                                             __1_k:
                                                                 (Variable
-                                                                    215
+                                                                    217
                                                                     __1_k
                                                                     []
                                                                     Local
@@ -129,7 +129,7 @@
                                                                 ),
                                                             arg0:
                                                                 (Variable
-                                                                    215
+                                                                    217
                                                                     arg0
                                                                     []
                                                                     In
@@ -150,7 +150,7 @@
                                                                 ),
                                                             arg1:
                                                                 (Variable
-                                                                    215
+                                                                    217
                                                                     arg1
                                                                     []
                                                                     In
@@ -171,7 +171,7 @@
                                                                 ),
                                                             arg2:
                                                                 (Variable
-                                                                    215
+                                                                    217
                                                                     arg2
                                                                     []
                                                                     In
@@ -187,7 +187,7 @@
                                                                 ),
                                                             arg3:
                                                                 (Variable
-                                                                    215
+                                                                    217
                                                                     arg3
                                                                     []
                                                                     In
@@ -203,7 +203,7 @@
                                                                 ),
                                                             arg4:
                                                                 (Variable
-                                                                    215
+                                                                    217
                                                                     arg4
                                                                     []
                                                                     In
@@ -219,7 +219,7 @@
                                                                 ),
                                                             arg5:
                                                                 (Variable
-                                                                    215
+                                                                    217
                                                                     arg5
                                                                     []
                                                                     In
@@ -265,18 +265,18 @@
                                                         .false.
                                                     )
                                                     []
-                                                    [(Var 215 arg0)
-                                                    (Var 215 arg1)
-                                                    (Var 215 arg2)
-                                                    (Var 215 arg3)
-                                                    (Var 215 arg4)
-                                                    (Var 215 arg5)]
+                                                    [(Var 217 arg0)
+                                                    (Var 217 arg1)
+                                                    (Var 217 arg2)
+                                                    (Var 217 arg3)
+                                                    (Var 217 arg4)
+                                                    (Var 217 arg5)]
                                                     [(=
-                                                        (Var 215 __1_k)
+                                                        (Var 217 __1_k)
                                                         (IntegerBinOp
-                                                            (Var 215 arg2)
+                                                            (Var 217 arg2)
                                                             Sub
-                                                            (Var 215 arg4)
+                                                            (Var 217 arg4)
                                                             (Integer 4)
                                                             ()
                                                         )
@@ -286,23 +286,23 @@
                                                         ()
                                                         (IntegerCompare
                                                             (IntegerBinOp
-                                                                (Var 215 __1_k)
+                                                                (Var 217 __1_k)
                                                                 Add
-                                                                (Var 215 arg4)
+                                                                (Var 217 arg4)
                                                                 (Integer 4)
                                                                 ()
                                                             )
                                                             Lt
-                                                            (Var 215 arg3)
+                                                            (Var 217 arg3)
                                                             (Logical 4)
                                                             ()
                                                         )
                                                         [(=
-                                                            (Var 215 __1_k)
+                                                            (Var 217 __1_k)
                                                             (IntegerBinOp
-                                                                (Var 215 __1_k)
+                                                                (Var 217 __1_k)
                                                                 Add
-                                                                (Var 215 arg4)
+                                                                (Var 217 arg4)
                                                                 (Integer 4)
                                                                 ()
                                                             )
@@ -310,18 +310,18 @@
                                                         )
                                                         (=
                                                             (ArrayItem
-                                                                (Var 215 arg0)
+                                                                (Var 217 arg0)
                                                                 [(()
-                                                                (Var 215 __1_k)
+                                                                (Var 217 __1_k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
                                                                 ()
                                                             )
                                                             (ArrayItem
-                                                                (Var 215 arg1)
+                                                                (Var 217 arg1)
                                                                 [(()
-                                                                (Var 215 __1_k)
+                                                                (Var 217 __1_k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
@@ -355,7 +355,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 209 a)
+                                        (Var 211 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -369,7 +369,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 209 b)
+                                        (Var 211 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -384,7 +384,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 209 i)
+                                        ((Var 211 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -396,9 +396,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 209 b)
+                                                (Var 211 b)
                                                 [(()
-                                                (Var 209 i)
+                                                (Var 211 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -413,17 +413,17 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 209 i)
+                                        ((Var 211 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerConstant 1151 (Integer 4))
                                         (IntegerConstant 1 (Integer 4)))
                                         [(SubroutineCall
-                                            209 vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization
+                                            211 vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization
                                             ()
-                                            [((Var 209 a))
-                                            ((Var 209 b))
+                                            [((Var 211 a))
+                                            ((Var 211 b))
                                             ((IntegerBinOp
-                                                (Var 209 i)
+                                                (Var 211 i)
                                                 Mul
                                                 (IntegerConstant 8 (Integer 4))
                                                 (Integer 4)
@@ -431,7 +431,7 @@
                                             ))
                                             ((IntegerBinOp
                                                 (IntegerBinOp
-                                                    (Var 209 i)
+                                                    (Var 211 i)
                                                     Add
                                                     (IntegerConstant 1 (Integer 4))
                                                     (Integer 4)
@@ -449,7 +449,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 209 i)
+                                        ((Var 211 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -462,9 +462,9 @@
                                         [(Assert
                                             (RealCompare
                                                 (ArrayItem
-                                                    (Var 209 a)
+                                                    (Var 211 a)
                                                     [(()
-                                                    (Var 209 i)
+                                                    (Var 211 i)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -498,11 +498,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        214
+                        216
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    214
+                                    216
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -514,7 +514,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        214 __main__global_stmts
+                        216 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()


### PR DESCRIPTION
Relates to #2356.  

This PR adds support for ``str.split()`` (with or without a separator specified). I have commented out one of the tests because of a bug in ``_lpython_str_strip`` mentioned in #2444. 

I haven't implemented the ``maxsplit`` argument for the method, I can add it if there are no issues with this PR.