### PR TITLE
Get macOS test working again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LPython
+#  LPython
 
 LPython is a Python compiler. It is in heavy development, currently in alpha
 stage. LPython works on Windows, macOS and Linux. Some of the goals of LPython


### PR DESCRIPTION
Towards #2455.

The first macOS failure in master happened in https://github.com/lcompilers/lpython/pull/2452. This PR reverts LPython to the commit before that. We'll see if it reliably passes.

If it passes, then #2452 must have broken it.

If it doesn't pass, then something in the GitHub Actions or Conda environment changed.