### PR TITLE
Fixing symbolic compare for test_gruntz.py

### DIFF
--- a/integration_tests/test_gruntz.py
+++ b/integration_tests/test_gruntz.py
@@ -2,16 +2,28 @@ from lpython import S
 from sympy import Symbol
 
 def mmrv(e: S, x: S) -> list[S]:
-    l: list[S] = []
     if not e.has(x):
-        return l
+        list0: list[S] = []
+        return list0
+    elif e == x:
+        list1: list[S] = [x]
+        return list1
     else:
         raise
 
-def test_mrv1():
+def test_mrv():
+    # Case 1
     x: S = Symbol("x")
     y: S = Symbol("y")
-    ans: list[S] = mmrv(y, x)
-    assert len(ans) == 0
+    ans1: list[S] = mmrv(y, x)
+    print(ans1)
+    assert len(ans1) == 0
 
-test_mrv1()
+    # Case 2
+    ans2: list[S] = mmrv(x, x)
+    ele1: S = ans2[0]
+    print(ele1)
+    assert ele1 == x
+    assert len(ans2) == 1
+
+test_mrv()

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -690,6 +690,15 @@ public:
                     xx.m_test = new_logical_not;
                 }
             }
+        } else if (ASR::is_a<ASR::SymbolicCompare_t>(*xx.m_test)) {
+            ASR::SymbolicCompare_t *s = ASR::down_cast<ASR::SymbolicCompare_t>(xx.m_test);
+            ASR::expr_t* function_call = nullptr;
+            if (s->m_op == ASR::cmpopType::Eq) {
+                function_call = basic_compare(xx.base.base.loc, "basic_eq", s->m_left, s->m_right);
+            } else {
+                function_call = basic_compare(xx.base.base.loc, "basic_neq", s->m_left, s->m_right);
+            }
+            xx.m_test = function_call;
         }
     }
 


### PR DESCRIPTION
The next few cases for test_gruntz.py would involve cases where symbolic compare should work correctly 
For eg check case 2 ( we need `if e == x` working for the same)
```
def mmrv(e: S, x: S) -> list[S]:
    if not e.has(x):
        empty_list: list[S] = []
        return empty_list
    elif e == x:
        list1: list[S] = [x]
        return list1
    else:
        raise

def test_mrv():
    # Case 1
    x: S = Symbol("x")
    y: S = Symbol("y")
    ans1: list[S] = mmrv(y, x)
    print(ans1)
    assert len(ans1) == 0

    # Case 2
    ans2: list[S] = mmrv(x, x)
    ele1: S = ans2[0]
    print(ele1)
    assert len(ans2) == 1

test_mrv()
```