### PR TITLE
CI: XX should fail

### DIFF
--- a/ci/test.xsh
+++ b/ci/test.xsh
@@ -29,5 +29,5 @@ else:
         python run_tests.py -j16 -b x86 wasm_x86 wasm_x64
         python run_tests.py -j16 -b x86 wasm_x86 wasm_x64 -f
     else:
-        python run_tests.py -j1 -b llvm cpython c wasm
-        python run_tests.py -j1 -b llvm cpython c wasm -f
+        python run_tests.py -j16 -b llvm cpython c wasm
+        python run_tests.py -j16 -b llvm cpython c wasm -f

--- a/ci/test.xsh
+++ b/ci/test.xsh
@@ -29,5 +29,5 @@ else:
         python run_tests.py -j16 -b x86 wasm_x86 wasm_x64
         python run_tests.py -j16 -b x86 wasm_x86 wasm_x64 -f
     else:
-        python run_tests.py -j1 -b cpython wasm
-        python run_tests.py -j1 -b cpython wasm -f
+        python run_tests.py -j1 -b llvm cpython c wasm
+        python run_tests.py -j1 -b llvm cpython c wasm -f


### PR DESCRIPTION
This is the same as https://github.com/lcompilers/lpython/pull/2521, but using `-j16` instead of `-j1`. It should fail almost every time.

If so, we found the bug.