### PR TITLE
Using basic_new_heap for assigning elements of symbolic list

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -720,6 +720,7 @@ RUN(NAME symbolics_12        LABELS cpython_sym c_sym llvm_sym NOFAST)
 RUN(NAME symbolics_13        LABELS cpython_sym c_sym llvm_sym NOFAST)
 RUN(NAME symbolics_14        LABELS cpython_sym llvm_sym NOFAST)
 RUN(NAME test_gruntz         LABELS cpython_sym c_sym llvm_sym NOFAST)
+RUN(NAME symbolics_15        LABELS c_sym llvm_sym NOFAST)
 
 RUN(NAME sizeof_01           LABELS llvm c
         EXTRAFILES sizeof_01b.c)

--- a/integration_tests/symbolics_15.py
+++ b/integration_tests/symbolics_15.py
@@ -21,9 +21,16 @@ def basic_assign(x: CPtr, y:CPtr) -> None:
 def basic_str(x: CPtr) -> str:
     pass
 
+@ccall(header="symengine/cwrapper.h", c_shared_lib="symengine", c_shared_lib_path=f"{os.environ['CONDA_PREFIX']}/lib")
+def basic_free_stack(x: CPtr) -> None:
+    pass
+
 def mmrv(r: Out[list[CPtr]]) -> None:
     # x: S = pi
-    x: CPtr = basic_new_heap()
+    _x: i64 = i64(0)
+    x: CPtr = empty_c_void_p()
+    p_c_pointer(pointer(_x, i64), x)
+    basic_new_stack(x)
     basic_const_pi(x)
 
     # l1: list[S]
@@ -44,6 +51,8 @@ def mmrv(r: Out[list[CPtr]]) -> None:
 
     # r = l1
     r = l1
+
+    basic_free_stack(x)
 
 def test_mrv():
     # ans : list[S]

--- a/integration_tests/symbolics_15.py
+++ b/integration_tests/symbolics_15.py
@@ -1,0 +1,64 @@
+from lpython import ccall, CPtr, p_c_pointer, pointer, i64, empty_c_void_p, Out
+import os
+
+@ccall(header="symengine/cwrapper.h", c_shared_lib="symengine", c_shared_lib_path=f"{os.environ['CONDA_PREFIX']}/lib")
+def basic_new_stack(x: CPtr) -> None:
+    pass
+
+@ccall(header="symengine/cwrapper.h", c_shared_lib="symengine", c_shared_lib_path=f"{os.environ['CONDA_PREFIX']}/lib")
+def basic_new_heap() -> CPtr:
+    pass
+
+@ccall(header="symengine/cwrapper.h", c_shared_lib="symengine", c_shared_lib_path=f"{os.environ['CONDA_PREFIX']}/lib")
+def basic_const_pi(x: CPtr) -> None:
+    pass
+
+@ccall(header="symengine/cwrapper.h", c_shared_lib="symengine", c_shared_lib_path=f"{os.environ['CONDA_PREFIX']}/lib")
+def basic_assign(x: CPtr, y:CPtr) -> None:
+    pass
+
+@ccall(header="symengine/cwrapper.h", c_shared_lib="symengine", c_shared_lib_path=f"{os.environ['CONDA_PREFIX']}/lib")
+def basic_str(x: CPtr) -> str:
+    pass
+
+def mmrv(r: Out[list[CPtr]]) -> None:
+    # x: S = pi
+    x: CPtr = basic_new_heap()
+    basic_const_pi(x)
+
+    # l1: list[S]
+    l1: list[CPtr] = []
+
+    # l1 = [x]
+    i: i32 = 0
+    Len: i32 = 1
+    for i in range(Len):
+        tmp: CPtr = basic_new_heap()
+        l1.append(tmp)
+        basic_assign(l1[0], x)
+
+    # print(l1[0])
+    s1: str = basic_str(l1[0])
+    print(s1)
+    assert s1 == "pi"
+
+    # r = l1
+    r = l1
+
+def test_mrv():
+    # ans : list[S]
+    # temp : list[S]
+    ans: list[CPtr] = []
+    temp: list[CPtr] = []
+
+    # mmrv(ans)
+    # temp = ans
+    mmrv(ans)
+    temp = ans
+
+    # print(temp[0])
+    s2: str = basic_str(temp[0])
+    print(s2)
+    assert s2 == "pi"
+
+test_mrv()


### PR DESCRIPTION
This PR adds an example to address the first TODO as pointed out here (https://github.com/lcompilers/lpython/issues/2450#issuecomment-1896363685)

We are trying to replicate this code snippet essentially 
```
from lpython import S
from sympy import Symbol, pi

def mmrv(r: Out[list[S]]) -> None:
    x: S = pi
    l1: list[S]
    l1 = [x]
    print(l1[0])
    r = l1

def test_mrv2():
    ans: list[S]
    temp: list[S]
    mmrv(ans)
    temp = ans
    print(temp[0])

test_mrv2()
```