### PR TITLE
stacktrace.cpp: include syslimits.h for PATH_MAX

### DIFF
--- a/src/libasr/stacktrace.cpp
+++ b/src/libasr/stacktrace.cpp
@@ -15,6 +15,11 @@
 // For registering SIGSEGV callbacks
 #include <csignal>
 
+#ifdef __APPLE__
+// For PATH_MAX
+#  include <sys/syslimits.h>
+#endif
+
 
 // The following C headers are needed for some specific C functionality (see
 // the comments), which is not available in C++:


### PR DESCRIPTION
Otherwise PATH_MAX may be undefined on Apple.