### PR TITLE
fixes semantic error for int (Issue #1926)

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -876,7 +876,12 @@ public:
         }
 
         if( !type && raise_error ) {
-            throw SemanticError("Unsupported type annotation: " + var_annotation, loc);
+            if (var_annotation == "int") {
+                throw SemanticError(var_annotation + " type is not supported yet. " , loc);
+            } else
+            { 
+                throw SemanticError("Unsupported type annotation: " + var_annotation, loc);
+            }
         }
 
         return type;


### PR DESCRIPTION
Issue Link: #1926 

Changes:
Introduces a clear error message:
```plaintext
Semantic Error: 'int' type is not supported yet.
```
Context:
As discussed in [this comment](https://github.com/lcompilers/lpython/issues/1926#issuecomment-1737847500), this improvement enhances the usability of LPython.