### PR TITLE
Enabling c_sym backend for symbolics_14

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -718,7 +718,7 @@ RUN(NAME symbolics_10        LABELS cpython_sym c_sym llvm_sym NOFAST)
 RUN(NAME symbolics_11        LABELS cpython_sym c_sym llvm_sym NOFAST)
 RUN(NAME symbolics_12        LABELS cpython_sym c_sym llvm_sym NOFAST)
 RUN(NAME symbolics_13        LABELS cpython_sym c_sym llvm_sym NOFAST)
-RUN(NAME symbolics_14        LABELS cpython_sym llvm_sym NOFAST)
+RUN(NAME symbolics_14        LABELS cpython_sym c_sym llvm_sym NOFAST)
 RUN(NAME test_gruntz         LABELS cpython_sym c_sym llvm_sym NOFAST)
 RUN(NAME symbolics_15        LABELS c_sym llvm_sym NOFAST)
 


### PR DESCRIPTION
Now that #2454 has been merged (fixing issues related to the c_sym backend) , I think symbolics_14 can be supported through it.