### PR TITLE
Fixes SEGFAULT in integration_tests/elemental_01.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Please follow the below steps for Windows:
 
   ```bash
   ctest
+  ./run_tests.py -u
   ./run_tests.py
   ```
 

--- a/integration_tests/elemental_01.py
+++ b/integration_tests/elemental_01.py
@@ -9,17 +9,17 @@ def verify1d(array: f32[:], result: f32[:], size: i32):
     for i in range(size):
         assert abs(sin(sin(array[i])) - result[i]) <= eps
 
-def verifynd(array: f64[:, :, :], result: f64[:, :, :], size1: i32, size2: i32, size3: i32):
+def verifynd(array: f32[:, :, :], result: f32[:, :, :], size1: i32, size2: i32, size3: i32):
     i: i32
     j: i32
     k: i32
-    eps: f64
-    eps = 1e-12
+    eps: f32
+    eps = f32(1e-6)
 
     for i in range(size1):
         for j in range(size2):
             for k in range(size3):
-                assert abs(sin(array[i, j, k])**2.0 - result[i, j, k]) <= eps
+                assert abs(sin(array[i, j, k])**f32(2) - result[i, j, k]) <= eps
 
 def verify2d(array: f64[:, :], result: f64[:, :], size1: i32, size2: i32):
     i: i32
@@ -101,17 +101,17 @@ def elemental_sin():
 
     sin1d = sin(sin(array1d))
 
-    verify1d(array1d, sin1d, 256)
+    verify1d(array1d, sin1d, 256) # working fine
 
-    arraynd: f64[256, 64, 16] = empty((256, 64, 16), dtype=float64)
-    sinnd: f64[256, 64, 16] = empty((256, 64, 16), dtype=float64)
+    arraynd: f32[256, 64, 16] = empty((256, 64, 16), dtype=float32)
+    sinnd: f32[256, 64, 16] = empty((256, 64, 16), dtype=float32)
 
     for i in range(256):
         for j in range(64):
             for k in range(16):
-                arraynd[i, j, k] = float(i + j + k)
+                arraynd[i, j, k] = f32(i + j + k)
 
-    sinnd = sin(arraynd)**2.0
+    sinnd = sin(arraynd)**f32(2)
 
     verifynd(arraynd, sinnd, 256, 64, 16)
 

--- a/integration_tests/elemental_01.py
+++ b/integration_tests/elemental_01.py
@@ -101,7 +101,7 @@ def elemental_sin():
 
     sin1d = sin(sin(array1d))
 
-    verify1d(array1d, sin1d, 256) # working fine
+    verify1d(array1d, sin1d, 256)
 
     arraynd: f32[256, 64, 16] = empty((256, 64, 16), dtype=float32)
     sinnd: f32[256, 64, 16] = empty((256, 64, 16), dtype=float32)

--- a/integration_tests/elemental_01.py
+++ b/integration_tests/elemental_01.py
@@ -9,17 +9,17 @@ def verify1d(array: f32[:], result: f32[:], size: i32):
     for i in range(size):
         assert abs(sin(sin(array[i])) - result[i]) <= eps
 
-def verifynd(array: f32[:, :, :], result: f32[:, :, :], size1: i32, size2: i32, size3: i32):
+def verifynd(array: f64[:, :, :], result: f64[:, :, :], size1: i32, size2: i32, size3: i32):
     i: i32
     j: i32
     k: i32
-    eps: f32
-    eps = f32(1e-6)
+    eps: f64
+    eps = 1e-12
 
     for i in range(size1):
         for j in range(size2):
             for k in range(size3):
-                assert abs(sin(array[i, j, k])**f32(2) - result[i, j, k]) <= eps
+                assert abs(sin(array[i, j, k])**2.0 - result[i, j, k]) <= eps
 
 def verify2d(array: f64[:, :], result: f64[:, :], size1: i32, size2: i32):
     i: i32
@@ -103,17 +103,17 @@ def elemental_sin():
 
     verify1d(array1d, sin1d, 256)
 
-    arraynd: f32[256, 64, 16] = empty((256, 64, 16), dtype=float32)
-    sinnd: f32[256, 64, 16] = empty((256, 64, 16), dtype=float32)
+    arraynd: f64[200, 64, 16] = empty((200, 64, 16), dtype=float64)
+    sinnd: f64[200, 64, 16] = empty((200, 64, 16), dtype=float64)
 
-    for i in range(256):
+    for i in range(200):
         for j in range(64):
             for k in range(16):
-                arraynd[i, j, k] = f32(i + j + k)
+                arraynd[i, j, k] = float(i + j + k)
 
-    sinnd = sin(arraynd)**f32(2)
+    sinnd = sin(arraynd)**2.0
 
