### PR TITLE
Implement ``str.replace()`` and ``str.index()``

### DIFF
--- a/integration_tests/test_str_01.py
+++ b/integration_tests/test_str_01.py
@@ -145,6 +145,19 @@ def test_str_split():
     assert res5 == ["123"]
     # assert res6 == [""]
 
+def test_str_replace():
+    a: str = "abracadabra"
+    res: str = a.replace("a","b")
+    res1: str = a.replace("a","")
+    res2: str = a.replace("e","a") 
+    res3: str = a.replace("ab","ba")
+    res4: str = a.replace("","")
+    assert res == "bbrbcbdbbrb"
+    assert res1 == "brcdbr"
+    assert res2 == "abracadabra"
+    assert res3 == "baracadbara"
+    assert res4 == "abracadabra"
+
 def check():
     f()
     test_str_concat()
@@ -160,5 +173,6 @@ def check():
     test_str_istitle()
     test_str_isalpha()
     test_str_split()
+    test_str_replace()
 
 check()

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6789,6 +6789,53 @@ public:
             } else {
                 fn_args.push_back(al, str);
             }
+        } else if(attr_name == "replace") {
+            if(args.size() != 2) {
+                throw SemanticError("str.replace() takes two argument for now.", loc);
+            }
+            ASR::expr_t *arg_value = args[0].m_value;
+            ASR::ttype_t *arg_value_type = ASRUtils::expr_type(arg_value);
+            if (!ASRUtils::is_character(*arg_value_type)) {
+                throw SemanticError("str.replace() argument 1 must be str", loc);
+            }
+            arg_value = args[1].m_value;
+            arg_value_type = ASRUtils::expr_type(arg_value);
+            if (!ASRUtils::is_character(*arg_value_type)) {
+                throw SemanticError("str.replace() argument 2 must be str", loc);
+            }
+            fn_call_name = "_lpython_str_replace";
+            ASR::call_arg_t str;
+            str.loc = loc;
+            str.m_value = s_var;
+
+            ASR::call_arg_t value;
+            value.loc = loc;
+            value.m_value = args[0].m_value;
+                                    
+            fn_args.push_back(al, str);
+            fn_args.push_back(al, value);
+            value.m_value = args[1].m_value;
+            fn_args.push_back(al, value);
+        } else if(attr_name == "index") {
+            if (args.size() != 1) {
+                throw SemanticError("str.index() takes one argument",
+                    loc);
+            }
+            ASR::expr_t *arg_sub = args[0].m_value;
+            ASR::ttype_t *arg_sub_type = ASRUtils::expr_type(arg_sub);
+            if (!ASRUtils::is_character(*arg_sub_type)) {
+                throw SemanticError("str.index() takes one argument of type: str",
+                    loc);
+            }
+            fn_call_name = "_lpython_str_index";
+            ASR::call_arg_t str;
+            str.loc = loc;
+            str.m_value = s_var;
+            ASR::call_arg_t sub;
+            sub.loc = loc;
+            sub.m_value = args[0].m_value;
+            fn_args.push_back(al, str);
+            fn_args.push_back(al, sub);
         } else if(attr_name.size() > 2 && attr_name[0] == 'i' && attr_name[1] == 's') {
             /*
                 String Validation Methods i.e all "is" based functions are handled here

--- a/src/lpython/semantics/python_comptime_eval.h
+++ b/src/lpython/semantics/python_comptime_eval.h
@@ -89,6 +89,8 @@ struct PythonIntrinsicProcedures {
             {"_lpython_str_lstrip", {m_builtin, &not_implemented}},
             {"_lpython_str_strip", {m_builtin, &not_implemented}},
             {"_lpython_str_split", {m_builtin, &not_implemented}},
+            {"_lpython_str_replace", {m_builtin, &not_implemented}},
+            {"_lpython_str_index", {m_builtin, &not_implemented}},
             {"_lpython_str_swapcase", {m_builtin, &not_implemented}},
             {"_lpython_str_startswith", {m_builtin, &not_implemented}},
             {"_lpython_str_endswith", {m_builtin, &not_implemented}},

--- a/src/runtime/lpython_builtin.py
+++ b/src/runtime/lpython_builtin.py
@@ -860,6 +860,24 @@ def _lpython_str_split(x: str, sep:str) -> list[str]:
     return res
 
 @overload
+def _lpython_str_replace(x: str, old:str, new:str) -> str:
+    if (old == ""):
+        res: str = ""
+        i: str
+        for i in x:
+            res += new + i
+        return res
+    return _lpython_str_join(new, _lpython_str_split(x,old))
+
+@overload
+def _lpython_str_index(s: str, sub: str) -> i32:
+    ind: i32 = _lpython_str_find(s, sub);
+    if (ind == -1):
+        raise ValueError("substring not found")
+    return ind
+
+
+@overload
 def _lpython_str_swapcase(s: str) -> str:
     res :str = ""
     cur: str

--- a/tests/reference/asr-array_01_decl-39cf894.json
+++ b/tests/reference/asr-array_01_decl-39cf894.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_01_decl-39cf894.stdout",
-    "stdout_hash": "5d4751789e2ddcd882c4d6026f801ba32cfc227fafff7395a788bdd9",
+    "stdout_hash": "74bc84a1e1097e1d450910b0122bfd6fddff20d3d5df5ba282f0b2bb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_01_decl-39cf894.stdout
+++ b/tests/reference/asr-array_01_decl-39cf894.stdout
@@ -10,11 +10,11 @@
                             ArraySizes:
                                 (EnumType
                                     (SymbolTable
-                                        211
+                                        214
                                         {
                                             SIZE_10:
                                                 (Variable
-                                                    211
+                                                    214
                                                     SIZE_10
                                                     []
                                                     Local
@@ -30,7 +30,7 @@
                                                 ),
                                             SIZE_3:
                                                 (Variable
-                                                    211
+                                                    214
                                                     SIZE_3
                                                     []
                                                     Local
@@ -58,7 +58,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        221
                                         {
                                             
                                         })
@@ -94,11 +94,11 @@
                             accept_f32_array:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        218
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    215
+                                                    218
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -114,7 +114,7 @@
                                                 ),
                                             xf32:
                                                 (Variable
-                                                    215
+                                                    218
                                                     xf32
                                                     []
                                                     InOut
@@ -155,10 +155,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 215 xf32)]
+                                    [(Var 218 xf32)]
                                     [(=
                                         (ArrayItem
-                                            (Var 215 xf32)
+                                            (Var 218 xf32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -181,9 +181,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 _lpython_return_variable)
+                                        (Var 218 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 215 xf32)
+                                            (Var 218 xf32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -194,7 +194,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 215 _lpython_return_variable)
+                                    (Var 218 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -203,11 +203,11 @@
                             accept_f64_array:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        219
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    216
+                                                    219
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -223,7 +223,7 @@
                                                 ),
                                             xf64:
                                                 (Variable
-                                                    216
+                                                    219
                                                     xf64
                                                     []
                                                     InOut
@@ -264,10 +264,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 216 xf64)]
+                                    [(Var 219 xf64)]
                                     [(=
                                         (ArrayItem
-                                            (Var 216 xf64)
+                                            (Var 219 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -282,9 +282,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 216 _lpython_return_variable)
+                                        (Var 219 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 216 xf64)
+                                            (Var 219 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -295,7 +295,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 216 _lpython_return_variable)
+                                    (Var 219 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -304,11 +304,11 @@
                             accept_i16_array:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        215
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    212
+                                                    215
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -324,7 +324,7 @@
                                                 ),
                                             xi16:
                                                 (Variable
-                                                    212
+                                                    215
                                                     xi16
                                                     []
                                                     InOut
@@ -365,10 +365,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 xi16)]
+                                    [(Var 215 xi16)]
                                     [(=
                                         (ArrayItem
-                                            (Var 212 xi16)
+                                            (Var 215 xi16)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -385,9 +385,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 _lpython_return_variable)
+                                        (Var 215 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 212 xi16)
+                                            (Var 215 xi16)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -398,7 +398,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 212 _lpython_return_variable)
+                                    (Var 215 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -407,11 +407,11 @@
                             accept_i32_array:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        216
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    216
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -427,7 +427,7 @@
                                                 ),
                                             xi32:
                                                 (Variable
-                                                    213
+                                                    216
                                                     xi32
                                                     []
                                                     InOut
@@ -468,10 +468,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 xi32)]
+                                    [(Var 216 xi32)]
                                     [(=
                                         (ArrayItem
-                                            (Var 213 xi32)
+                                            (Var 216 xi32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -483,9 +483,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 216 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 213 xi32)
+                                            (Var 216 xi32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -496,7 +496,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 216 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -505,11 +505,11 @@
                             accept_i64_array:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        217
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    214
+                                                    217
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -525,7 +525,7 @@
                                                 ),
                                             xi64:
                                                 (Variable
-                                                    214
+                                                    217
                                                     xi64
                                                     []
                                                     InOut
@@ -566,10 +566,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 xi64)]
+                                    [(Var 217 xi64)]
                                     [(=
                                         (ArrayItem
-                                            (Var 214 xi64)
+                                            (Var 217 xi64)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -586,9 +586,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 _lpython_return_variable)
+                                        (Var 217 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 214 xi64)
+                                            (Var 217 xi64)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -599,7 +599,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 214 _lpython_return_variable)
+                                    (Var 217 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -608,11 +608,11 @@
                             declare_arrays:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        220
                                         {
                                             ac32:
                                                 (Variable
-                                                    217
+                                                    220
                                                     ac32
                                                     []
                                                     Local
@@ -633,7 +633,7 @@
                                                 ),
                                             ac64:
                                                 (Variable
-                                                    217
+                                                    220
                                                     ac64
                                                     []
                                                     Local
@@ -654,7 +654,7 @@
                                                 ),
                                             af32:
                                                 (Variable
-                                                    217
+                                                    220
                                                     af32
                                                     []
                                                     Local
@@ -675,7 +675,7 @@
                                                 ),
                                             af64:
                                                 (Variable
-                                                    217
+                                                    220
                                                     af64
                                                     []
                                                     Local
@@ -696,7 +696,7 @@
                                                 ),
                                             ai16:
                                                 (Variable
-                                                    217
+                                                    220
                                                     ai16
                                                     []
                                                     Local
@@ -717,7 +717,7 @@
                                                 ),
                                             ai32:
                                                 (Variable
-                                                    217
+                                                    220
                                                     ai32
                                                     []
                                                     Local
@@ -738,7 +738,7 @@
                                                 ),
                                             ai64:
                                                 (Variable
-                                                    217
+                                                    220
                                                     ai64
                                                     []
                                                     Local
@@ -780,7 +780,7 @@
                                     accept_f64_array]
                                     []
                                     [(=
-                                        (Var 217 ai16)
+                                        (Var 220 ai16)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -794,7 +794,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 ai32)
+                                        (Var 220 ai32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -808,7 +808,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 ai64)
+                                        (Var 220 ai64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -822,7 +822,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 af32)
+                                        (Var 220 af32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -836,7 +836,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 af64)
+                                        (Var 220 af64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -850,7 +850,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 ac32)
+                                        (Var 220 ac32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -864,7 +864,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 ac64)
+                                        (Var 220 ac64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -882,7 +882,7 @@
                                             2 accept_i16_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 ai16)
+                                                (Var 220 ai16)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -905,7 +905,7 @@
                                             2 accept_i32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 ai32)
+                                                (Var 220 ai32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -928,7 +928,7 @@
                                             2 accept_i64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 ai64)
+                                                (Var 220 ai64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -951,7 +951,7 @@
                                             2 accept_f32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 af32)
+                                                (Var 220 af32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -974,7 +974,7 @@
                                             2 accept_f64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 af64)
+                                                (Var 220 af64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -1009,11 +1009,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        219
+                        222
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    219
+                                    222
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1025,7 +1025,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        219 __main__global_stmts
+                        222 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-array_02_decl-e8f6874.json
+++ b/tests/reference/asr-array_02_decl-e8f6874.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_02_decl-e8f6874.stdout",
-    "stdout_hash": "b75476498ff1c6620f1cdafe5c25e26006b5e47e3ad06663d288feb5",
+    "stdout_hash": "1e49b4d361147634a844614c900946dcab46b2a0c8d46f6ba51a10c6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_02_decl-e8f6874.stdout
+++ b/tests/reference/asr-array_02_decl-e8f6874.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        219
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             accept_multidim_f32_array:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        216
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    216
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -66,7 +66,7 @@
                                                 ),
                                             xf32:
                                                 (Variable
-                                                    213
+                                                    216
                                                     xf32
                                                     []
                                                     InOut
@@ -107,11 +107,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 xf32)]
+                                    [(Var 216 xf32)]
                                     [(=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 216 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 213 xf32)
+                                            (Var 216 xf32)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -122,7 +122,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 216 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -131,11 +131,11 @@
                             accept_multidim_f64_array:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        217
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    214
+                                                    217
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -151,7 +151,7 @@
                                                 ),
                                             xf64:
                                                 (Variable
-                                                    214
+                                                    217
                                                     xf64
                                                     []
                                                     InOut
@@ -196,11 +196,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 xf64)]
+                                    [(Var 217 xf64)]
                                     [(=
-                                        (Var 214 _lpython_return_variable)
+                                        (Var 217 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 214 xf64)
+                                            (Var 217 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -214,7 +214,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 214 _lpython_return_variable)
+                                    (Var 217 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -223,11 +223,11 @@
                             accept_multidim_i32_array:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        214
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    214
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -243,7 +243,7 @@
                                                 ),
                                             xi32:
                                                 (Variable
-                                                    211
+                                                    214
                                                     xi32
                                                     []
                                                     InOut
@@ -288,11 +288,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 xi32)]
+                                    [(Var 214 xi32)]
                                     [(=
-                                        (Var 211 _lpython_return_variable)
+                                        (Var 214 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 211 xi32)
+                                            (Var 214 xi32)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -306,7 +306,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 214 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -315,11 +315,11 @@
                             accept_multidim_i64_array:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        215
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    212
+                                                    215
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -335,7 +335,7 @@
                                                 ),
                                             xi64:
                                                 (Variable
-                                                    212
+                                                    215
                                                     xi64
                                                     []
                                                     InOut
@@ -384,11 +384,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 xi64)]
+                                    [(Var 215 xi64)]
                                     [(=
-                                        (Var 212 _lpython_return_variable)
+                                        (Var 215 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 212 xi64)
+                                            (Var 215 xi64)
                                             [(()
                                             (IntegerConstant 9 (Integer 4))
                                             ())
@@ -405,7 +405,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 212 _lpython_return_variable)
+                                    (Var 215 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -414,11 +414,11 @@
                             declare_arrays:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        218
                                         {
                                             ac32:
                                                 (Variable
-                                                    215
+                                                    218
                                                     ac32
                                                     []
                                                     Local
@@ -443,7 +443,7 @@
                                                 ),
                                             ac64:
                                                 (Variable
-                                                    215
+                                                    218
                                                     ac64
                                                     []
                                                     Local
@@ -470,7 +470,7 @@
                                                 ),
                                             af32:
                                                 (Variable
-                                                    215
+                                                    218
                                                     af32
                                                     []
                                                     Local
@@ -491,7 +491,7 @@
                                                 ),
                                             af64:
                                                 (Variable
-                                                    215
+                                                    218
                                                     af64
                                                     []
                                                     Local
@@ -514,7 +514,7 @@
                                                 ),
                                             ai32:
                                                 (Variable
-                                                    215
+                                                    218
                                                     ai32
                                                     []
                                                     Local
@@ -537,7 +537,7 @@
                                                 ),
                                             ai64:
                                                 (Variable
-                                                    215
+                                                    218
                                                     ai64
                                                     []
                                                     Local
@@ -582,7 +582,7 @@
                                     accept_multidim_f64_array]
                                     []
                                     [(=
-                                        (Var 215 ai32)
+                                        (Var 218 ai32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -598,7 +598,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 ai64)
+                                        (Var 218 ai64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -616,7 +616,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 af32)
+                                        (Var 218 af32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -630,7 +630,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 af64)
+                                        (Var 218 af64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -646,7 +646,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 ac32)
+                                        (Var 218 ac32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -664,7 +664,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 ac64)
+                                        (Var 218 ac64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -688,7 +688,7 @@
                                             2 accept_multidim_i32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 ai32)
+                                                (Var 218 ai32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -713,7 +713,7 @@
                                             2 accept_multidim_i64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 ai64)
+                                                (Var 218 ai64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -740,7 +740,7 @@
                                             2 accept_multidim_f32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 af32)
+                                                (Var 218 af32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -763,7 +763,7 @@
                                             2 accept_multidim_f64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 af64)
+                                                (Var 218 af64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -800,11 +800,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        217
+                        220
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    217
+                                    220
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -816,7 +816,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        217 __main__global_stmts
+                        220 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-bindc_02-bc1a7ea.json
+++ b/tests/reference/asr-bindc_02-bc1a7ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-bindc_02-bc1a7ea.stdout",
-    "stdout_hash": "b0061b776455e9077daa9d47fecc543d08c919c9dad365ad2c3f6b33",
+    "stdout_hash": "b279b0968dd398976753b3d6b88ae646260e57617f68f5c16b72c6e1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-bindc_02-bc1a7ea.stdout
+++ b/tests/reference/asr-bindc_02-bc1a7ea.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        215
                                         {
                                             
                                         })
@@ -76,11 +76,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        214
                                         {
                                             y:
                                                 (Variable
-                                                    211
+                                                    214
                                                     y
                                                     []
                                                     Local
@@ -101,7 +101,7 @@
                                                 ),
                                             yptr1:
                                                 (Variable
-                                                    211
+                                                    214
                                                     yptr1
                                                     []
                                                     Local
@@ -124,7 +124,7 @@
                                                 ),
                                             yq:
                                                 (Variable
-                                                    211
+                                                    214
                                                     yq
                                                     []
                                                     Local
@@ -157,14 +157,14 @@
                                     []
                                     []
                                     [(=
-                                        (Var 211 yq)
+                                        (Var 214 yq)
                                         (PointerNullConstant
                                             (CPtr)
                                         )
                                         ()
                                     )
                                     (=
-                                        (Var 211 y)
+                                        (Var 214 y)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -179,7 +179,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 211 y)
+                                            (Var 214 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -197,7 +197,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 211 y)
+                                            (Var 214 y)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -214,9 +214,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 yptr1)
+                                        (Var 214 yptr1)
                                         (GetPointer
-                                            (Var 211 y)
+                                            (Var 214 y)
                                             (Pointer
                                                 (Array
                                                     (Integer 2)
@@ -231,7 +231,7 @@
                                     )
                                     (Print
                                         [(GetPointer
-                                            (Var 211 y)
+                                            (Var 214 y)
                                             (Pointer
                                                 (Array
                                                     (Integer 2)
@@ -242,13 +242,13 @@
                                             )
                                             ()
                                         )
-                                        (Var 211 yptr1)]
+                                        (Var 214 yptr1)]
                                         ()
                                         ()
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 211 yptr1)
+                                            (Var 214 yptr1)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -257,7 +257,7 @@
                                             ()
                                         )
                                         (ArrayItem
-                                            (Var 211 yptr1)
+                                            (Var 214 yptr1)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -271,7 +271,7 @@
                                     (Assert
                                         (IntegerCompare
                                             (ArrayItem
-                                                (Var 211 yptr1)
+                                                (Var 214 yptr1)
                                                 [(()
                                                 (IntegerConstant 0 (Integer 4))
                                                 ())]
@@ -294,7 +294,7 @@
                                     (Assert
                                         (IntegerCompare
                                             (ArrayItem
-                                                (Var 211 yptr1)
+                                                (Var 214 yptr1)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -315,8 +315,8 @@
                                         ()
                                     )
                                     (CPtrToPointer
-                                        (Var 211 yq)
-                                        (Var 211 yptr1)
+                                        (Var 214 yq)
+                                        (Var 214 yptr1)
                                         (ArrayConstant
                                             [(IntegerConstant 2 (Integer 4))]
                                             (Array
@@ -339,8 +339,8 @@
                                         )
                                     )
                                     (Print
-                                        [(Var 211 yq)
-                                        (Var 211 yptr1)]
+                                        [(Var 214 yq)
+                                        (Var 214 yptr1)]
                                         ()
                                         ()
                                     )]
@@ -404,11 +404,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        213
+                        216
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    213
+                                    216
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -420,7 +420,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        213 __main__global_stmts
+                        216 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-cast-435c233.json
+++ b/tests/reference/asr-cast-435c233.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-cast-435c233.stdout",
-    "stdout_hash": "da51ce5078b2a34b978ae26fc76fb325b261a218555466a38aeeec6a",
+    "stdout_hash": "34d0c35836b719faad9915a1a6eb2b26eeb38b7b2739c212b4960ba6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-cast-435c233.stdout
+++ b/tests/reference/asr-cast-435c233.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        132
                                         {
                                             
                                         })
@@ -285,11 +285,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        133
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    133
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -301,7 +301,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        133 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-complex1-f26c460.json
+++ b/tests/reference/asr-complex1-f26c460.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-complex1-f26c460.stdout",
-    "stdout_hash": "7c3f0d1d66094c100e19a8b2b83c3589ece73fc7224de1e618a4f4c2",
+    "stdout_hash": "2f7c4269bd1f1acfe7d5d279c75f2472ce450af26fafcdb3daec8cee",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-complex1-f26c460.stdout
+++ b/tests/reference/asr-complex1-f26c460.stdout
@@ -776,7 +776,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        133
                         {
                             
                         })

--- a/tests/reference/asr-constants1-5828e8a.json
+++ b/tests/reference/asr-constants1-5828e8a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-constants1-5828e8a.stdout",
-    "stdout_hash": "417211efafb2f2d5bb5defcc9f4de14b6e4c0945c52c0a5f53c75d49",
+    "stdout_hash": "3e62087c9a7aa3e75812f8c42963fa1f3a212c285348f49f98135092",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-constants1-5828e8a.stdout
+++ b/tests/reference/asr-constants1-5828e8a.stdout
@@ -1778,7 +1778,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        138
+                        141
                         {
                             
                         })

--- a/tests/reference/asr-elemental_01-b58df26.json
+++ b/tests/reference/asr-elemental_01-b58df26.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-elemental_01-b58df26.stdout",
-    "stdout_hash": "f6657ff256291caa10a0681ae7c5ad89f5c103725e44318d42b1445e",
+    "stdout_hash": "991d5a4d8271853dba9dfc517a05b6fa4e997a03eedeb928a09f9fca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-elemental_01-b58df26.stdout
+++ b/tests/reference/asr-elemental_01-b58df26.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        244
+                                        247
                                         {
                                             
                                         })
@@ -84,11 +84,11 @@
                             elemental_cos:
                                 (Function
                                     (SymbolTable
-                                        219
+                                        222
                                         {
                                             array2d:
                                                 (Variable
-                                                    219
+                                                    222
                                                     array2d
                                                     []
                                                     Local
@@ -111,7 +111,7 @@
                                                 ),
                                             cos2d:
                                                 (Variable
-                                                    219
+                                                    222
                                                     cos2d
                                                     []
                                                     Local
@@ -134,7 +134,7 @@
                                                 ),
                                             cos@__lpython_overloaded_0__cos:
                                                 (ExternalSymbol
-                                                    219
+                                                    222
                                                     cos@__lpython_overloaded_0__cos
                                                     3 __lpython_overloaded_0__cos
                                                     numpy
@@ -144,7 +144,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    219
+                                                    222
                                                     i
                                                     []
                                                     Local
@@ -160,7 +160,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    219
+                                                    222
                                                     j
                                                     []
                                                     Local
@@ -193,7 +193,7 @@
                                     [verify2d]
                                     []
                                     [(=
-                                        (Var 219 array2d)
+                                        (Var 222 array2d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -209,7 +209,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 219 cos2d)
+                                        (Var 222 cos2d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -226,7 +226,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 219 i)
+                                        ((Var 222 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -238,7 +238,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 219 j)
+                                            ((Var 222 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 64 (Integer 4))
@@ -250,12 +250,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 219 array2d)
+                                                    (Var 222 array2d)
                                                     [(()
-                                                    (Var 219 i)
+                                                    (Var 222 i)
                                                     ())
                                                     (()
-                                                    (Var 219 j)
+                                                    (Var 222 j)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -263,9 +263,9 @@
                                                 )
                                                 (Cast
                                                     (IntegerBinOp
-                                                        (Var 219 i)
+                                                        (Var 222 i)
                                                         Add
-                                                        (Var 219 j)
+                                                        (Var 222 j)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -278,12 +278,12 @@
                                         )]
                                     )
                                     (=
-                                        (Var 219 cos2d)
+                                        (Var 222 cos2d)
                                         (RealBinOp
                                             (FunctionCall
-                                                219 cos@__lpython_overloaded_0__cos
+                                                222 cos@__lpython_overloaded_0__cos
                                                 2 cos
-                                                [((Var 219 array2d))]
+                                                [((Var 222 array2d))]
                                                 (Array
                                                     (Real 8)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -316,7 +316,7 @@
                                         2 verify2d
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 219 array2d)
+                                            (Var 222 array2d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -330,7 +330,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 219 cos2d)
+                                            (Var 222 cos2d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -356,11 +356,11 @@
                             elemental_mul:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        220
                                         {
                                             array_a:
                                                 (Variable
-                                                    217
+                                                    220
                                                     array_a
                                                     []
                                                     Local
@@ -381,7 +381,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    217
+                                                    220
                                                     array_b
                                                     []
                                                     Local
@@ -402,7 +402,7 @@
                                                 ),
                                             array_c:
                                                 (Variable
-                                                    217
+                                                    220
                                                     array_c
                                                     []
                                                     Local
@@ -423,7 +423,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    217
+                                                    220
                                                     i
                                                     []
                                                     Local
@@ -439,7 +439,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    217
+                                                    220
                                                     j
                                                     []
                                                     Local
@@ -455,7 +455,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    217
+                                                    220
                                                     k
                                                     []
                                                     Local
@@ -488,7 +488,7 @@
                                     [verify1d_mul]
                                     []
                                     [(=
-                                        (Var 217 array_a)
+                                        (Var 220 array_a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -502,7 +502,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 array_b)
+                                        (Var 220 array_b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -516,7 +516,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 array_c)
+                                        (Var 220 array_c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -531,7 +531,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 217 i)
+                                        ((Var 220 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -543,16 +543,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 217 array_a)
+                                                (Var 220 array_a)
                                                 [(()
-                                                (Var 217 i)
+                                                (Var 220 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 217 i)
+                                                (Var 220 i)
                                                 IntegerToReal
                                                 (Real 8)
                                                 ()
@@ -562,7 +562,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 217 j)
+                                        ((Var 220 j)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -574,9 +574,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 217 array_b)
+                                                (Var 220 array_b)
                                                 [(()
-                                                (Var 217 j)
+                                                (Var 220 j)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -584,7 +584,7 @@
                                             )
                                             (Cast
                                                 (IntegerBinOp
-                                                    (Var 217 j)
+                                                    (Var 220 j)
                                                     Add
                                                     (IntegerConstant 5 (Integer 4))
                                                     (Integer 4)
@@ -598,11 +598,11 @@
                                         )]
                                     )
                                     (=
-                                        (Var 217 array_c)
+                                        (Var 220 array_c)
                                         (RealBinOp
                                             (RealBinOp
                                                 (RealBinOp
-                                                    (Var 217 array_a)
+                                                    (Var 220 array_a)
                                                     Pow
                                                     (RealConstant
                                                         2.000000
@@ -631,7 +631,7 @@
                                             )
                                             Mul
                                             (RealBinOp
-                                                (Var 217 array_b)
+                                                (Var 220 array_b)
                                                 Pow
                                                 (RealConstant
                                                     3.000000
@@ -659,7 +659,7 @@
                                         2 verify1d_mul
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 217 array_a)
+                                            (Var 220 array_a)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -671,7 +671,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 217 array_b)
+                                            (Var 220 array_b)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -683,7 +683,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 217 array_c)
+                                            (Var 220 array_c)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -706,11 +706,11 @@
                             elemental_sin:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        221
                                         {
                                             array1d:
                                                 (Variable
-                                                    218
+                                                    221
                                                     array1d
                                                     []
                                                     Local
@@ -731,7 +731,7 @@
                                                 ),
                                             arraynd:
                                                 (Variable
-                                                    218
+                                                    221
                                                     arraynd
                                                     []
                                                     Local
@@ -756,7 +756,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    218
+                                                    221
                                                     i
                                                     []
                                                     Local
@@ -772,7 +772,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    218
+                                                    221
                                                     j
                                                     []
                                                     Local
@@ -788,7 +788,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    218
+                                                    221
                                                     k
                                                     []
                                                     Local
@@ -804,7 +804,7 @@
                                                 ),
                                             sin1d:
                                                 (Variable
-                                                    218
+                                                    221
                                                     sin1d
                                                     []
                                                     Local
@@ -825,7 +825,7 @@
                                                 ),
                                             sin@__lpython_overloaded_0__sin:
                                                 (ExternalSymbol
-                                                    218
+                                                    221
                                                     sin@__lpython_overloaded_0__sin
                                                     3 __lpython_overloaded_0__sin
                                                     numpy
@@ -835,7 +835,7 @@
                                                 ),
                                             sin@__lpython_overloaded_1__sin:
                                                 (ExternalSymbol
-                                                    218
+                                                    221
                                                     sin@__lpython_overloaded_1__sin
                                                     3 __lpython_overloaded_1__sin
                                                     numpy
@@ -845,7 +845,7 @@
                                                 ),
                                             sinnd:
                                                 (Variable
-                                                    218
+                                                    221
                                                     sinnd
                                                     []
                                                     Local
@@ -888,7 +888,7 @@
                                     verifynd]
                                     []
                                     [(=
-                                        (Var 218 array1d)
+                                        (Var 221 array1d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -902,7 +902,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 sin1d)
+                                        (Var 221 sin1d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -917,7 +917,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 218 i)
+                                        ((Var 221 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -929,16 +929,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 218 array1d)
+                                                (Var 221 array1d)
                                                 [(()
-                                                (Var 218 i)
+                                                (Var 221 i)
                                                 ())]
                                                 (Real 4)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 218 i)
+                                                (Var 221 i)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -947,14 +947,14 @@
                                         )]
                                     )
                                     (=
-                                        (Var 218 sin1d)
+                                        (Var 221 sin1d)
                                         (FunctionCall
-                                            218 sin@__lpython_overloaded_1__sin
+                                            221 sin@__lpython_overloaded_1__sin
                                             2 sin
                                             [((FunctionCall
-                                                218 sin@__lpython_overloaded_1__sin
+                                                221 sin@__lpython_overloaded_1__sin
                                                 2 sin
-                                                [((Var 218 array1d))]
+                                                [((Var 221 array1d))]
                                                 (Array
                                                     (Real 4)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -979,7 +979,7 @@
                                         2 verify1d
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 218 array1d)
+                                            (Var 221 array1d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -991,7 +991,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 218 sin1d)
+                                            (Var 221 sin1d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1006,7 +1006,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 arraynd)
+                                        (Var 221 arraynd)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1024,7 +1024,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 sinnd)
+                                        (Var 221 sinnd)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1043,7 +1043,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 218 i)
+                                        ((Var 221 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -1055,7 +1055,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 218 j)
+                                            ((Var 221 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 64 (Integer 4))
@@ -1067,7 +1067,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 218 k)
+                                                ((Var 221 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 16 (Integer 4))
@@ -1079,15 +1079,15 @@
                                                 (IntegerConstant 1 (Integer 4)))
                                                 [(=
                                                     (ArrayItem
-                                                        (Var 218 arraynd)
+                                                        (Var 221 arraynd)
                                                         [(()
-                                                        (Var 218 i)
+                                                        (Var 221 i)
                                                         ())
                                                         (()
-                                                        (Var 218 j)
+                                                        (Var 221 j)
                                                         ())
                                                         (()
-                                                        (Var 218 k)
+                                                        (Var 221 k)
                                                         ())]
                                                         (Real 8)
                                                         RowMajor
@@ -1096,14 +1096,14 @@
                                                     (Cast
                                                         (IntegerBinOp
                                                             (IntegerBinOp
-                                                                (Var 218 i)
+                                                                (Var 221 i)
                                                                 Add
-                                                                (Var 218 j)
+                                                                (Var 221 j)
                                                                 (Integer 4)
                                                                 ()
                                                             )
                                                             Add
-                                                            (Var 218 k)
+                                                            (Var 221 k)
                                                             (Integer 4)
                                                             ()
                                                         )
@@ -1117,12 +1117,12 @@
                                         )]
                                     )
                                     (=
-                                        (Var 218 sinnd)
+                                        (Var 221 sinnd)
                                         (RealBinOp
                                             (FunctionCall
-                                                218 sin@__lpython_overloaded_0__sin
+                                                221 sin@__lpython_overloaded_0__sin
                                                 2 sin
-                                                [((Var 218 arraynd))]
+                                                [((Var 221 arraynd))]
                                                 (Array
                                                     (Real 8)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -1159,7 +1159,7 @@
                                         2 verifynd
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 218 arraynd)
+                                            (Var 221 arraynd)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1175,7 +1175,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 218 sinnd)
+                                            (Var 221 sinnd)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1204,11 +1204,11 @@
                             elemental_sum:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        219
                                         {
                                             array_a:
                                                 (Variable
-                                                    216
+                                                    219
                                                     array_a
                                                     []
                                                     Local
@@ -1229,7 +1229,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    216
+                                                    219
                                                     array_b
                                                     []
                                                     Local
@@ -1250,7 +1250,7 @@
                                                 ),
                                             array_c:
                                                 (Variable
-                                                    216
+                                                    219
                                                     array_c
                                                     []
                                                     Local
@@ -1271,7 +1271,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    216
+                                                    219
                                                     i
                                                     []
                                                     Local
@@ -1287,7 +1287,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    216
+                                                    219
                                                     j
                                                     []
                                                     Local
@@ -1303,7 +1303,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    216
+                                                    219
                                                     k
                                                     []
                                                     Local
@@ -1336,7 +1336,7 @@
                                     [verify1d_sum]
                                     []
                                     [(=
-                                        (Var 216 array_a)
+                                        (Var 219 array_a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1350,7 +1350,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 216 array_b)
+                                        (Var 219 array_b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1364,7 +1364,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 216 array_c)
+                                        (Var 219 array_c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1379,7 +1379,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 216 i)
+                                        ((Var 219 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -1391,16 +1391,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 216 array_a)
+                                                (Var 219 array_a)
                                                 [(()
-                                                (Var 216 i)
+                                                (Var 219 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 216 i)
+                                                (Var 219 i)
                                                 IntegerToReal
                                                 (Real 8)
                                                 ()
@@ -1410,7 +1410,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 216 j)
+                                        ((Var 219 j)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -1422,9 +1422,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 216 array_b)
+                                                (Var 219 array_b)
                                                 [(()
-                                                (Var 216 j)
+                                                (Var 219 j)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -1432,7 +1432,7 @@
                                             )
                                             (Cast
                                                 (IntegerBinOp
-                                                    (Var 216 j)
+                                                    (Var 219 j)
                                                     Add
                                                     (IntegerConstant 5 (Integer 4))
                                                     (Integer 4)
@@ -1446,10 +1446,10 @@
                                         )]
                                     )
                                     (=
-                                        (Var 216 array_c)
+                                        (Var 219 array_c)
                                         (RealBinOp
                                             (RealBinOp
-                                                (Var 216 array_a)
+                                                (Var 219 array_a)
                                                 Pow
                                                 (RealConstant
                                                     2.000000
@@ -1471,7 +1471,7 @@
                                                 )
                                                 Mul
                                                 (RealBinOp
-                                                    (Var 216 array_b)
+                                                    (Var 219 array_b)
                                                     Pow
                                                     (RealConstant
                                                         3.000000
@@ -1507,7 +1507,7 @@
                                         2 verify1d_sum
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 216 array_a)
+                                            (Var 219 array_a)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1519,7 +1519,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 216 array_b)
+                                            (Var 219 array_b)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1531,7 +1531,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 216 array_c)
+                                            (Var 219 array_c)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1554,11 +1554,11 @@
                             elemental_trig_identity:
                                 (Function
                                     (SymbolTable
-                                        220
+                                        223
                                         {
                                             arraynd:
                                                 (Variable
-                                                    220
+                                                    223
                                                     arraynd
                                                     []
                                                     Local
@@ -1585,7 +1585,7 @@
                                                 ),
                                             cos@__lpython_overloaded_1__cos:
                                                 (ExternalSymbol
-                                                    220
+                                                    223
                                                     cos@__lpython_overloaded_1__cos
                                                     3 __lpython_overloaded_1__cos
                                                     numpy
@@ -1595,7 +1595,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    220
+                                                    223
                                                     eps
                                                     []
                                                     Local
@@ -1611,7 +1611,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    220
+                                                    223
                                                     i
                                                     []
                                                     Local
@@ -1627,7 +1627,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    220
+                                                    223
                                                     j
                                                     []
                                                     Local
@@ -1643,7 +1643,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    220
+                                                    223
                                                     k
                                                     []
                                                     Local
@@ -1659,7 +1659,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    220
+                                                    223
                                                     l
                                                     []
                                                     Local
@@ -1675,7 +1675,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    220
+                                                    223
                                                     newshape
                                                     []
                                                     Local
@@ -1696,7 +1696,7 @@
                                                 ),
                                             observed:
                                                 (Variable
-                                                    220
+                                                    223
                                                     observed
                                                     []
                                                     Local
@@ -1723,7 +1723,7 @@
                                                 ),
                                             observed1d:
                                                 (Variable
-                                                    220
+                                                    223
                                                     observed1d
                                                     []
                                                     Local
@@ -1744,7 +1744,7 @@
                                                 ),
                                             sin@__lpython_overloaded_1__sin:
                                                 (ExternalSymbol
-                                                    220
+                                                    223
                                                     sin@__lpython_overloaded_1__sin
                                                     3 __lpython_overloaded_1__sin
                                                     numpy
@@ -1771,7 +1771,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 220 eps)
+                                        (Var 223 eps)
                                         (Cast
                                             (RealConstant
                                                 0.000001
@@ -1787,7 +1787,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 arraynd)
+                                        (Var 223 arraynd)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1807,7 +1807,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 observed)
+                                        (Var 223 observed)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1827,7 +1827,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 observed1d)
+                                        (Var 223 observed1d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1842,7 +1842,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 220 i)
+                                        ((Var 223 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 64 (Integer 4))
@@ -1854,7 +1854,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 220 j)
+                                            ((Var 223 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 32 (Integer 4))
@@ -1866,7 +1866,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 220 k)
+                                                ((Var 223 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 8 (Integer 4))
@@ -1878,7 +1878,7 @@
                                                 (IntegerConstant 1 (Integer 4)))
                                                 [(DoLoop
                                                     ()
-                                                    ((Var 220 l)
+                                                    ((Var 223 l)
                                                     (IntegerConstant 0 (Integer 4))
                                                     (IntegerBinOp
                                                         (IntegerConstant 4 (Integer 4))
@@ -1890,18 +1890,18 @@
                                                     (IntegerConstant 1 (Integer 4)))
                                                     [(=
                                                         (ArrayItem
-                                                            (Var 220 arraynd)
+                                                            (Var 223 arraynd)
                                                             [(()
-                                                            (Var 220 i)
+                                                            (Var 223 i)
                                                             ())
                                                             (()
-                                                            (Var 220 j)
+                                                            (Var 223 j)
                                                             ())
                                                             (()
-                                                            (Var 220 k)
+                                                            (Var 223 k)
                                                             ())
                                                             (()
-                                                            (Var 220 l)
+                                                            (Var 223 l)
                                                             ())]
                                                             (Real 4)
                                                             RowMajor
@@ -1911,19 +1911,19 @@
                                                             (IntegerBinOp
                                                                 (IntegerBinOp
                                                                     (IntegerBinOp
-                                                                        (Var 220 i)
+                                                                        (Var 223 i)
                                                                         Add
-                                                                        (Var 220 j)
+                                                                        (Var 223 j)
                                                                         (Integer 4)
                                                                         ()
                                                                     )
                                                                     Add
-                                                                    (Var 220 k)
+                                                                    (Var 223 k)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
                                                                 Add
-                                                                (Var 220 l)
+                                                                (Var 223 l)
                                                                 (Integer 4)
                                                                 ()
                                                             )
@@ -1938,13 +1938,13 @@
                                         )]
                                     )
                                     (=
-                                        (Var 220 observed)
+                                        (Var 223 observed)
                                         (RealBinOp
                                             (RealBinOp
                                                 (FunctionCall
-                                                    220 sin@__lpython_overloaded_1__sin
+                                                    223 sin@__lpython_overloaded_1__sin
                                                     2 sin
-                                                    [((Var 220 arraynd))]
+                                                    [((Var 223 arraynd))]
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
@@ -1987,9 +1987,9 @@
                                             Add
                                             (RealBinOp
                                                 (FunctionCall
-                                                    220 cos@__lpython_overloaded_1__cos
+                                                    223 cos@__lpython_overloaded_1__cos
                                                     2 cos
-                                                    [((Var 220 arraynd))]
+                                                    [((Var 223 arraynd))]
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
@@ -2046,7 +2046,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 newshape)
+                                        (Var 223 newshape)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -2061,7 +2061,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 220 newshape)
+                                            (Var 223 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -2073,11 +2073,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 observed1d)
+                                        (Var 223 observed1d)
                                         (ArrayReshape
-                                            (Var 220 observed)
+                                            (Var 223 observed)
                                             (ArrayPhysicalCast
-                                                (Var 220 newshape)
+                                                (Var 223 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -2100,7 +2100,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 220 i)
+                                        ((Var 223 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 65536 (Integer 4))
@@ -2116,9 +2116,9 @@
                                                     Abs
                                                     [(RealBinOp
                                                         (ArrayItem
-                                                            (Var 220 observed1d)
+                                                            (Var 223 observed1d)
                                                             [(()
-                                                            (Var 220 i)
+                                                            (Var 223 i)
                                                             ())]
                                                             (Real 4)
                                                             RowMajor
@@ -2145,7 +2145,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 220 eps)
+                                                (Var 223 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2171,11 +2171,11 @@
                             verify1d:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        214
                                         {
                                             array:
                                                 (Variable
-                                                    211
+                                                    214
                                                     array
                                                     []
                                                     InOut
@@ -2197,11 +2197,11 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        221
+                                                        224
                                                         {
                                                             sin@__lpython_overloaded_1__sin:
                                                                 (ExternalSymbol
-                                                                    221
+                                                                    224
                                                                     sin@__lpython_overloaded_1__sin
                                                                     3 __lpython_overloaded_1__sin
                                                                     numpy
@@ -2217,15 +2217,15 @@
                                                                 Abs
                                                                 [(RealBinOp
                                                                     (FunctionCall
-                                                                        221 sin@__lpython_overloaded_1__sin
+                                                                        224 sin@__lpython_overloaded_1__sin
                                                                         2 sin
                                                                         [((FunctionCall
-                                                                            221 sin@__lpython_overloaded_1__sin
+                                                                            224 sin@__lpython_overloaded_1__sin
                                                                             2 sin
                                                                             [((ArrayItem
-                                                                                (Var 211 array)
+                                                                                (Var 214 array)
                                                                                 [(()
-                                                                                (Var 211 i)
+                                                                                (Var 214 i)
                                                                                 ())]
                                                                                 (Real 4)
                                                                                 RowMajor
@@ -2241,9 +2241,9 @@
                                                                     )
                                                                     Sub
                                                                     (ArrayItem
-                                                                        (Var 211 result)
+                                                                        (Var 214 result)
                                                                         [(()
-                                                                        (Var 211 i)
+                                                                        (Var 214 i)
                                                                         ())]
                                                                         (Real 4)
                                                                         RowMajor
@@ -2257,7 +2257,7 @@
                                                                 ()
                                                             )
                                                             LtE
-                                                            (Var 211 eps)
+                                                            (Var 214 eps)
                                                             (Logical 4)
                                                             ()
                                                         )
@@ -2266,7 +2266,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    211
+                                                    214
                                                     eps
                                                     []
                                                     Local
@@ -2282,7 +2282,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    211
+                                                    214
                                                     i
                                                     []
                                                     Local
@@ -2298,7 +2298,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    211
+                                                    214
                                                     result
                                                     []
                                                     InOut
@@ -2319,7 +2319,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    211
+                                                    214
                                                     size
                                                     []
                                                     In
@@ -2362,11 +2362,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 array)
-                                    (Var 211 result)
-                                    (Var 211 size)]
+                                    [(Var 214 array)
+                                    (Var 214 result)
+                                    (Var 214 size)]
                                     [(=
-                                        (Var 211 eps)
+                                        (Var 214 eps)
                                         (Cast
                                             (RealConstant
                                                 0.000001
@@ -2383,10 +2383,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 211 size)
+                                            (Var 214 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2395,7 +2395,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            211 block
+                                            214 block
                                         )]
                                     )]
                                     ()
@@ -2407,11 +2407,11 @@
                             verify1d_mul:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        218
                                         {
                                             array_a:
                                                 (Variable
-                                                    215
+                                                    218
                                                     array_a
                                                     []
                                                     InOut
@@ -2432,7 +2432,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    215
+                                                    218
                                                     array_b
                                                     []
                                                     InOut
@@ -2453,7 +2453,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    215
+                                                    218
                                                     eps
                                                     []
                                                     Local
@@ -2469,7 +2469,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    215
+                                                    218
                                                     i
                                                     []
                                                     Local
@@ -2485,7 +2485,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    215
+                                                    218
                                                     result
                                                     []
                                                     InOut
@@ -2506,7 +2506,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    215
+                                                    218
                                                     size
                                                     []
                                                     In
@@ -2555,12 +2555,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 215 array_a)
-                                    (Var 215 array_b)
-                                    (Var 215 result)
-                                    (Var 215 size)]
+                                    [(Var 218 array_a)
+                                    (Var 218 array_b)
+                                    (Var 218 result)
+                                    (Var 218 size)]
                                     [(=
-                                        (Var 215 eps)
+                                        (Var 218 eps)
                                         (RealConstant
                                             0.000010
                                             (Real 8)
@@ -2569,10 +2569,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 215 i)
+                                        ((Var 218 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 215 size)
+                                            (Var 218 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2588,9 +2588,9 @@
                                                             (RealBinOp
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 215 array_a)
+                                                                        (Var 218 array_a)
                                                                         [(()
-                                                                        (Var 215 i)
+                                                                        (Var 218 i)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -2615,9 +2615,9 @@
                                                             Mul
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 215 array_b)
+                                                                    (Var 218 array_b)
                                                                     [(()
-                                                                    (Var 215 i)
+                                                                    (Var 218 i)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -2636,9 +2636,9 @@
                                                         )
                                                         Sub
                                                         (ArrayItem
-                                                            (Var 215 result)
+                                                            (Var 218 result)
                                                             [(()
-                                                            (Var 215 i)
+                                                            (Var 218 i)
                                                             ())]
                                                             (Real 8)
                                                             RowMajor
@@ -2652,7 +2652,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 215 eps)
+                                                (Var 218 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2668,11 +2668,11 @@
                             verify1d_sum:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        217
                                         {
                                             array_a:
                                                 (Variable
-                                                    214
+                                                    217
                                                     array_a
                                                     []
                                                     InOut
@@ -2693,7 +2693,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    214
+                                                    217
                                                     array_b
                                                     []
                                                     InOut
@@ -2714,7 +2714,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    214
+                                                    217
                                                     eps
                                                     []
                                                     Local
@@ -2730,7 +2730,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    214
+                                                    217
                                                     i
                                                     []
                                                     Local
@@ -2746,7 +2746,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    214
+                                                    217
                                                     result
                                                     []
                                                     InOut
@@ -2767,7 +2767,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    214
+                                                    217
                                                     size
                                                     []
                                                     In
@@ -2816,12 +2816,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 array_a)
-                                    (Var 214 array_b)
-                                    (Var 214 result)
-                                    (Var 214 size)]
+                                    [(Var 217 array_a)
+                                    (Var 217 array_b)
+                                    (Var 217 result)
+                                    (Var 217 size)]
                                     [(=
-                                        (Var 214 eps)
+                                        (Var 217 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -2830,10 +2830,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 214 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 214 size)
+                                            (Var 217 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2848,9 +2848,9 @@
                                                         (RealBinOp
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 214 array_a)
+                                                                    (Var 217 array_a)
                                                                     [(()
-                                                                    (Var 214 i)
+                                                                    (Var 217 i)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -2873,9 +2873,9 @@
                                                                 Mul
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 214 array_b)
+                                                                        (Var 217 array_b)
                                                                         [(()
-                                                                        (Var 214 i)
+                                                                        (Var 217 i)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -2897,9 +2897,9 @@
                                                         )
                                                         Sub
                                                         (ArrayItem
-                                                            (Var 214 result)
+                                                            (Var 217 result)
                                                             [(()
-                                                            (Var 214 i)
+                                                            (Var 217 i)
                                                             ())]
                                                             (Real 8)
                                                             RowMajor
@@ -2913,7 +2913,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 214 eps)
+                                                (Var 217 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2929,11 +2929,11 @@
                             verify2d:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        216
                                         {
                                             array:
                                                 (Variable
-                                                    213
+                                                    216
                                                     array
                                                     []
                                                     InOut
@@ -2957,16 +2957,16 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        225
+                                                        228
                                                         {
                                                             block:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        226
+                                                                        229
                                                                         {
                                                                             cos@__lpython_overloaded_0__cos:
                                                                                 (ExternalSymbol
-                                                                                    226
+                                                                                    229
                                                                                     cos@__lpython_overloaded_0__cos
                                                                                     3 __lpython_overloaded_0__cos
                                                                                     numpy
@@ -2983,15 +2983,15 @@
                                                                                 [(RealBinOp
                                                                                     (RealBinOp
                                                                                         (FunctionCall
-                                                                                            226 cos@__lpython_overloaded_0__cos
+                                                                                            229 cos@__lpython_overloaded_0__cos
                                                                                             2 cos
                                                                                             [((ArrayItem
-                                                                                                (Var 213 array)
+                                                                                                (Var 216 array)
                                                                                                 [(()
-                                                                                                (Var 213 i)
+                                                                                                (Var 216 i)
                                                                                                 ())
                                                                                                 (()
-                                                                                                (Var 213 j)
+                                                                                                (Var 216 j)
                                                                                                 ())]
                                                                                                 (Real 8)
                                                                                                 RowMajor
@@ -3011,12 +3011,12 @@
                                                                                     )
                                                                                     Sub
                                                                                     (ArrayItem
-                                                                                        (Var 213 result)
+                                                                                        (Var 216 result)
                                                                                         [(()
-                                                                                        (Var 213 i)
+                                                                                        (Var 216 i)
                                                                                         ())
                                                                                         (()
-                                                                                        (Var 213 j)
+                                                                                        (Var 216 j)
                                                                                         ())]
                                                                                         (Real 8)
                                                                                         RowMajor
@@ -3030,7 +3030,7 @@
                                                                                 ()
                                                                             )
                                                                             LtE
-                                                                            (Var 213 eps)
+                                                                            (Var 216 eps)
                                                                             (Logical 4)
                                                                             ()
                                                                         )
@@ -3041,10 +3041,10 @@
                                                     block
                                                     [(DoLoop
                                                         ()
-                                                        ((Var 213 j)
+                                                        ((Var 216 j)
                                                         (IntegerConstant 0 (Integer 4))
                                                         (IntegerBinOp
-                                                            (Var 213 size2)
+                                                            (Var 216 size2)
                                                             Sub
                                                             (IntegerConstant 1 (Integer 4))
                                                             (Integer 4)
@@ -3053,13 +3053,13 @@
                                                         (IntegerConstant 1 (Integer 4)))
                                                         [(BlockCall
                                                             -1
-                                                            225 block
+                                                            228 block
                                                         )]
                                                     )]
                                                 ),
                                             eps:
                                                 (Variable
-                                                    213
+                                                    216
                                                     eps
                                                     []
                                                     Local
@@ -3075,7 +3075,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    213
+                                                    216
                                                     i
                                                     []
                                                     Local
@@ -3091,7 +3091,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    213
+                                                    216
                                                     j
                                                     []
                                                     Local
@@ -3107,7 +3107,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    213
+                                                    216
                                                     result
                                                     []
                                                     InOut
@@ -3130,7 +3130,7 @@
                                                 ),
                                             size1:
                                                 (Variable
-                                                    213
+                                                    216
                                                     size1
                                                     []
                                                     In
@@ -3146,7 +3146,7 @@
                                                 ),
                                             size2:
                                                 (Variable
-                                                    213
+                                                    216
                                                     size2
                                                     []
                                                     In
@@ -3194,12 +3194,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 array)
-                                    (Var 213 result)
-                                    (Var 213 size1)
-                                    (Var 213 size2)]
+                                    [(Var 216 array)
+                                    (Var 216 result)
+                                    (Var 216 size1)
+                                    (Var 216 size2)]
                                     [(=
-                                        (Var 213 eps)
+                                        (Var 216 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -3208,10 +3208,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 i)
+                                        ((Var 216 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 213 size1)
+                                            (Var 216 size1)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -3220,7 +3220,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            213 block
+                                            216 block
                                         )]
                                     )]
                                     ()
@@ -3232,11 +3232,11 @@
                             verifynd:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        215
                                         {
                                             array:
                                                 (Variable
-                                                    212
+                                                    215
                                                     array
                                                     []
                                                     InOut
@@ -3262,21 +3262,21 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        222
+                                                        225
                                                         {
                                                             block:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        223
+                                                                        226
                                                                         {
                                                                             block:
                                                                                 (Block
                                                                                     (SymbolTable
-                                                                                        224
+                                                                                        227
                                                                                         {
                                                                                             sin@__lpython_overloaded_0__sin:
                                                                                                 (ExternalSymbol
-                                                                                                    224
+                                                                                                    227
                                                                                                     sin@__lpython_overloaded_0__sin
                                                                                                     3 __lpython_overloaded_0__sin
                                                                                                     numpy
@@ -3293,18 +3293,18 @@
                                                                                                 [(RealBinOp
                                                                                                     (RealBinOp
                                                                                                         (FunctionCall
-                                                                                                            224 sin@__lpython_overloaded_0__sin
+                                                                                                            227 sin@__lpython_overloaded_0__sin
                                                                                                             2 sin
                                                                                                             [((ArrayItem
-                                                                                                                (Var 212 array)
+                                                                                                                (Var 215 array)
                                                                                                                 [(()
-                                                                                                                (Var 212 i)
+                                                                                                                (Var 215 i)
                                                                                                                 ())
                                                                                                                 (()
-                                                                                                                (Var 212 j)
+                                                                                                                (Var 215 j)
                                                                                                                 ())
                                                                                                                 (()
-                                                                                                                (Var 212 k)
+                                                                                                                (Var 215 k)
                                                                                                                 ())]
                                                                                                                 (Real 8)
                                                                                                                 RowMajor
@@ -3324,15 +3324,15 @@
                                                                                                     )
                                                                                                     Sub
                                                                                                     (ArrayItem
-                                                                                                        (Var 212 result)
+                                                                                                        (Var 215 result)
                                                                                                         [(()
-                                                                                                        (Var 212 i)
+                                                                                                        (Var 215 i)
                                                                                                         ())
                                                                                                         (()
-                                                                                                        (Var 212 j)
+                                                                                                        (Var 215 j)
                                                                                                         ())
                                                                                                         (()
-                                                                                                        (Var 212 k)
+                                                                                                        (Var 215 k)
                                                                                                         ())]
                                                                                                         (Real 8)
                                                                                                         RowMajor
@@ -3346,7 +3346,7 @@
                                                                                                 ()
                                                                                             )
                                                                                             LtE
-                                                                                            (Var 212 eps)
+                                                                                            (Var 215 eps)
                                                                                             (Logical 4)
                                                                                             ()
                                                                                         )
@@ -3357,10 +3357,10 @@
                                                                     block
                                                                     [(DoLoop
                                                                         ()
-                                                                        ((Var 212 k)
+                                                                        ((Var 215 k)
                                                                         (IntegerConstant 0 (Integer 4))
                                                                         (IntegerBinOp
-                                                                            (Var 212 size3)
+                                                                            (Var 215 size3)
                                                                             Sub
                                                                             (IntegerConstant 1 (Integer 4))
                                                                             (Integer 4)
@@ -3369,7 +3369,7 @@
                                                                         (IntegerConstant 1 (Integer 4)))
                                                                         [(BlockCall
                                                                             -1
-                                                                            223 block
+                                                                            226 block
                                                                         )]
                                                                     )]
                                                                 )
@@ -3377,10 +3377,10 @@
                                                     block
                                                     [(DoLoop
                                                         ()
-                                                        ((Var 212 j)
+                                                        ((Var 215 j)
                                                         (IntegerConstant 0 (Integer 4))
                                                         (IntegerBinOp
-                                                            (Var 212 size2)
+                                                            (Var 215 size2)
                                                             Sub
                                                             (IntegerConstant 1 (Integer 4))
                                                             (Integer 4)
@@ -3389,13 +3389,13 @@
                                                         (IntegerConstant 1 (Integer 4)))
                                                         [(BlockCall
                                                             -1
-                                                            222 block
+                                                            225 block
                                                         )]
                                                     )]
                                                 ),
                                             eps:
                                                 (Variable
-                                                    212
+                                                    215
                                                     eps
                                                     []
                                                     Local
@@ -3411,7 +3411,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    212
+                                                    215
                                                     i
                                                     []
                                                     Local
@@ -3427,7 +3427,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    212
+                                                    215
                                                     j
                                                     []
                                                     Local
@@ -3443,7 +3443,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    212
+                                                    215
                                                     k
                                                     []
                                                     Local
@@ -3459,7 +3459,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    212
+                                                    215
                                                     result
                                                     []
                                                     InOut
@@ -3484,7 +3484,7 @@
                                                 ),
                                             size1:
                                                 (Variable
-                                                    212
+                                                    215
                                                     size1
                                                     []
                                                     In
@@ -3500,7 +3500,7 @@
                                                 ),
                                             size2:
                                                 (Variable
-                                                    212
+                                                    215
                                                     size2
                                                     []
                                                     In
@@ -3516,7 +3516,7 @@
                                                 ),
                                             size3:
                                                 (Variable
-                                                    212
+                                                    215
                                                     size3
                                                     []
                                                     In
@@ -3569,13 +3569,13 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 array)
-                                    (Var 212 result)
-                                    (Var 212 size1)
-                                    (Var 212 size2)
-                                    (Var 212 size3)]
+                                    [(Var 215 array)
+                                    (Var 215 result)
+                                    (Var 215 size1)
+                                    (Var 215 size2)
+                                    (Var 215 size3)]
                                     [(=
-                                        (Var 212 eps)
+                                        (Var 215 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -3584,10 +3584,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 212 i)
+                                        ((Var 215 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 212 size1)
+                                            (Var 215 size1)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -3596,7 +3596,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            212 block
+                                            215 block
                                         )]
                                     )]
                                     ()
@@ -3616,11 +3616,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        245
+                        248
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    245
+                                    248
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -3632,7 +3632,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        245 __main__global_stmts
+                        248 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-expr10-efcbb1b.json
+++ b/tests/reference/asr-expr10-efcbb1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr10-efcbb1b.stdout",
-    "stdout_hash": "e5af4d07e688e5d3f0fa40058fe7d249ce5675929b44d2858d9ac6fa",
+    "stdout_hash": "db23071a8c35c6beca728a45275cbf4a95106cb646f4f9637884a0f0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr10-efcbb1b.stdout
+++ b/tests/reference/asr-expr10-efcbb1b.stdout
@@ -440,7 +440,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        129
+                        132
                         {
                             
                         })

--- a/tests/reference/asr-expr13-81bdb5a.json
+++ b/tests/reference/asr-expr13-81bdb5a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr13-81bdb5a.stdout",
-    "stdout_hash": "3faa0920151f2cb40d38e75757bf51817410141b1d74fb55da4215e6",
+    "stdout_hash": "42ada2aa8d8e3a6900fddfcadb89ff26e4564f71b1f6e6a012b10db1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr13-81bdb5a.stdout
+++ b/tests/reference/asr-expr13-81bdb5a.stdout
@@ -459,7 +459,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        129
+                        132
                         {
                             
                         })

--- a/tests/reference/asr-expr7-480ba2f.json
+++ b/tests/reference/asr-expr7-480ba2f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr7-480ba2f.stdout",
-    "stdout_hash": "eadbba4703440765da070a31d868859432c562349c5c2552222b70fc",
+    "stdout_hash": "d6b877deea6ac954bae4c9fd992a91262c7f03ae9f0512533c71056c",
     "stderr": "asr-expr7-480ba2f.stderr",
     "stderr_hash": "6e9790ac88db1a9ead8f64a91ba8a6605de67167037908a74b77be0c",
     "returncode": 0

--- a/tests/reference/asr-expr7-480ba2f.stdout
+++ b/tests/reference/asr-expr7-480ba2f.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        131
+                                        134
                                         {
                                             
                                         })
@@ -344,11 +344,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        132
+                        135
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    132
+                                    135
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -360,7 +360,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        132 __main__global_stmts
+                        135 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-expr_05-3a37324.json
+++ b/tests/reference/asr-expr_05-3a37324.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr_05-3a37324.stdout",
-    "stdout_hash": "a83c0f670181262a752f1ed741cb5d1f075b8bca5d6d4d7ae4c9c15c",
+    "stdout_hash": "23fba26e242ce853402ddd54fdcb182f1cda64907d8d0462dba53f5a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr_05-3a37324.stdout
+++ b/tests/reference/asr-expr_05-3a37324.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        131
+                                        134
                                         {
                                             
                                         })
@@ -1612,11 +1612,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        132
+                        135
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    132
+                                    135
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1628,7 +1628,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        132 __main__global_stmts
+                        135 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_01-682b1b2.json
+++ b/tests/reference/asr-generics_array_01-682b1b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_01-682b1b2.stdout",
-    "stdout_hash": "c4e52ae547d6c1e2d120fe108b5c332d2ec5155a275fc76da9dee893",
+    "stdout_hash": "b638a5f7ebae96356111dc1743dca87dda7f8bc99e23630c37393e34",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_01-682b1b2.stdout
+++ b/tests/reference/asr-generics_array_01-682b1b2.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_f_0:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        216
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    216
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -48,7 +48,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    213
+                                                    216
                                                     i
                                                     []
                                                     In
@@ -64,7 +64,7 @@
                                                 ),
                                             lst:
                                                 (Variable
-                                                    213
+                                                    216
                                                     lst
                                                     []
                                                     InOut
@@ -106,11 +106,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 lst)
-                                    (Var 213 i)]
+                                    [(Var 216 lst)
+                                    (Var 216 i)]
                                     [(=
                                         (ArrayItem
-                                            (Var 213 lst)
+                                            (Var 216 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -118,13 +118,13 @@
                                             RowMajor
                                             ()
                                         )
-                                        (Var 213 i)
+                                        (Var 216 i)
                                         ()
                                     )
                                     (=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 216 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 213 lst)
+                                            (Var 216 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -135,7 +135,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 216 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -144,7 +144,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        217
                                         {
                                             
                                         })
@@ -180,11 +180,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        214
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    214
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -202,7 +202,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    211
+                                                    214
                                                     i
                                                     []
                                                     In
@@ -220,7 +220,7 @@
                                                 ),
                                             lst:
                                                 (Variable
-                                                    211
+                                                    214
                                                     lst
                                                     []
                                                     InOut
@@ -270,11 +270,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 lst)
-                                    (Var 211 i)]
+                                    [(Var 214 lst)
+                                    (Var 214 i)]
                                     [(=
                                         (ArrayItem
-                                            (Var 211 lst)
+                                            (Var 214 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -284,13 +284,13 @@
                                             RowMajor
                                             ()
                                         )
-                                        (Var 211 i)
+                                        (Var 214 i)
                                         ()
                                     )
                                     (=
-                                        (Var 211 _lpython_return_variable)
+                                        (Var 214 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 211 lst)
+                                            (Var 214 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -303,7 +303,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 214 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -312,11 +312,11 @@
                             use_array:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        215
                                         {
                                             array:
                                                 (Variable
-                                                    212
+                                                    215
                                                     array
                                                     []
                                                     Local
@@ -337,7 +337,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    212
+                                                    215
                                                     x
                                                     []
                                                     Local
@@ -370,7 +370,7 @@
                                     [__asr_generic_f_0]
                                     []
                                     [(=
-                                        (Var 212 array)
+                                        (Var 215 array)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -384,7 +384,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 x)
+                                        (Var 215 x)
                                         (IntegerConstant 69 (Integer 4))
                                         ()
                                     )
@@ -393,7 +393,7 @@
                                             2 __asr_generic_f_0
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 212 array)
+                                                (Var 215 array)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -404,7 +404,7 @@
                                                 )
                                                 ()
                                             ))
-                                            ((Var 212 x))]
+                                            ((Var 215 x))]
                                             (Integer 4)
                                             ()
                                             ()
@@ -429,11 +429,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        215
+                        218
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    215
+                                    218
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -445,7 +445,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        215 __main__global_stmts
+                        218 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_02-22c8dc1.json
+++ b/tests/reference/asr-generics_array_02-22c8dc1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_02-22c8dc1.stdout",
-    "stdout_hash": "75ccb4ee0e075aa0ed2e7da482eb1afe58c4bd1028306f083047014d",
+    "stdout_hash": "e079d0b117f9e91ae7a9e990565a1e30a10e4fd9b96132f24fffd407",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_02-22c8dc1.stdout
+++ b/tests/reference/asr-generics_array_02-22c8dc1.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_g_0:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        220
                                         {
                                             a:
                                                 (Variable
-                                                    217
+                                                    220
                                                     a
                                                     [n]
                                                     InOut
@@ -42,7 +42,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 n))]
+                                                        (Var 220 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -53,7 +53,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    217
+                                                    220
                                                     b
                                                     [n]
                                                     InOut
@@ -63,7 +63,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 n))]
+                                                        (Var 220 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -74,7 +74,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    217
+                                                    220
                                                     i
                                                     []
                                                     Local
@@ -90,7 +90,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    217
+                                                    220
                                                     n
                                                     []
                                                     In
@@ -106,7 +106,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    217
+                                                    220
                                                     r
                                                     [n]
                                                     Local
@@ -116,7 +116,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 n))]
+                                                        (Var 220 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -162,17 +162,17 @@
                                         .false.
                                     )
                                     [add_integer]
-                                    [(Var 217 n)
-                                    (Var 217 a)
-                                    (Var 217 b)]
+                                    [(Var 220 n)
+                                    (Var 220 a)
+                                    (Var 220 b)]
                                     [(=
-                                        (Var 217 r)
+                                        (Var 220 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Integer 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 217 n))]
+                                                (Var 220 n))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -181,10 +181,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 217 i)
+                                        ((Var 220 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 217 n)
+                                            (Var 220 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -193,9 +193,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 217 r)
+                                                (Var 220 r)
                                                 [(()
-                                                (Var 217 i)
+                                                (Var 220 i)
                                                 ())]
                                                 (Integer 4)
                                                 RowMajor
@@ -205,18 +205,18 @@
                                                 2 add_integer
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 217 a)
+                                                    (Var 220 a)
                                                     [(()
-                                                    (Var 217 i)
+                                                    (Var 220 i)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 217 b)
+                                                    (Var 220 b)
                                                     [(()
-                                                    (Var 217 i)
+                                                    (Var 220 i)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
@@ -231,7 +231,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 217 r)
+                                            (Var 220 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -251,11 +251,11 @@
                             __asr_generic_g_1:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        221
                                         {
                                             a:
                                                 (Variable
-                                                    218
+                                                    221
                                                     a
                                                     [n]
                                                     InOut
@@ -265,7 +265,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))]
+                                                        (Var 221 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -276,7 +276,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    218
+                                                    221
                                                     b
                                                     [n]
                                                     InOut
@@ -286,7 +286,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))]
+                                                        (Var 221 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -297,7 +297,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    218
+                                                    221
                                                     i
                                                     []
                                                     Local
@@ -313,7 +313,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    218
+                                                    221
                                                     n
                                                     []
                                                     In
@@ -329,7 +329,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    218
+                                                    221
                                                     r
                                                     [n]
                                                     Local
@@ -339,7 +339,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))]
+                                                        (Var 221 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -385,17 +385,17 @@
                                         .false.
                                     )
                                     [add_float]
-                                    [(Var 218 n)
-                                    (Var 218 a)
-                                    (Var 218 b)]
+                                    [(Var 221 n)
+                                    (Var 221 a)
+                                    (Var 221 b)]
                                     [(=
-                                        (Var 218 r)
+                                        (Var 221 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Real 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 218 n))]
+                                                (Var 221 n))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -404,10 +404,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 218 i)
+                                        ((Var 221 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 218 n)
+                                            (Var 221 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -416,9 +416,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 218 r)
+                                                (Var 221 r)
                                                 [(()
-                                                (Var 218 i)
+                                                (Var 221 i)
                                                 ())]
                                                 (Real 4)
                                                 RowMajor
@@ -428,18 +428,18 @@
                                                 2 add_float
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 218 a)
+                                                    (Var 221 a)
                                                     [(()
-                                                    (Var 218 i)
+                                                    (Var 221 i)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 218 b)
+                                                    (Var 221 b)
                                                     [(()
-                                                    (Var 218 i)
+                                                    (Var 221 i)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
@@ -454,7 +454,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 218 r)
+                                            (Var 221 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -474,7 +474,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        219
+                                        222
                                         {
                                             
                                         })
@@ -510,11 +510,11 @@
                             add:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        214
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    214
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -532,7 +532,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    211
+                                                    214
                                                     x
                                                     []
                                                     In
@@ -550,7 +550,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    211
+                                                    214
                                                     y
                                                     []
                                                     In
@@ -590,10 +590,10 @@
                                         .true.
                                     )
                                     []
-                                    [(Var 211 x)
-                                    (Var 211 y)]
+                                    [(Var 214 x)
+                                    (Var 214 y)]
                                     []
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 214 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -602,11 +602,11 @@
                             add_float:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        216
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    216
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -622,7 +622,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    213
+                                                    216
                                                     x
                                                     []
                                                     In
@@ -638,7 +638,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    213
+                                                    216
                                                     y
                                                     []
                                                     In
@@ -670,21 +670,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 x)
-                                    (Var 213 y)]
+                                    [(Var 216 x)
+                                    (Var 216 y)]
                                     [(=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 216 _lpython_return_variable)
                                         (RealBinOp
-                                            (Var 213 x)
+                                            (Var 216 x)
                                             Add
-                                            (Var 213 y)
+                                            (Var 216 y)
                                             (Real 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 216 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -693,11 +693,11 @@
                             add_integer:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        215
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    212
+                                                    215
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -713,7 +713,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    212
+                                                    215
                                                     x
                                                     []
                                                     In
@@ -729,7 +729,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    212
+                                                    215
                                                     y
                                                     []
                                                     In
@@ -761,21 +761,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 x)
-                                    (Var 212 y)]
+                                    [(Var 215 x)
+                                    (Var 215 y)]
                                     [(=
-                                        (Var 212 _lpython_return_variable)
+                                        (Var 215 _lpython_return_variable)
                                         (IntegerBinOp
-                                            (Var 212 x)
+                                            (Var 215 x)
                                             Add
-                                            (Var 212 y)
+                                            (Var 215 y)
                                             (Integer 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 212 _lpython_return_variable)
+                                    (Var 215 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -784,11 +784,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        217
                                         {
                                             a:
                                                 (Variable
-                                                    214
+                                                    217
                                                     a
                                                     [n]
                                                     InOut
@@ -800,7 +800,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))]
+                                                        (Var 217 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -811,7 +811,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    214
+                                                    217
                                                     b
                                                     [n]
                                                     InOut
@@ -823,7 +823,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))]
+                                                        (Var 217 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -834,7 +834,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    214
+                                                    217
                                                     i
                                                     []
                                                     Local
@@ -850,7 +850,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    214
+                                                    217
                                                     n
                                                     []
                                                     In
@@ -866,7 +866,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    214
+                                                    217
                                                     r
                                                     [n]
                                                     Local
@@ -878,7 +878,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))]
+                                                        (Var 217 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -928,11 +928,11 @@
                                         .false.
                                     )
                                     [add]
-                                    [(Var 214 n)
-                                    (Var 214 a)
-                                    (Var 214 b)]
+                                    [(Var 217 n)
+                                    (Var 217 a)
+                                    (Var 217 b)]
                                     [(=
-                                        (Var 214 r)
+                                        (Var 217 r)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -940,7 +940,7 @@
                                                     T
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 214 n))]
+                                                (Var 217 n))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -949,10 +949,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 214 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 214 n)
+                                            (Var 217 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -961,9 +961,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 214 r)
+                                                (Var 217 r)
                                                 [(()
-                                                (Var 214 i)
+                                                (Var 217 i)
                                                 ())]
                                                 (TypeParameter
                                                     T
@@ -975,9 +975,9 @@
                                                 2 add
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 214 a)
+                                                    (Var 217 a)
                                                     [(()
-                                                    (Var 214 i)
+                                                    (Var 217 i)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -986,9 +986,9 @@
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 214 b)
+                                                    (Var 217 b)
                                                     [(()
-                                                    (Var 214 i)
+                                                    (Var 217 i)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -1007,7 +1007,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 214 r)
+                                            (Var 217 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1029,11 +1029,11 @@
                             main:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        218
                                         {
                                             a_float:
                                                 (Variable
-                                                    215
+                                                    218
                                                     a_float
                                                     []
                                                     Local
@@ -1054,7 +1054,7 @@
                                                 ),
                                             a_int:
                                                 (Variable
-                                                    215
+                                                    218
                                                     a_int
                                                     []
                                                     Local
@@ -1075,7 +1075,7 @@
                                                 ),
                                             b_float:
                                                 (Variable
-                                                    215
+                                                    218
                                                     b_float
                                                     []
                                                     Local
@@ -1096,7 +1096,7 @@
                                                 ),
                                             b_int:
                                                 (Variable
-                                                    215
+                                                    218
                                                     b_int
                                                     []
                                                     Local
@@ -1135,7 +1135,7 @@
                                     __asr_generic_g_1]
                                     []
                                     [(=
-                                        (Var 215 a_int)
+                                        (Var 218 a_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1150,7 +1150,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 a_int)
+                                            (Var 218 a_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1162,7 +1162,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 b_int)
+                                        (Var 218 b_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1177,7 +1177,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 b_int)
+                                            (Var 218 b_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1193,7 +1193,7 @@
                                         ()
                                         [((IntegerConstant 1 (Integer 4)))
                                         ((ArrayPhysicalCast
-                                            (Var 215 a_int)
+                                            (Var 218 a_int)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1205,7 +1205,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 215 b_int)
+                                            (Var 218 b_int)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1219,7 +1219,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 a_float)
+                                        (Var 218 a_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1234,7 +1234,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 a_float)
+                                            (Var 218 a_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1257,7 +1257,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 b_float)
+                                        (Var 218 b_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1272,7 +1272,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 b_float)
+                                            (Var 218 b_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1299,7 +1299,7 @@
                                         ()
                                         [((IntegerConstant 1 (Integer 4)))
                                         ((ArrayPhysicalCast
-                                            (Var 215 a_float)
+                                            (Var 218 a_float)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1311,7 +1311,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 215 b_float)
+                                            (Var 218 b_float)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1359,11 +1359,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        220
+                        223
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    220
+                                    223
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1375,7 +1375,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        220 __main__global_stmts
+                        223 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_03-fb3706c.json
+++ b/tests/reference/asr-generics_array_03-fb3706c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_03-fb3706c.stdout",
-    "stdout_hash": "604160a697a7d9fb44eb61417d9f9363a16563e903f31c861a5e7bf6",
+    "stdout_hash": "5f2c17f54a06cda73ace269213f2f548081a76d94de4c7bcc4c7405b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_03-fb3706c.stdout
+++ b/tests/reference/asr-generics_array_03-fb3706c.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_g_0:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        221
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    218
+                                                    221
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -43,9 +43,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))
+                                                        (Var 221 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 m))]
+                                                        (Var 221 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -56,7 +56,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    218
+                                                    221
                                                     a
                                                     [n
                                                     m]
@@ -67,9 +67,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))
+                                                        (Var 221 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 m))]
+                                                        (Var 221 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -80,7 +80,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    218
+                                                    221
                                                     b
                                                     [n
                                                     m]
@@ -91,9 +91,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))
+                                                        (Var 221 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 m))]
+                                                        (Var 221 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -104,7 +104,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    218
+                                                    221
                                                     i
                                                     []
                                                     Local
@@ -120,7 +120,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    218
+                                                    221
                                                     j
                                                     []
                                                     Local
@@ -136,7 +136,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    218
+                                                    221
                                                     m
                                                     []
                                                     In
@@ -152,7 +152,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    218
+                                                    221
                                                     n
                                                     []
                                                     In
@@ -168,7 +168,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    218
+                                                    221
                                                     r
                                                     [n
                                                     m]
@@ -179,9 +179,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))
+                                                        (Var 221 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 m))]
+                                                        (Var 221 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -255,20 +255,20 @@
                                         .false.
                                     )
                                     [add_integer]
-                                    [(Var 218 n)
-                                    (Var 218 m)
-                                    (Var 218 a)
-                                    (Var 218 b)]
+                                    [(Var 221 n)
+                                    (Var 221 m)
+                                    (Var 221 a)
+                                    (Var 221 b)]
                                     [(=
-                                        (Var 218 r)
+                                        (Var 221 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Integer 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 218 n))
+                                                (Var 221 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 218 m))]
+                                                (Var 221 m))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -277,10 +277,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 218 i)
+                                        ((Var 221 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 218 n)
+                                            (Var 221 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -289,10 +289,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 218 j)
+                                            ((Var 221 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 218 m)
+                                                (Var 221 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -301,12 +301,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 218 r)
+                                                    (Var 221 r)
                                                     [(()
-                                                    (Var 218 i)
+                                                    (Var 221 i)
                                                     ())
                                                     (()
-                                                    (Var 218 j)
+                                                    (Var 221 j)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
@@ -316,24 +316,24 @@
                                                     2 add_integer
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 218 a)
+                                                        (Var 221 a)
                                                         [(()
-                                                        (Var 218 i)
+                                                        (Var 221 i)
                                                         ())
                                                         (()
-                                                        (Var 218 j)
+                                                        (Var 221 j)
                                                         ())]
                                                         (Integer 4)
                                                         RowMajor
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 218 b)
+                                                        (Var 221 b)
                                                         [(()
-                                                        (Var 218 i)
+                                                        (Var 221 i)
                                                         ())
                                                         (()
-                                                        (Var 218 j)
+                                                        (Var 221 j)
                                                         ())]
                                                         (Integer 4)
                                                         RowMajor
@@ -349,7 +349,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 218 r)
+                                            (Var 221 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -363,7 +363,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 218 _lpython_return_variable)
+                                    (Var 221 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -372,11 +372,11 @@
                             __asr_generic_g_1:
                                 (Function
                                     (SymbolTable
-                                        219
+                                        222
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    219
+                                                    222
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -387,9 +387,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 n))
+                                                        (Var 222 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 m))]
+                                                        (Var 222 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -400,7 +400,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    219
+                                                    222
                                                     a
                                                     [n
                                                     m]
@@ -411,9 +411,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 n))
+                                                        (Var 222 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 m))]
+                                                        (Var 222 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -424,7 +424,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    219
+                                                    222
                                                     b
                                                     [n
                                                     m]
@@ -435,9 +435,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 n))
+                                                        (Var 222 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 m))]
+                                                        (Var 222 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -448,7 +448,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    219
+                                                    222
                                                     i
                                                     []
                                                     Local
@@ -464,7 +464,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    219
+                                                    222
                                                     j
                                                     []
                                                     Local
@@ -480,7 +480,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    219
+                                                    222
                                                     m
                                                     []
                                                     In
@@ -496,7 +496,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    219
+                                                    222
                                                     n
                                                     []
                                                     In
@@ -512,7 +512,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    219
+                                                    222
                                                     r
                                                     [n
                                                     m]
@@ -523,9 +523,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 n))
+                                                        (Var 222 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 m))]
+                                                        (Var 222 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -599,20 +599,20 @@
                                         .false.
                                     )
                                     [add_float]
-                                    [(Var 219 n)
-                                    (Var 219 m)
-                                    (Var 219 a)
-                                    (Var 219 b)]
+                                    [(Var 222 n)
+                                    (Var 222 m)
+                                    (Var 222 a)
+                                    (Var 222 b)]
                                     [(=
-                                        (Var 219 r)
+                                        (Var 222 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Real 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 219 n))
+                                                (Var 222 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 219 m))]
+                                                (Var 222 m))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -621,10 +621,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 219 i)
+                                        ((Var 222 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 219 n)
+                                            (Var 222 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -633,10 +633,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 219 j)
+                                            ((Var 222 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 219 m)
+                                                (Var 222 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -645,12 +645,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 219 r)
+                                                    (Var 222 r)
                                                     [(()
-                                                    (Var 219 i)
+                                                    (Var 222 i)
                                                     ())
                                                     (()
-                                                    (Var 219 j)
+                                                    (Var 222 j)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
@@ -660,24 +660,24 @@
                                                     2 add_float
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 219 a)
+                                                        (Var 222 a)
                                                         [(()
-                                                        (Var 219 i)
+                                                        (Var 222 i)
                                                         ())
                                                         (()
-                                                        (Var 219 j)
+                                                        (Var 222 j)
                                                         ())]
                                                         (Real 4)
                                                         RowMajor
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 219 b)
+                                                        (Var 222 b)
                                                         [(()
-                                                        (Var 219 i)
+                                                        (Var 222 i)
                                                         ())
                                                         (()
-                                                        (Var 219 j)
+                                                        (Var 222 j)
                                                         ())]
                                                         (Real 4)
                                                         RowMajor
@@ -693,7 +693,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 219 r)
+                                            (Var 222 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -707,7 +707,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 219 _lpython_return_variable)
+                                    (Var 222 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -716,7 +716,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        220
+                                        223
                                         {
                                             
                                         })
@@ -752,11 +752,11 @@
                             add:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        214
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    214
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -774,7 +774,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    211
+                                                    214
                                                     x
                                                     []
                                                     In
@@ -792,7 +792,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    211
+                                                    214
                                                     y
                                                     []
                                                     In
@@ -832,10 +832,10 @@
                                         .true.
                                     )
                                     []
-                                    [(Var 211 x)
-                                    (Var 211 y)]
+                                    [(Var 214 x)
+                                    (Var 214 y)]
                                     []
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 214 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -844,11 +844,11 @@
                             add_float:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        216
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    216
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -864,7 +864,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    213
+                                                    216
                                                     x
                                                     []
                                                     In
@@ -880,7 +880,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    213
+                                                    216
                                                     y
                                                     []
                                                     In
@@ -912,21 +912,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 x)
-                                    (Var 213 y)]
+                                    [(Var 216 x)
+                                    (Var 216 y)]
                                     [(=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 216 _lpython_return_variable)
                                         (RealBinOp
-                                            (Var 213 x)
+                                            (Var 216 x)
                                             Add
-                                            (Var 213 y)
+                                            (Var 216 y)
                                             (Real 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 216 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -935,11 +935,11 @@
                             add_integer:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        215
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    212
+                                                    215
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -955,7 +955,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    212
+                                                    215
                                                     x
                                                     []
                                                     In
@@ -971,7 +971,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    212
+                                                    215
                                                     y
                                                     []
                                                     In
@@ -1003,21 +1003,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 x)
-                                    (Var 212 y)]
+                                    [(Var 215 x)
+                                    (Var 215 y)]
                                     [(=
-                                        (Var 212 _lpython_return_variable)
+                                        (Var 215 _lpython_return_variable)
                                         (IntegerBinOp
-                                            (Var 212 x)
+                                            (Var 215 x)
                                             Add
-                                            (Var 212 y)
+                                            (Var 215 y)
                                             (Integer 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 212 _lpython_return_variable)
+                                    (Var 215 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -1026,11 +1026,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        217
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    214
+                                                    217
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -1043,9 +1043,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))
+                                                        (Var 217 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 m))]
+                                                        (Var 217 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1056,7 +1056,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    214
+                                                    217
                                                     a
                                                     [n
                                                     m]
@@ -1069,9 +1069,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))
+                                                        (Var 217 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 m))]
+                                                        (Var 217 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1082,7 +1082,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    214
+                                                    217
                                                     b
                                                     [n
                                                     m]
@@ -1095,9 +1095,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))
+                                                        (Var 217 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 m))]
+                                                        (Var 217 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1108,7 +1108,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    214
+                                                    217
                                                     i
                                                     []
                                                     Local
@@ -1124,7 +1124,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    214
+                                                    217
                                                     j
                                                     []
                                                     Local
@@ -1140,7 +1140,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    214
+                                                    217
                                                     m
                                                     []
                                                     In
@@ -1156,7 +1156,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    214
+                                                    217
                                                     n
                                                     []
                                                     In
@@ -1172,7 +1172,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    214
+                                                    217
                                                     r
                                                     [n
                                                     m]
@@ -1185,9 +1185,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))
+                                                        (Var 217 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 m))]
+                                                        (Var 217 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1267,12 +1267,12 @@
                                         .false.
                                     )
                                     [add]
-                                    [(Var 214 n)
-                                    (Var 214 m)
-                                    (Var 214 a)
-                                    (Var 214 b)]
+                                    [(Var 217 n)
+                                    (Var 217 m)
+                                    (Var 217 a)
+                                    (Var 217 b)]
                                     [(=
-                                        (Var 214 r)
+                                        (Var 217 r)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1280,9 +1280,9 @@
                                                     T
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 214 n))
+                                                (Var 217 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 214 m))]
+                                                (Var 217 m))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -1291,10 +1291,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 214 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 214 n)
+                                            (Var 217 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -1303,10 +1303,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 214 j)
+                                            ((Var 217 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 214 m)
+                                                (Var 217 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -1315,12 +1315,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 214 r)
+                                                    (Var 217 r)
                                                     [(()
-                                                    (Var 214 i)
+                                                    (Var 217 i)
                                                     ())
                                                     (()
-                                                    (Var 214 j)
+                                                    (Var 217 j)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -1332,12 +1332,12 @@
                                                     2 add
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 214 a)
+                                                        (Var 217 a)
                                                         [(()
-                                                        (Var 214 i)
+                                                        (Var 217 i)
                                                         ())
                                                         (()
-                                                        (Var 214 j)
+                                                        (Var 217 j)
                                                         ())]
                                                         (TypeParameter
                                                             T
@@ -1346,12 +1346,12 @@
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 214 b)
+                                                        (Var 217 b)
                                                         [(()
-                                                        (Var 214 i)
+                                                        (Var 217 i)
                                                         ())
                                                         (()
-                                                        (Var 214 j)
+                                                        (Var 217 j)
                                                         ())]
                                                         (TypeParameter
                                                             T
@@ -1371,7 +1371,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 214 r)
+                                            (Var 217 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1387,7 +1387,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 214 _lpython_return_variable)
+                                    (Var 217 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -1414,11 +1414,11 @@
                             main:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        218
                                         {
                                             __lcompilers_dummy:
                                                 (Variable
-                                                    215
+                                                    218
                                                     __lcompilers_dummy
                                                     []
                                                     Local
@@ -1441,7 +1441,7 @@
                                                 ),
                                             __lcompilers_dummy1:
                                                 (Variable
-                                                    215
+                                                    218
                                                     __lcompilers_dummy1
                                                     []
                                                     Local
@@ -1464,7 +1464,7 @@
                                                 ),
                                             a_float:
                                                 (Variable
-                                                    215
+                                                    218
                                                     a_float
                                                     []
                                                     Local
@@ -1487,7 +1487,7 @@
                                                 ),
                                             a_int:
                                                 (Variable
-                                                    215
+                                                    218
                                                     a_int
                                                     []
                                                     Local
@@ -1510,7 +1510,7 @@
                                                 ),
                                             b_float:
                                                 (Variable
-                                                    215
+                                                    218
                                                     b_float
                                                     []
                                                     Local
@@ -1533,7 +1533,7 @@
                                                 ),
                                             b_int:
                                                 (Variable
-                                                    215
+                                                    218
                                                     b_int
                                                     []
                                                     Local
@@ -1574,7 +1574,7 @@
                                     __asr_generic_g_1]
                                     []
                                     [(=
-                                        (Var 215 a_int)
+                                        (Var 218 a_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1591,7 +1591,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 a_int)
+                                            (Var 218 a_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1606,7 +1606,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 b_int)
+                                        (Var 218 b_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1623,7 +1623,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 b_int)
+                                            (Var 218 b_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1638,14 +1638,14 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 __lcompilers_dummy)
+                                        (Var 218 __lcompilers_dummy)
                                         (FunctionCall
                                             2 __asr_generic_g_0
                                             ()
                                             [((IntegerConstant 1 (Integer 4)))
                                             ((IntegerConstant 1 (Integer 4)))
                                             ((ArrayPhysicalCast
-                                                (Var 215 a_int)
+                                                (Var 218 a_int)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1659,7 +1659,7 @@
                                                 ()
                                             ))
                                             ((ArrayPhysicalCast
-                                                (Var 215 b_int)
+                                                (Var 218 b_int)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1686,7 +1686,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 a_float)
+                                        (Var 218 a_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1703,7 +1703,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 a_float)
+                                            (Var 218 a_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1726,7 +1726,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 b_float)
+                                        (Var 218 b_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1743,7 +1743,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 b_float)
+                                            (Var 218 b_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1766,14 +1766,14 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 __lcompilers_dummy1)
+                                        (Var 218 __lcompilers_dummy1)
                                         (FunctionCall
                                             2 __asr_generic_g_1
                                             ()
                                             [((IntegerConstant 1 (Integer 4)))
                                             ((IntegerConstant 1 (Integer 4)))
                                             ((ArrayPhysicalCast
-                                                (Var 215 a_float)
+                                                (Var 218 a_float)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1787,7 +1787,7 @@
                                                 ()
                                             ))
                                             ((ArrayPhysicalCast
-                                                (Var 215 b_float)
+                                                (Var 218 b_float)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1848,11 +1848,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        221
+                        224
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    221
+                                    224
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1864,7 +1864,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        221 __main__global_stmts
+                        224 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-structs_05-fa98307.json
+++ b/tests/reference/asr-structs_05-fa98307.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_05-fa98307.stdout",
-    "stdout_hash": "370ee356dca208792b4f44a5657e7f2ce3da67e9ec213d3664139c70",
+    "stdout_hash": "2084b5ab21c189a26227491af3962ff447d0a621c99acbb2bbb42d07",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_05-fa98307.stdout
+++ b/tests/reference/asr-structs_05-fa98307.stdout
@@ -10,11 +10,11 @@
                             A:
                                 (StructType
                                     (SymbolTable
-                                        211
+                                        214
                                         {
                                             a:
                                                 (Variable
-                                                    211
+                                                    214
                                                     a
                                                     []
                                                     Local
@@ -30,7 +30,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    211
+                                                    214
                                                     b
                                                     []
                                                     Local
@@ -46,7 +46,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    211
+                                                    214
                                                     c
                                                     []
                                                     Local
@@ -62,7 +62,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    211
+                                                    214
                                                     d
                                                     []
                                                     Local
@@ -78,7 +78,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    211
+                                                    214
                                                     x
                                                     []
                                                     Local
@@ -94,7 +94,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    211
+                                                    214
                                                     y
                                                     []
                                                     Local
@@ -110,7 +110,7 @@
                                                 ),
                                             z:
                                                 (Variable
-                                                    211
+                                                    214
                                                     z
                                                     []
                                                     Local
@@ -151,7 +151,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        220
                                         {
                                             
                                         })
@@ -187,11 +187,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        218
                                         {
                                             y:
                                                 (Variable
-                                                    215
+                                                    218
                                                     y
                                                     []
                                                     Local
@@ -233,7 +233,7 @@
                                     update_2]
                                     []
                                     [(=
-                                        (Var 215 y)
+                                        (Var 218 y)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -250,7 +250,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 y)
+                                            (Var 218 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -310,7 +310,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 y)
+                                            (Var 218 y)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -372,7 +372,7 @@
                                         2 verify
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 215 y)
+                                            (Var 218 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -401,7 +401,7 @@
                                         2 update_1
                                         ()
                                         [((ArrayItem
-                                            (Var 215 y)
+                                            (Var 218 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -417,7 +417,7 @@
                                         2 update_2
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 215 y)
+                                            (Var 218 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -436,7 +436,7 @@
                                         2 verify
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 215 y)
+                                            (Var 218 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -470,11 +470,11 @@
                             update_1:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        216
                                         {
                                             s:
                                                 (Variable
-                                                    213
+                                                    216
                                                     s
                                                     []
                                                     InOut
@@ -509,11 +509,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 s)]
+                                    [(Var 216 s)]
                                     [(=
                                         (StructInstanceMember
-                                            (Var 213 s)
-                                            211 x
+                                            (Var 216 s)
+                                            214 x
                                             (Integer 4)
                                             ()
                                         )
@@ -522,8 +522,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 213 s)
-                                            211 y
+                                            (Var 216 s)
+                                            214 y
                                             (Real 8)
                                             ()
                                         )
@@ -535,8 +535,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 213 s)
-                                            211 z
+                                            (Var 216 s)
+                                            214 z
                                             (Integer 8)
                                             ()
                                         )
@@ -550,8 +550,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 213 s)
-                                            211 a
+                                            (Var 216 s)
+                                            214 a
                                             (Real 4)
                                             ()
                                         )
@@ -571,8 +571,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 213 s)
-                                            211 b
+                                            (Var 216 s)
+                                            214 b
                                             (Integer 2)
                                             ()
                                         )
@@ -586,8 +586,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 213 s)
-                                            211 c
+                                            (Var 216 s)
+                                            214 c
                                             (Integer 1)
                                             ()
                                         )
@@ -608,11 +608,11 @@
                             update_2:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        217
                                         {
                                             s:
                                                 (Variable
-                                                    214
+                                                    217
                                                     s
                                                     []
                                                     InOut
@@ -657,11 +657,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 s)]
+                                    [(Var 217 s)]
                                     [(=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 214 s)
+                                                (Var 217 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -671,7 +671,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            211 x
+                                            214 x
                                             (Integer 4)
                                             ()
                                         )
@@ -681,7 +681,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 214 s)
+                                                (Var 217 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -691,7 +691,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            211 y
+                                            214 y
                                             (Real 8)
                                             ()
                                         )
@@ -704,7 +704,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 214 s)
+                                                (Var 217 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -714,7 +714,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            211 z
+                                            214 z
                                             (Integer 8)
                                             ()
                                         )
@@ -729,7 +729,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 214 s)
+                                                (Var 217 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -739,7 +739,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            211 a
+                                            214 a
                                             (Real 4)
                                             ()
                                         )
@@ -760,7 +760,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 214 s)
+                                                (Var 217 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -770,7 +770,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            211 b
+                                            214 b
                                             (Integer 2)
                                             ()
                                         )
@@ -785,7 +785,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 214 s)
+                                                (Var 217 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -795,7 +795,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            211 c
+                                            214 c
                                             (Integer 1)
                                             ()
                                         )
@@ -816,11 +816,11 @@
                             verify:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        215
                                         {
                                             eps:
                                                 (Variable
-                                                    212
+                                                    215
                                                     eps
                                                     []
                                                     Local
@@ -836,7 +836,7 @@
                                                 ),
                                             s:
                                                 (Variable
-                                                    212
+                                                    215
                                                     s
                                                     []
                                                     InOut
@@ -859,7 +859,7 @@
                                                 ),
                                             s0:
                                                 (Variable
-                                                    212
+                                                    215
                                                     s0
                                                     []
                                                     Local
@@ -877,7 +877,7 @@
                                                 ),
                                             s1:
                                                 (Variable
-                                                    212
+                                                    215
                                                     s1
                                                     []
                                                     Local
@@ -895,7 +895,7 @@
                                                 ),
                                             x1:
                                                 (Variable
-                                                    212
+                                                    215
                                                     x1
                                                     []
                                                     In
@@ -911,7 +911,7 @@
                                                 ),
                                             x2:
                                                 (Variable
-                                                    212
+                                                    215
                                                     x2
                                                     []
                                                     In
@@ -927,7 +927,7 @@
                                                 ),
                                             y1:
                                                 (Variable
-                                                    212
+                                                    215
                                                     y1
                                                     []
                                                     In
@@ -943,7 +943,7 @@
                                                 ),
                                             y2:
                                                 (Variable
-                                                    212
+                                                    215
                                                     y2
                                                     []
                                                     In
@@ -985,13 +985,13 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 s)
-                                    (Var 212 x1)
-                                    (Var 212 y1)
-                                    (Var 212 x2)
-                                    (Var 212 y2)]
+                                    [(Var 215 s)
+                                    (Var 215 x1)
+                                    (Var 215 y1)
+                                    (Var 215 x2)
+                                    (Var 215 y2)]
                                     [(=
-                                        (Var 212 eps)
+                                        (Var 215 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -999,9 +999,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 s0)
+                                        (Var 215 s0)
                                         (ArrayItem
-                                            (Var 212 s)
+                                            (Var 215 s)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1015,44 +1015,44 @@
                                     )
                                     (Print
                                         [(StructInstanceMember
-                                            (Var 212 s0)
-                                            211 x
+                                            (Var 215 s0)
+                                            214 x
                                             (Integer 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 y
+                                            (Var 215 s0)
+                                            214 y
                                             (Real 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 z
+                                            (Var 215 s0)
+                                            214 z
                                             (Integer 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 a
+                                            (Var 215 s0)
+                                            214 a
                                             (Real 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 b
+                                            (Var 215 s0)
+                                            214 b
                                             (Integer 2)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 c
+                                            (Var 215 s0)
+                                            214 c
                                             (Integer 1)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 d
+                                            (Var 215 s0)
+                                            214 d
                                             (Logical 4)
                                             ()
                                         )]
@@ -1062,13 +1062,13 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s0)
-                                                211 x
+                                                (Var 215 s0)
+                                                214 x
                                                 (Integer 4)
                                                 ()
                                             )
                                             Eq
-                                            (Var 212 x1)
+                                            (Var 215 x1)
                                             (Logical 4)
                                             ()
                                         )
@@ -1080,13 +1080,13 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 212 s0)
-                                                        211 y
+                                                        (Var 215 s0)
+                                                        214 y
                                                         (Real 8)
                                                         ()
                                                     )
                                                     Sub
-                                                    (Var 212 y1)
+                                                    (Var 215 y1)
                                                     (Real 8)
                                                     ()
                                                 )]
@@ -1095,7 +1095,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 212 eps)
+                                            (Var 215 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -1104,14 +1104,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s0)
-                                                211 z
+                                                (Var 215 s0)
+                                                214 z
                                                 (Integer 8)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 212 x1)
+                                                (Var 215 x1)
                                                 IntegerToInteger
                                                 (Integer 8)
                                                 ()
@@ -1127,14 +1127,14 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 212 s0)
-                                                        211 a
+                                                        (Var 215 s0)
+                                                        214 a
                                                         (Real 4)
                                                         ()
                                                     )
                                                     Sub
                                                     (Cast
-                                                        (Var 212 y1)
+                                                        (Var 215 y1)
                                                         RealToReal
                                                         (Real 4)
                                                         ()
@@ -1167,14 +1167,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s0)
-                                                211 b
+                                                (Var 215 s0)
+                                                214 b
                                                 (Integer 2)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 212 x1)
+                                                (Var 215 x1)
                                                 IntegerToInteger
                                                 (Integer 2)
                                                 ()
@@ -1187,14 +1187,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s0)
-                                                211 c
+                                                (Var 215 s0)
+                                                214 c
                                                 (Integer 1)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 212 x1)
+                                                (Var 215 x1)
                                                 IntegerToInteger
                                                 (Integer 1)
                                                 ()
@@ -1206,17 +1206,17 @@
                                     )
                                     (Assert
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 d
+                                            (Var 215 s0)
+                                            214 d
                                             (Logical 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (=
-                                        (Var 212 s1)
+                                        (Var 215 s1)
                                         (ArrayItem
-                                            (Var 212 s)
+                                            (Var 215 s)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -1230,44 +1230,44 @@
                                     )
                                     (Print
                                         [(StructInstanceMember
-                                            (Var 212 s1)
-                                            211 x
+                                            (Var 215 s1)
+                                            214 x
                                             (Integer 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 y
+                                            (Var 215 s1)
+                                            214 y
                                             (Real 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 z
+                                            (Var 215 s1)
+                                            214 z
                                             (Integer 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 a
+                                            (Var 215 s1)
+                                            214 a
                                             (Real 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 b
+                                            (Var 215 s1)
+                                            214 b
                                             (Integer 2)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 c
+                                            (Var 215 s1)
+                                            214 c
                                             (Integer 1)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 d
+                                            (Var 215 s1)
+                                            214 d
                                             (Logical 4)
                                             ()
                                         )]
@@ -1277,13 +1277,13 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s1)
-                                                211 x
+                                                (Var 215 s1)
+                                                214 x
                                                 (Integer 4)
                                                 ()
                                             )
                                             Eq
-                                            (Var 212 x2)
+                                            (Var 215 x2)
                                             (Logical 4)
                                             ()
                                         )
@@ -1295,13 +1295,13 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 212 s1)
-                                                        211 y
+                                                        (Var 215 s1)
+                                                        214 y
                                                         (Real 8)
                                                         ()
                                                     )
                                                     Sub
-                                                    (Var 212 y2)
+                                                    (Var 215 y2)
                                                     (Real 8)
                                                     ()
                                                 )]
@@ -1310,7 +1310,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 212 eps)
+                                            (Var 215 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -1319,14 +1319,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s1)
-                                                211 z
+                                                (Var 215 s1)
+                                                214 z
                                                 (Integer 8)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 212 x2)
+                                                (Var 215 x2)
                                                 IntegerToInteger
                                                 (Integer 8)
                                                 ()
@@ -1342,14 +1342,14 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 212 s1)
-                                                        211 a
+                                                        (Var 215 s1)
+                                                        214 a
                                                         (Real 4)
                                                         ()
                                                     )
                                                     Sub
                                                     (Cast
-                                                        (Var 212 y2)
+                                                        (Var 215 y2)
                                                         RealToReal
                                                         (Real 4)
                                                         ()
@@ -1382,14 +1382,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s1)
-                                                211 b
+                                                (Var 215 s1)
+                                                214 b
                                                 (Integer 2)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 212 x2)
+                                                (Var 215 x2)
                                                 IntegerToInteger
                                                 (Integer 2)
                                                 ()
@@ -1402,14 +1402,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s1)
-                                                211 c
+                                                (Var 215 s1)
+                                                214 c
                                                 (Integer 1)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 212 x2)
+                                                (Var 215 x2)
                                                 IntegerToInteger
                                                 (Integer 1)
                                                 ()
@@ -1421,8 +1421,8 @@
                                     )
                                     (Assert
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 d
+                                            (Var 215 s1)
+                                            214 d
                                             (Logical 4)
                                             ()
                                         )
@@ -1445,11 +1445,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        218
+                        221
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    218
+                                    221
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1461,7 +1461,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        218 __main__global_stmts
+                        221 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_bin-52ba9fa.json
+++ b/tests/reference/asr-test_builtin_bin-52ba9fa.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_bin-52ba9fa.stdout",
-    "stdout_hash": "8fd060dd84db4f7c18de2d216cefcccc5515af6e6f5a770f65c1b71a",
+    "stdout_hash": "a97588c48f37abb0f1d20d8fe939505688a12935341001bf3cb24d40",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_bin-52ba9fa.stdout
+++ b/tests/reference/asr-test_builtin_bin-52ba9fa.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        132
                                         {
                                             
                                         })
@@ -244,11 +244,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        133
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    133
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -260,7 +260,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        133 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_bool-330223a.json
+++ b/tests/reference/asr-test_builtin_bool-330223a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_bool-330223a.stdout",
-    "stdout_hash": "e98ced1a47246ef02452991e9ceaa2d49b9120834fe8092966fe015e",
+    "stdout_hash": "13cb0026104ce05f32ba8d61892232c0726343a5b4ad7ec1a9040cee",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_bool-330223a.stdout
+++ b/tests/reference/asr-test_builtin_bool-330223a.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        132
                                         {
                                             
                                         })
@@ -868,11 +868,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        133
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    133
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -884,7 +884,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        133 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_hex-64bd268.json
+++ b/tests/reference/asr-test_builtin_hex-64bd268.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_hex-64bd268.stdout",
-    "stdout_hash": "6e6192771598830edbd7d8a833184396f040b182b9004af5ffb3c599",
+    "stdout_hash": "0ab42a0b0c13271782b4090078945e44ac7849ec83ffdd01d36d9ed7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_hex-64bd268.stdout
+++ b/tests/reference/asr-test_builtin_hex-64bd268.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        132
                                         {
                                             
                                         })
@@ -219,11 +219,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        133
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    133
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -235,7 +235,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        133 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_oct-20b9066.json
+++ b/tests/reference/asr-test_builtin_oct-20b9066.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_oct-20b9066.stdout",
-    "stdout_hash": "a3b3f11d9cbcb6f57d5b23e364c26ced7b915e8c72eded358f01d9cd",
+    "stdout_hash": "600371fd78e08c40ab8336a3e7fb442372b725241bbf0adc7bc4ff9e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_oct-20b9066.stdout
+++ b/tests/reference/asr-test_builtin_oct-20b9066.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        132
                                         {
                                             
                                         })
@@ -219,11 +219,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        133
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    133
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -235,7 +235,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        133 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_pow-f02fcda.json
+++ b/tests/reference/asr-test_builtin_pow-f02fcda.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_pow-f02fcda.stdout",
-    "stdout_hash": "b0aa9ff1f31769b515e2aedd650656b6a53676d5bf276e6b9a4b12b9",
+    "stdout_hash": "aad7faa6f46405b5c8925691713f03ed92489739124d3b9adb71428d",
     "stderr": "asr-test_builtin_pow-f02fcda.stderr",
     "stderr_hash": "859ce76c74748f2d32c7eab92cfbba789a78d4cbf5818646b99806ea",
     "returncode": 0

--- a/tests/reference/asr-test_builtin_pow-f02fcda.stdout
+++ b/tests/reference/asr-test_builtin_pow-f02fcda.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        132
                                         {
                                             
                                         })
@@ -1880,11 +1880,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        133
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    133
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1896,7 +1896,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        133 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_round-7417a21.json
+++ b/tests/reference/asr-test_builtin_round-7417a21.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_round-7417a21.stdout",
-    "stdout_hash": "9fcfa25b2101c8a11d06e0ae473edee98c3c76beeb20fceb1e5f528d",
+    "stdout_hash": "40dd4ba45912032faab291408c686267281ce9c184e854a80bd5276f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_round-7417a21.stdout
+++ b/tests/reference/asr-test_builtin_round-7417a21.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        132
                                         {
                                             
                                         })
@@ -886,11 +886,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        133
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    133
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -902,7 +902,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        133 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_complex_01-a6def58.json
+++ b/tests/reference/asr-test_complex_01-a6def58.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_complex_01-a6def58.stdout",
-    "stdout_hash": "f0bab05549d2ee9805936995e3f111a308efc78a61ce593d2c765339",
+    "stdout_hash": "4ea709628d70bb8da03d1681a5b04429528824af9739cc00d371de3b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_complex_01-a6def58.stdout
+++ b/tests/reference/asr-test_complex_01-a6def58.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        133
+                                        136
                                         {
                                             
                                         })
@@ -1975,11 +1975,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        134
+                        137
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    134
+                                    137
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1991,7 +1991,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        134 __main__global_stmts
+                        137 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_complex_02-782ba2d.json
+++ b/tests/reference/asr-test_complex_02-782ba2d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_complex_02-782ba2d.stdout",
-    "stdout_hash": "8855f80a3c24a954dd0d003ef093368456a95c20b7d723ddd8a01c81",
+    "stdout_hash": "3a68cb59521748bd788f1b51b2ab0f479fe6f9f5aed8b9c6814b17a8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_complex_02-782ba2d.stdout
+++ b/tests/reference/asr-test_complex_02-782ba2d.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        132
+                                        135
                                         {
                                             
                                         })
@@ -691,11 +691,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        133
+                        136
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    133
+                                    136
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -707,7 +707,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        133 __main__global_stmts
+                        136 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_max_min-3c2fc51.json
+++ b/tests/reference/asr-test_max_min-3c2fc51.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_max_min-3c2fc51.stdout",
-    "stdout_hash": "e67150b066db479e51b74178342475bc51b3e56bc715d5c4b4495693",
+    "stdout_hash": "33452ec6f580a0e21f7be6b11df4a8354087380368099ee573483fac",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_max_min-3c2fc51.stdout
+++ b/tests/reference/asr-test_max_min-3c2fc51.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        133
+                                        136
                                         {
                                             
                                         })
@@ -785,11 +785,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        134
+                        137
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    134
+                                    137
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -801,7 +801,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        134 __main__global_stmts
+                        137 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_numpy_03-e600a49.json
+++ b/tests/reference/asr-test_numpy_03-e600a49.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_03-e600a49.stdout",
-    "stdout_hash": "7f77da6be087aeb05ea730aeac6010a55558cfde8497bbbda2940736",
+    "stdout_hash": "bd5b86023d4b4b6881828669e97f8615c99ff8bf43e1dfc45b71617f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_03-e600a49.stdout
+++ b/tests/reference/asr-test_numpy_03-e600a49.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        228
+                                        231
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             test_1d_to_nd:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        215
                                         {
                                             a:
                                                 (Variable
-                                                    212
+                                                    215
                                                     a
                                                     []
                                                     Local
@@ -73,7 +73,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    212
+                                                    215
                                                     b
                                                     []
                                                     Local
@@ -94,7 +94,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    212
+                                                    215
                                                     c
                                                     []
                                                     Local
@@ -119,7 +119,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    212
+                                                    215
                                                     d
                                                     []
                                                     InOut
@@ -140,7 +140,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    212
+                                                    215
                                                     eps
                                                     []
                                                     Local
@@ -156,7 +156,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    212
+                                                    215
                                                     i
                                                     []
                                                     Local
@@ -172,7 +172,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    212
+                                                    215
                                                     j
                                                     []
                                                     Local
@@ -188,7 +188,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    212
+                                                    215
                                                     k
                                                     []
                                                     Local
@@ -204,7 +204,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    212
+                                                    215
                                                     l
                                                     []
                                                     Local
@@ -220,7 +220,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    212
+                                                    215
                                                     newshape
                                                     []
                                                     Local
@@ -241,7 +241,7 @@
                                                 ),
                                             newshape1:
                                                 (Variable
-                                                    212
+                                                    215
                                                     newshape1
                                                     []
                                                     Local
@@ -282,9 +282,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 d)]
+                                    [(Var 215 d)]
                                     [(=
-                                        (Var 212 eps)
+                                        (Var 215 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -292,7 +292,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 b)
+                                        (Var 215 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -307,7 +307,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 212 k)
+                                        ((Var 215 k)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -318,10 +318,10 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
-                                            (Var 212 i)
+                                            (Var 215 i)
                                             (IntrinsicScalarFunction
                                                 FloorDiv
-                                                [(Var 212 k)
+                                                [(Var 215 k)
                                                 (IntegerConstant 16 (Integer 4))]
                                                 0
                                                 (Integer 4)
@@ -330,12 +330,12 @@
                                             ()
                                         )
                                         (=
-                                            (Var 212 j)
+                                            (Var 215 j)
                                             (IntegerBinOp
-                                                (Var 212 k)
+                                                (Var 215 k)
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 212 i)
+                                                    (Var 215 i)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -348,9 +348,9 @@
                                         )
                                         (=
                                             (ArrayItem
-                                                (Var 212 b)
+                                                (Var 215 b)
                                                 [(()
-                                                (Var 212 k)
+                                                (Var 215 k)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -359,9 +359,9 @@
                                             (RealBinOp
                                                 (Cast
                                                     (IntegerBinOp
-                                                        (Var 212 i)
+                                                        (Var 215 i)
                                                         Add
-                                                        (Var 212 j)
+                                                        (Var 215 j)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -381,7 +381,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 212 a)
+                                        (Var 215 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -397,7 +397,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 newshape)
+                                        (Var 215 newshape)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -412,7 +412,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 212 newshape)
+                                            (Var 215 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -425,7 +425,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 212 newshape)
+                                            (Var 215 newshape)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -437,11 +437,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 a)
+                                        (Var 215 a)
                                         (ArrayReshape
-                                            (Var 212 b)
+                                            (Var 215 b)
                                             (ArrayPhysicalCast
-                                                (Var 212 newshape)
+                                                (Var 215 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -464,7 +464,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 212 i)
+                                        ((Var 215 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -476,7 +476,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 212 j)
+                                            ((Var 215 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -493,12 +493,12 @@
                                                         [(RealBinOp
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 212 a)
+                                                                    (Var 215 a)
                                                                     [(()
-                                                                    (Var 212 i)
+                                                                    (Var 215 i)
                                                                     ())
                                                                     (()
-                                                                    (Var 212 j)
+                                                                    (Var 215 j)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -507,9 +507,9 @@
                                                                 Sub
                                                                 (Cast
                                                                     (IntegerBinOp
-                                                                        (Var 212 i)
+                                                                        (Var 215 i)
                                                                         Add
-                                                                        (Var 212 j)
+                                                                        (Var 215 j)
                                                                         (Integer 4)
                                                                         ()
                                                                     )
@@ -533,7 +533,7 @@
                                                         ()
                                                     )
                                                     LtE
-                                                    (Var 212 eps)
+                                                    (Var 215 eps)
                                                     (Logical 4)
                                                     ()
                                                 )
@@ -542,7 +542,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 212 c)
+                                        (Var 215 c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -560,7 +560,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 newshape1)
+                                        (Var 215 newshape1)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -575,7 +575,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 212 newshape1)
+                                            (Var 215 newshape1)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -588,7 +588,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 212 newshape1)
+                                            (Var 215 newshape1)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -601,7 +601,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 212 newshape1)
+                                            (Var 215 newshape1)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -613,11 +613,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 c)
+                                        (Var 215 c)
                                         (ArrayReshape
-                                            (Var 212 d)
+                                            (Var 215 d)
                                             (ArrayPhysicalCast
-                                                (Var 212 newshape1)
+                                                (Var 215 newshape1)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -640,7 +640,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 212 i)
+                                        ((Var 215 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -652,7 +652,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 212 j)
+                                            ((Var 215 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -664,7 +664,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 212 k)
+                                                ((Var 215 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 16 (Integer 4))
@@ -681,15 +681,15 @@
                                                             [(RealBinOp
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 212 c)
+                                                                        (Var 215 c)
                                                                         [(()
-                                                                        (Var 212 i)
+                                                                        (Var 215 i)
                                                                         ())
                                                                         (()
-                                                                        (Var 212 j)
+                                                                        (Var 215 j)
                                                                         ())
                                                                         (()
-                                                                        (Var 212 k)
+                                                                        (Var 215 k)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -699,14 +699,14 @@
                                                                     (Cast
                                                                         (IntegerBinOp
                                                                             (IntegerBinOp
-                                                                                (Var 212 i)
+                                                                                (Var 215 i)
                                                                                 Add
-                                                                                (Var 212 j)
+                                                                                (Var 215 j)
                                                                                 (Integer 4)
                                                                                 ()
                                                                             )
                                                                             Add
-                                                                            (Var 212 k)
+                                                                            (Var 215 k)
                                                                             (Integer 4)
                                                                             ()
                                                                         )
@@ -730,7 +730,7 @@
                                                             ()
                                                         )
                                                         LtE
-                                                        (Var 212 eps)
+                                                        (Var 215 eps)
                                                         (Logical 4)
                                                         ()
                                                     )
@@ -748,11 +748,11 @@
                             test_nd_to_1d:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        214
                                         {
                                             a:
                                                 (Variable
-                                                    211
+                                                    214
                                                     a
                                                     []
                                                     InOut
@@ -775,7 +775,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    211
+                                                    214
                                                     b
                                                     []
                                                     Local
@@ -796,7 +796,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    211
+                                                    214
                                                     c
                                                     []
                                                     Local
@@ -821,7 +821,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    211
+                                                    214
                                                     d
                                                     []
                                                     Local
@@ -842,7 +842,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    211
+                                                    214
                                                     eps
                                                     []
                                                     Local
@@ -858,7 +858,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    211
+                                                    214
                                                     i
                                                     []
                                                     Local
@@ -874,7 +874,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    211
+                                                    214
                                                     j
                                                     []
                                                     Local
@@ -890,7 +890,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    211
+                                                    214
                                                     k
                                                     []
                                                     Local
@@ -906,7 +906,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    211
+                                                    214
                                                     l
                                                     []
                                                     Local
@@ -922,7 +922,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    211
+                                                    214
                                                     newshape
                                                     []
                                                     Local
@@ -943,7 +943,7 @@
                                                 ),
                                             newshape1:
                                                 (Variable
-                                                    211
+                                                    214
                                                     newshape1
                                                     []
                                                     Local
@@ -986,9 +986,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 a)]
+                                    [(Var 214 a)]
                                     [(=
-                                        (Var 211 eps)
+                                        (Var 214 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -996,7 +996,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 b)
+                                        (Var 214 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1010,7 +1010,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 newshape)
+                                        (Var 214 newshape)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1025,7 +1025,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 211 newshape)
+                                            (Var 214 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1037,11 +1037,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 b)
+                                        (Var 214 b)
                                         (ArrayReshape
-                                            (Var 211 a)
+                                            (Var 214 a)
                                             (ArrayPhysicalCast
-                                                (Var 211 newshape)
+                                                (Var 214 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -1064,7 +1064,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 k)
+                                        ((Var 214 k)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -1075,10 +1075,10 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
-                                            (Var 211 i)
+                                            (Var 214 i)
                                             (IntrinsicScalarFunction
                                                 FloorDiv
-                                                [(Var 211 k)
+                                                [(Var 214 k)
                                                 (IntegerConstant 16 (Integer 4))]
                                                 0
                                                 (Integer 4)
@@ -1087,12 +1087,12 @@
                                             ()
                                         )
                                         (=
-                                            (Var 211 j)
+                                            (Var 214 j)
                                             (IntegerBinOp
-                                                (Var 211 k)
+                                                (Var 214 k)
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 211 i)
+                                                    (Var 214 i)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -1110,9 +1110,9 @@
                                                     [(RealBinOp
                                                         (RealBinOp
                                                             (ArrayItem
-                                                                (Var 211 b)
+                                                                (Var 214 b)
                                                                 [(()
-                                                                (Var 211 k)
+                                                                (Var 214 k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
@@ -1121,9 +1121,9 @@
                                                             Sub
                                                             (Cast
                                                                 (IntegerBinOp
-                                                                    (Var 211 i)
+                                                                    (Var 214 i)
                                                                     Add
-                                                                    (Var 211 j)
+                                                                    (Var 214 j)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
@@ -1147,7 +1147,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 211 eps)
+                                                (Var 214 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -1155,7 +1155,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 211 c)
+                                        (Var 214 c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1173,7 +1173,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 c)
+                                        (Var 214 c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1192,7 +1192,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -1204,7 +1204,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 211 j)
+                                            ((Var 214 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -1216,7 +1216,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 211 k)
+                                                ((Var 214 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 16 (Integer 4))
@@ -1228,15 +1228,15 @@
                                                 (IntegerConstant 1 (Integer 4)))
                                                 [(=
                                                     (ArrayItem
-                                                        (Var 211 c)
+                                                        (Var 214 c)
                                                         [(()
-                                                        (Var 211 i)
+                                                        (Var 214 i)
                                                         ())
                                                         (()
-                                                        (Var 211 j)
+                                                        (Var 214 j)
                                                         ())
                                                         (()
-                                                        (Var 211 k)
+                                                        (Var 214 k)
                                                         ())]
                                                         (Real 8)
                                                         RowMajor
@@ -1246,14 +1246,14 @@
                                                         (Cast
                                                             (IntegerBinOp
                                                                 (IntegerBinOp
-                                                                    (Var 211 i)
+                                                                    (Var 214 i)
                                                                     Add
-                                                                    (Var 211 j)
+                                                                    (Var 214 j)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
                                                                 Add
-                                                                (Var 211 k)
+                                                                (Var 214 k)
                                                                 (Integer 4)
                                                                 ()
                                                             )
@@ -1275,7 +1275,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 211 d)
+                                        (Var 214 d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1289,7 +1289,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 newshape1)
+                                        (Var 214 newshape1)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1304,7 +1304,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 211 newshape1)
+                                            (Var 214 newshape1)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1316,11 +1316,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 d)
+                                        (Var 214 d)
                                         (ArrayReshape
-                                            (Var 211 c)
+                                            (Var 214 c)
                                             (ArrayPhysicalCast
-                                                (Var 211 newshape1)
+                                                (Var 214 newshape1)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -1343,7 +1343,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 l)
+                                        ((Var 214 l)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 4096 (Integer 4))
@@ -1354,11 +1354,11 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
-                                            (Var 211 i)
+                                            (Var 214 i)
                                             (Cast
                                                 (RealBinOp
                                                     (Cast
-                                                        (Var 211 l)
+                                                        (Var 214 l)
                                                         IntegerToReal
                                                         (Real 8)
                                                         ()
@@ -1383,14 +1383,14 @@
                                             ()
                                         )
                                         (=
-                                            (Var 211 j)
+                                            (Var 214 j)
                                             (IntrinsicScalarFunction
                                                 FloorDiv
                                                 [(IntegerBinOp
-                                                    (Var 211 l)
+                                                    (Var 214 l)
                                                     Sub
                                                     (IntegerBinOp
-                                                        (Var 211 i)
+                                                        (Var 214 i)
                                                         Mul
                                                         (IntegerConstant 256 (Integer 4))
                                                         (Integer 4)
@@ -1407,13 +1407,13 @@
                                             ()
                                         )
                                         (=
-                                            (Var 211 k)
+                                            (Var 214 k)
                                             (IntegerBinOp
                                                 (IntegerBinOp
-                                                    (Var 211 l)
+                                                    (Var 214 l)
                                                     Sub
                                                     (IntegerBinOp
-                                                        (Var 211 i)
+                                                        (Var 214 i)
                                                         Mul
                                                         (IntegerConstant 256 (Integer 4))
                                                         (Integer 4)
@@ -1424,7 +1424,7 @@
                                                 )
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 211 j)
+                                                    (Var 214 j)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -1442,9 +1442,9 @@
                                                     [(RealBinOp
                                                         (RealBinOp
                                                             (ArrayItem
-                                                                (Var 211 d)
+                                                                (Var 214 d)
                                                                 [(()
-                                                                (Var 211 l)
+                                                                (Var 214 l)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
@@ -1454,14 +1454,14 @@
                                                             (Cast
                                                                 (IntegerBinOp
                                                                     (IntegerBinOp
-                                                                        (Var 211 i)
+                                                                        (Var 214 i)
                                                                         Add
-                                                                        (Var 211 j)
+                                                                        (Var 214 j)
                                                                         (Integer 4)
                                                                         ()
                                                                     )
                                                                     Add
-                                                                    (Var 211 k)
+                                                                    (Var 214 k)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
@@ -1485,7 +1485,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 211 eps)
+                                                (Var 214 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -1501,11 +1501,11 @@
                             test_reshape_with_argument:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        216
                                         {
                                             a:
                                                 (Variable
-                                                    213
+                                                    216
                                                     a
                                                     []
                                                     Local
@@ -1528,7 +1528,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    213
+                                                    216
                                                     d
                                                     []
                                                     Local
@@ -1549,7 +1549,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    213
+                                                    216
                                                     i
                                                     []
                                                     Local
@@ -1565,7 +1565,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    213
+                                                    216
                                                     j
                                                     []
                                                     Local
@@ -1581,7 +1581,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    213
+                                                    216
                                                     k
                                                     []
                                                     Local
@@ -1597,7 +1597,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    213
+                                                    216
                                                     l
                                                     []
                                                     Local
@@ -1631,7 +1631,7 @@
                                     test_1d_to_nd]
                                     []
                                     [(=
-                                        (Var 213 a)
+                                        (Var 216 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1648,7 +1648,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 i)
+                                        ((Var 216 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -1660,7 +1660,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 213 j)
+                                            ((Var 216 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -1672,12 +1672,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 213 a)
+                                                    (Var 216 a)
                                                     [(()
-                                                    (Var 213 i)
+                                                    (Var 216 i)
                                                     ())
                                                     (()
-                                                    (Var 213 j)
+                                                    (Var 216 j)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -1686,9 +1686,9 @@
                                                 (RealBinOp
                                                     (Cast
                                                         (IntegerBinOp
-                                                            (Var 213 i)
+                                                            (Var 216 i)
                                                             Add
-                                                            (Var 213 j)
+                                                            (Var 216 j)
                                                             (Integer 4)
                                                             ()
                                                         )
@@ -1712,7 +1712,7 @@
                                         2 test_nd_to_1d
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 213 a)
+                                            (Var 216 a)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1728,7 +1728,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 d)
+                                        (Var 216 d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1743,7 +1743,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 l)
+                                        ((Var 216 l)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 4096 (Integer 4))
@@ -1754,11 +1754,11 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
-                                            (Var 213 i)
+                                            (Var 216 i)
                                             (Cast
                                                 (RealBinOp
                                                     (Cast
-                                                        (Var 213 l)
+                                                        (Var 216 l)
                                                         IntegerToReal
                                                         (Real 8)
                                                         ()
@@ -1783,14 +1783,14 @@
                                             ()
                                         )
                                         (=
-                                            (Var 213 j)
+                                            (Var 216 j)
                                             (IntrinsicScalarFunction
                                                 FloorDiv
                                                 [(IntegerBinOp
-                                                    (Var 213 l)
+                                                    (Var 216 l)
                                                     Sub
                                                     (IntegerBinOp
-                                                        (Var 213 i)
+                                                        (Var 216 i)
                                                         Mul
                                                         (IntegerConstant 256 (Integer 4))
                                                         (Integer 4)
@@ -1807,13 +1807,13 @@
                                             ()
                                         )
                                         (=
-                                            (Var 213 k)
+                                            (Var 216 k)
                                             (IntegerBinOp
                                                 (IntegerBinOp
-                                                    (Var 213 l)
+                                                    (Var 216 l)
                                                     Sub
                                                     (IntegerBinOp
-                                                        (Var 213 i)
+                                                        (Var 216 i)
                                                         Mul
                                                         (IntegerConstant 256 (Integer 4))
                                                         (Integer 4)
@@ -1824,7 +1824,7 @@
                                                 )
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 213 j)
+                                                    (Var 216 j)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -1837,9 +1837,9 @@
                                         )
                                         (=
                                             (ArrayItem
-                                                (Var 213 d)
+                                                (Var 216 d)
                                                 [(()
-                                                (Var 213 l)
+                                                (Var 216 l)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -1849,14 +1849,14 @@
                                                 (Cast
                                                     (IntegerBinOp
                                                         (IntegerBinOp
-                                                            (Var 213 i)
+                                                            (Var 216 i)
                                                             Add
-                                                            (Var 213 j)
+                                                            (Var 216 j)
                                                             (Integer 4)
                                                             ()
                                                         )
                                                         Add
-                                                        (Var 213 k)
+                                                        (Var 216 k)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -1879,7 +1879,7 @@
                                         2 test_1d_to_nd
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 213 d)
+                                            (Var 216 d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1909,11 +1909,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        229
+                        232
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    229
+                                    232
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1925,7 +1925,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        229 __main__global_stmts
+                        232 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_numpy_04-ecbb614.json
+++ b/tests/reference/asr-test_numpy_04-ecbb614.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_04-ecbb614.stdout",
-    "stdout_hash": "1da36df6cdd76caa08790fe22f8bff306736f6f61ca8c0e9535528ed",
+    "stdout_hash": "eaf643c013a9412244ea1b255d6498c68dd097dafdef333b28b2e109",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_04-ecbb614.stdout
+++ b/tests/reference/asr-test_numpy_04-ecbb614.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        217
                                         {
                                             
                                         })
@@ -46,7 +46,7 @@
                             check:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        216
                                         {
                                             
                                         })
@@ -89,11 +89,11 @@
                             test_array_01:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        214
                                         {
                                             eps:
                                                 (Variable
-                                                    211
+                                                    214
                                                     eps
                                                     []
                                                     Local
@@ -109,7 +109,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    211
+                                                    214
                                                     x
                                                     []
                                                     Local
@@ -147,7 +147,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 211 x)
+                                        (Var 214 x)
                                         (ArrayConstant
                                             [(RealConstant
                                                 1.000000
@@ -172,7 +172,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 eps)
+                                        (Var 214 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -185,7 +185,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 211 x)
+                                                        (Var 214 x)
                                                         [(()
                                                         (IntegerConstant 0 (Integer 4))
                                                         ())]
@@ -206,7 +206,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 211 eps)
+                                            (Var 214 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -218,7 +218,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 211 x)
+                                                        (Var 214 x)
                                                         [(()
                                                         (IntegerConstant 1 (Integer 4))
                                                         ())]
@@ -239,7 +239,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 211 eps)
+                                            (Var 214 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -251,7 +251,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 211 x)
+                                                        (Var 214 x)
                                                         [(()
                                                         (IntegerConstant 2 (Integer 4))
                                                         ())]
@@ -272,7 +272,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 211 eps)
+                                            (Var 214 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -287,11 +287,11 @@
                             test_array_02:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        215
                                         {
                                             eps:
                                                 (Variable
-                                                    212
+                                                    215
                                                     eps
                                                     []
                                                     Local
@@ -307,7 +307,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    212
+                                                    215
                                                     x
                                                     []
                                                     Local
@@ -345,7 +345,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 212 x)
+                                        (Var 215 x)
                                         (ArrayConstant
                                             [(IntegerConstant 1 (Integer 4))
                                             (IntegerConstant 2 (Integer 4))
@@ -361,7 +361,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 eps)
+                                        (Var 215 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -375,7 +375,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 212 x)
+                                                            (Var 215 x)
                                                             [(()
                                                             (IntegerConstant 0 (Integer 4))
                                                             ())]
@@ -397,7 +397,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 212 eps)
+                                            (Var 215 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -410,7 +410,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 212 x)
+                                                            (Var 215 x)
                                                             [(()
                                                             (IntegerConstant 1 (Integer 4))
                                                             ())]
@@ -432,7 +432,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 212 eps)
+                                            (Var 215 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -445,7 +445,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 212 x)
+                                                            (Var 215 x)
                                                             [(()
                                                             (IntegerConstant 2 (Integer 4))
                                                             ())]
@@ -467,7 +467,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 212 eps)
+                                            (Var 215 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -490,11 +490,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        215
+                        218
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    215
+                                    218
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -506,7 +506,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        215 __main__global_stmts
+                        218 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_pow-3f5d550.json
+++ b/tests/reference/asr-test_pow-3f5d550.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_pow-3f5d550.stdout",
-    "stdout_hash": "2e9aa5421687f0dc2a5b8aba48d887cef6c04c3d8e28569637396212",
+    "stdout_hash": "13306f8930dbe5787d7d38d34e0ceb533fb590f6fcf3c9d9777b7460",
     "stderr": "asr-test_pow-3f5d550.stderr",
     "stderr_hash": "3d950301563cce75654f28bf41f6f53428ed1f5ae997774345f374a3",
     "returncode": 0

--- a/tests/reference/asr-test_pow-3f5d550.stdout
+++ b/tests/reference/asr-test_pow-3f5d550.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        132
                                         {
                                             
                                         })
@@ -130,11 +130,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        133
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    133
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -146,7 +146,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        133 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-vec_01-66ac423.json
+++ b/tests/reference/asr-vec_01-66ac423.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-vec_01-66ac423.stdout",
-    "stdout_hash": "2e2b41cdaa38cabb5b6dee642fdbade4259561a9ab1b06f21dce79f4",
+    "stdout_hash": "ca06fb348ae975b2cd793fb1e864bcdac0ad386d8fd517d775f2276a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-vec_01-66ac423.stdout
+++ b/tests/reference/asr-vec_01-66ac423.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        218
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             loop_vec:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        214
                                         {
                                             a:
                                                 (Variable
-                                                    211
+                                                    214
                                                     a
                                                     []
                                                     Local
@@ -71,7 +71,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    211
+                                                    214
                                                     b
                                                     []
                                                     Local
@@ -92,7 +92,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    211
+                                                    214
                                                     i
                                                     []
                                                     Local
@@ -125,7 +125,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 211 a)
+                                        (Var 214 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -139,7 +139,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 b)
+                                        (Var 214 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -154,7 +154,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -166,9 +166,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 211 b)
+                                                (Var 214 b)
                                                 [(()
-                                                (Var 211 i)
+                                                (Var 214 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -183,7 +183,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -195,18 +195,18 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 211 a)
+                                                (Var 214 a)
                                                 [(()
-                                                (Var 211 i)
+                                                (Var 214 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (ArrayItem
-                                                (Var 211 b)
+                                                (Var 214 b)
                                                 [(()
-                                                (Var 211 i)
+                                                (Var 214 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -217,7 +217,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -230,9 +230,9 @@
                                         [(Assert
                                             (RealCompare
                                                 (ArrayItem
-                                                    (Var 211 a)
+                                                    (Var 214 a)
                                                     [(()
-                                                    (Var 211 i)
+                                                    (Var 214 i)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -266,11 +266,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        216
+                        219
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    216
+                                    219
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -282,7 +282,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        216 __main__global_stmts
+                        219 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/pass_loop_vectorise-vec_01-be9985e.json
+++ b/tests/reference/pass_loop_vectorise-vec_01-be9985e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_loop_vectorise-vec_01-be9985e.stdout",
-    "stdout_hash": "20734037fd1fecf92e8421c6b558117fc0a2831ddbcbd1b2877485d4",
+    "stdout_hash": "3f63b3231b33ef351b1a17af8348162e984d45f2951a8038e922d7a8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_loop_vectorise-vec_01-be9985e.stdout
+++ b/tests/reference/pass_loop_vectorise-vec_01-be9985e.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        218
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             loop_vec:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        214
                                         {
                                             a:
                                                 (Variable
-                                                    211
+                                                    214
                                                     a
                                                     []
                                                     Local
@@ -71,7 +71,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    211
+                                                    214
                                                     b
                                                     []
                                                     Local
@@ -92,7 +92,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    211
+                                                    214
                                                     i
                                                     []
                                                     Local
@@ -109,11 +109,11 @@
                                             vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization:
                                                 (Function
                                                     (SymbolTable
-                                                        217
+                                                        220
                                                         {
                                                             __1_k:
                                                                 (Variable
-                                                                    217
+                                                                    220
                                                                     __1_k
                                                                     []
                                                                     Local
@@ -129,7 +129,7 @@
                                                                 ),
                                                             arg0:
                                                                 (Variable
-                                                                    217
+                                                                    220
                                                                     arg0
                                                                     []
                                                                     In
@@ -150,7 +150,7 @@
                                                                 ),
                                                             arg1:
                                                                 (Variable
-                                                                    217
+                                                                    220
                                                                     arg1
                                                                     []
                                                                     In
@@ -171,7 +171,7 @@
                                                                 ),
                                                             arg2:
                                                                 (Variable
-                                                                    217
+                                                                    220
                                                                     arg2
                                                                     []
                                                                     In
@@ -187,7 +187,7 @@
                                                                 ),
                                                             arg3:
                                                                 (Variable
-                                                                    217
+                                                                    220
                                                                     arg3
                                                                     []
                                                                     In
@@ -203,7 +203,7 @@
                                                                 ),
                                                             arg4:
                                                                 (Variable
-                                                                    217
+                                                                    220
                                                                     arg4
                                                                     []
                                                                     In
@@ -219,7 +219,7 @@
                                                                 ),
                                                             arg5:
                                                                 (Variable
-                                                                    217
+                                                                    220
                                                                     arg5
                                                                     []
                                                                     In
@@ -265,18 +265,18 @@
                                                         .false.
                                                     )
                                                     []
-                                                    [(Var 217 arg0)
-                                                    (Var 217 arg1)
-                                                    (Var 217 arg2)
-                                                    (Var 217 arg3)
-                                                    (Var 217 arg4)
-                                                    (Var 217 arg5)]
+                                                    [(Var 220 arg0)
+                                                    (Var 220 arg1)
+                                                    (Var 220 arg2)
+                                                    (Var 220 arg3)
+                                                    (Var 220 arg4)
+                                                    (Var 220 arg5)]
                                                     [(=
-                                                        (Var 217 __1_k)
+                                                        (Var 220 __1_k)
                                                         (IntegerBinOp
-                                                            (Var 217 arg2)
+                                                            (Var 220 arg2)
                                                             Sub
-                                                            (Var 217 arg4)
+                                                            (Var 220 arg4)
                                                             (Integer 4)
                                                             ()
                                                         )
@@ -286,23 +286,23 @@
                                                         ()
                                                         (IntegerCompare
                                                             (IntegerBinOp
-                                                                (Var 217 __1_k)
+                                                                (Var 220 __1_k)
                                                                 Add
-                                                                (Var 217 arg4)
+                                                                (Var 220 arg4)
                                                                 (Integer 4)
                                                                 ()
                                                             )
                                                             Lt
-                                                            (Var 217 arg3)
+                                                            (Var 220 arg3)
                                                             (Logical 4)
                                                             ()
                                                         )
                                                         [(=
-                                                            (Var 217 __1_k)
+                                                            (Var 220 __1_k)
                                                             (IntegerBinOp
-                                                                (Var 217 __1_k)
+                                                                (Var 220 __1_k)
                                                                 Add
-                                                                (Var 217 arg4)
+                                                                (Var 220 arg4)
                                                                 (Integer 4)
                                                                 ()
                                                             )
@@ -310,18 +310,18 @@
                                                         )
                                                         (=
                                                             (ArrayItem
-                                                                (Var 217 arg0)
+                                                                (Var 220 arg0)
                                                                 [(()
-                                                                (Var 217 __1_k)
+                                                                (Var 220 __1_k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
                                                                 ()
                                                             )
                                                             (ArrayItem
-                                                                (Var 217 arg1)
+                                                                (Var 220 arg1)
                                                                 [(()
-                                                                (Var 217 __1_k)
+                                                                (Var 220 __1_k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
@@ -355,7 +355,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 211 a)
+                                        (Var 214 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -369,7 +369,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 b)
+                                        (Var 214 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -384,7 +384,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -396,9 +396,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 211 b)
+                                                (Var 214 b)
                                                 [(()
-                                                (Var 211 i)
+                                                (Var 214 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -413,17 +413,17 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerConstant 1151 (Integer 4))
                                         (IntegerConstant 1 (Integer 4)))
                                         [(SubroutineCall
-                                            211 vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization
+                                            214 vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization
                                             ()
-                                            [((Var 211 a))
-                                            ((Var 211 b))
+                                            [((Var 214 a))
+                                            ((Var 214 b))
                                             ((IntegerBinOp
-                                                (Var 211 i)
+                                                (Var 214 i)
                                                 Mul
                                                 (IntegerConstant 8 (Integer 4))
                                                 (Integer 4)
@@ -431,7 +431,7 @@
                                             ))
                                             ((IntegerBinOp
                                                 (IntegerBinOp
-                                                    (Var 211 i)
+                                                    (Var 214 i)
                                                     Add
                                                     (IntegerConstant 1 (Integer 4))
                                                     (Integer 4)
@@ -449,7 +449,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -462,9 +462,9 @@
                                         [(Assert
                                             (RealCompare
                                                 (ArrayItem
-                                                    (Var 211 a)
+                                                    (Var 214 a)
                                                     [(()
-                                                    (Var 211 i)
+                                                    (Var 214 i)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -498,11 +498,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        216
+                        219
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    216
+                                    219
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -514,7 +514,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        216 __main__global_stmts
+                        219 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()


### PR DESCRIPTION
Relates to #2356

I also noticed that these methods don't work with constant strings
```
semantic error: 'str' object has no attribute 'split'
 --> test.py:2:7
  |
2 | print("1 2 3".split())
  |       ^^^^^^^^^^^^^^^ 
```
and I'm guessing it's because they are not being handled in ``handle_constant_string_attributes``. 
1. Why can't both constant strings and variable strings be handled by the ``_lpython_str_...`` functions? Because it looks like the methods for constant strings are directly being implemented in C++.
2. Shall I also add separate implementations for these in ``handle_constant_string_attributes``?