### PR TITLE
CI: Disable C tests on macOS

### DIFF
--- a/ci/test.xsh
+++ b/ci/test.xsh
@@ -22,9 +22,12 @@ else:
     src/bin/lpython examples/expr2.py
     src/bin/lpython --backend=c examples/expr2.py
     cd integration_tests
-    python run_tests.py -j16 -b llvm cpython c wasm
-    python run_tests.py -j16 -b llvm cpython c wasm -f
 
     if $(uname).strip() == "Linux":
+        python run_tests.py -j16 -b llvm cpython c wasm
+        python run_tests.py -j16 -b llvm cpython c wasm -f
         python run_tests.py -j16 -b x86 wasm_x86 wasm_x64
         python run_tests.py -j16 -b x86 wasm_x86 wasm_x64 -f
+    else:
+        python run_tests.py -j16 -b llvm cpython wasm
+        python run_tests.py -j16 -b llvm cpython wasm -f


### PR DESCRIPTION
As a workaround for #2455.