### PR TITLE
Fixes empty string bug in str isalpha method

### DIFF
--- a/integration_tests/test_str_01.py
+++ b/integration_tests/test_str_01.py
@@ -42,14 +42,17 @@ def test_str_isalpha():
     b: str = "hj kl"
     c: str = "a12(){}A"
     d: str = " "
+    e: str = ""
     res: bool = a.isalpha()
     res2: bool = b.isalpha()
     res3: bool = c.isalpha()
     res4: bool = d.isalpha()
+    res5: bool = e.isalpha()
     assert res == True 
     assert res2 == False
     assert res3 == False
     assert res4 == False
+    assert res5 == False
 
    
 def test_str_title():

--- a/src/runtime/lpython_builtin.py
+++ b/src/runtime/lpython_builtin.py
@@ -687,6 +687,7 @@ def _lpython_str_join(s:str, lis:list[str]) -> str:
 
 def _lpython_str_isalpha(s: str) -> bool:
     ch: str
+    if len(s) == 0: return False
     for ch in s:
         ch_ord: i32 = ord(ch)
         if 65 <= ch_ord and ch_ord <= 90:


### PR DESCRIPTION
In the current implementation of the `isalpha()` method, an empty string returns a `True` value, but in CPython it returns `False`.