### PR TITLE
Fixed issue #1993 to improve readability of semantic error thrown

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -886,7 +886,7 @@ public:
                 );
                 throw SemanticAbort();
             } else { 
-                throw SemanticError("Unsupported type annotation: " + var_annotation, loc);
+                throw SemanticError("The type '" + var_annotation+"' is undeclared.", loc);
             }
         }
 

--- a/tests/reference/asr-test_annassign_01-2f18669.json
+++ b/tests/reference/asr-test_annassign_01-2f18669.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_annassign_01-2f18669.stderr",
-    "stderr_hash": "f3609cdad6bdb1be4a138587d5d36d0a28b71e4e51bb1304c2d2a01f",
+    "stderr_hash": "28c68e6612db1644548768280ac3d35d3735a13cd32c04da44cec570",
     "returncode": 2
 }

--- a/tests/reference/asr-test_annassign_01-2f18669.stderr
+++ b/tests/reference/asr-test_annassign_01-2f18669.stderr
@@ -1,4 +1,4 @@
-semantic error: Unsupported type annotation: Optional
+semantic error: The type 'Optional' is undeclared.
  --> tests/errors/test_annassign_01.py:2:8
   |
 2 |     a: Optional[i32] = 5

--- a/tests/reference/asr-test_annassign_02-accf6db.json
+++ b/tests/reference/asr-test_annassign_02-accf6db.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_annassign_02-accf6db.stderr",
-    "stderr_hash": "3a426fad190cfcadc94dd971acc709446147d8a63658953bfbb94771",
+    "stderr_hash": "1183fbf06e8412166eb5ca96b5b07cec67382752789a96c7c04c1950",
     "returncode": 2
 }

--- a/tests/reference/asr-test_annassign_02-accf6db.stderr
+++ b/tests/reference/asr-test_annassign_02-accf6db.stderr
@@ -1,4 +1,4 @@
-semantic error: Unsupported type annotation: Pattern
+semantic error: The type 'Pattern' is undeclared.
  --> tests/errors/test_annassign_02.py:2:15
   |
 2 |     hex_pat : Pattern[str] = r'-?0[xX]+'

--- a/tests/reference/asr-test_unsupported_type-0d813dd.json
+++ b/tests/reference/asr-test_unsupported_type-0d813dd.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_unsupported_type-0d813dd.stderr",
-    "stderr_hash": "1675de57db132a5a4a589070d7c54ff23a57532bd967ccb416ff8c2a",
+    "stderr_hash": "df2464bbcb9d52d4dbe40236762e965b1b771406f16ef90cf53b8611",
     "returncode": 2
 }

--- a/tests/reference/asr-test_unsupported_type-0d813dd.stderr
+++ b/tests/reference/asr-test_unsupported_type-0d813dd.stderr
@@ -1,4 +1,4 @@
-semantic error: Unsupported type annotation: i128
+semantic error: The type 'i128' is undeclared.
  --> tests/errors/test_unsupported_type.py:2:8
   |
 2 |     i: i128


### PR DESCRIPTION
Changed the error from "semantic error: Unsupported type annotation: ReRange" to "semantic error: The type 'ReRange' is undeclared." as per issue #1993 .