-    verifynd(arraynd, sinnd, 256, 64, 16)
+    verifynd(arraynd, sinnd, 200, 64, 16)
 
 def elemental_cos():
     i: i32

--- a/tests/reference/asr-elemental_01-b58df26.json
+++ b/tests/reference/asr-elemental_01-b58df26.json
@@ -2,11 +2,11 @@
     "basename": "asr-elemental_01-b58df26",
     "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/../integration_tests/elemental_01.py",
-    "infile_hash": "1d1eb8ce26df5817c1e474e4f69b0b96e53df362a31f1b722efaadf0",
+    "infile_hash": "fac03eb66f648c4cefdb08aa2f4f8d38c263f2794e680808c62cca81",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-elemental_01-b58df26.stdout",
-    "stdout_hash": "f6657ff256291caa10a0681ae7c5ad89f5c103725e44318d42b1445e",
+    "stdout_hash": "11322144ccc20362db9bf290de89fdbaaa0436821aa5377f20218dae",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-elemental_01-b58df26.stdout
+++ b/tests/reference/asr-elemental_01-b58df26.stdout
@@ -741,7 +741,7 @@
                                                     (Array
                                                         (Real 8)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (IntegerConstant 256 (Integer 4)))
+                                                        (IntegerConstant 200 (Integer 4)))
                                                         ((IntegerConstant 0 (Integer 4))
                                                         (IntegerConstant 64 (Integer 4)))
                                                         ((IntegerConstant 0 (Integer 4))
@@ -855,7 +855,7 @@
                                                     (Array
                                                         (Real 8)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (IntegerConstant 256 (Integer 4)))
+                                                        (IntegerConstant 200 (Integer 4)))
                                                         ((IntegerConstant 0 (Integer 4))
                                                         (IntegerConstant 64 (Integer 4)))
                                                         ((IntegerConstant 0 (Integer 4))
@@ -1012,7 +1012,7 @@
                                             (Array
                                                 (Real 8)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 256 (Integer 4)))
+                                                (IntegerConstant 200 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 64 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
@@ -1030,7 +1030,7 @@
                                             (Array
                                                 (Real 8)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 256 (Integer 4)))
+                                                (IntegerConstant 200 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 64 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
@@ -1046,11 +1046,11 @@
                                         ((Var 218 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (IntegerConstant 256 (Integer 4))
+                                            (IntegerConstant 200 (Integer 4))
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
-                                            (IntegerConstant 255 (Integer 4))
+                                            (IntegerConstant 199 (Integer 4))
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
@@ -1126,7 +1126,7 @@
                                                 (Array
                                                     (Real 8)
                                                     [((IntegerConstant 0 (Integer 4))
-                                                    (IntegerConstant 256 (Integer 4)))
+                                                    (IntegerConstant 200 (Integer 4)))
                                                     ((IntegerConstant 0 (Integer 4))
                                                     (IntegerConstant 64 (Integer 4)))
                                                     ((IntegerConstant 0 (Integer 4))
@@ -1144,7 +1144,7 @@
                                             (Array
                                                 (Real 8)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 256 (Integer 4)))
+                                                (IntegerConstant 200 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 64 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
@@ -1165,7 +1165,7 @@
                                             (Array
                                                 (Real 8)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 256 (Integer 4)))
+                                                (IntegerConstant 200 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 64 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
@@ -1181,7 +1181,7 @@
                                             (Array
                                                 (Real 8)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 256 (Integer 4)))
+                                                (IntegerConstant 200 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 64 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
@@ -1190,7 +1190,7 @@
                                             )
                                             ()
                                         ))
-                                        ((IntegerConstant 256 (Integer 4)))
+                                        ((IntegerConstant 200 (Integer 4)))
                                         ((IntegerConstant 64 (Integer 4)))
                                         ((IntegerConstant 16 (Integer 4)))]
                                         ()


### PR DESCRIPTION
On running /integration_tests/run_tests.py, a SEGFAULT error occurs and the test fails:

```
The following tests FAILED:
        159 - elemental_01 (SEGFAULT)
Errors while running CTest
Command failed: ctest -j8 --output-on-failure
```

Upon careful experimentation, I found that this is due to lines 106 and 107 in file elemental_01.py, where creating very large arrays of f64[256,64,16] causes memory overflow. The lines causing the issue are:

```
    arraynd: f64[256, 64, 16] = empty((256, 64, 16), dtype=float64)
    sinnd: f64[256, 64, 16] = empty((256, 64, 16), dtype=float64)
```

 I have changed the datatype to f32 where needed. This allows the required large arrays can be created and tested. Alternatively, we can increase the memory limit of the test.