### PR TITLE
UserOverride.cmake: fix native optflag for PowerPC

### DIFF
--- a/cmake/UserOverride.cmake
+++ b/cmake/UserOverride.cmake
@@ -9,7 +9,12 @@
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # g++
     set(common "-Wall -Wextra")
-    set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common} -O3 -march=native -funroll-loops -DNDEBUG")
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "ppc|powerpc")
+        set(native "-mtune=native")
+    else ()
+        set(native "-march=native")
+    endif ()
+    set(CMAKE_CXX_FLAGS_RELEASE_INIT "${common} -O3 ${native} -funroll-loops -DNDEBUG")
     set(CMAKE_CXX_FLAGS_DEBUG_INIT   "${common} -g -ggdb")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
     # icpc


### PR DESCRIPTION
@certik This is needed for the build to be feasible on PowerPC, since `-march` is unsupported there.
https://gcc.gnu.org/onlinedocs/gcc/RS_002f6000-and-PowerPC-Options.html

`-mtune` should be used instead; `-mcpu` also supported but may be unsafe and produce a broken code for some targets.