### PR TITLE
Added case to support log instances in mrv function

### DIFF
--- a/integration_tests/test_gruntz.py
+++ b/integration_tests/test_gruntz.py
@@ -1,5 +1,5 @@
 from lpython import S
-from sympy import Symbol
+from sympy import Symbol, log
 
 def mmrv(e: S, x: S) -> list[S]:
     if not e.has(x):
@@ -8,6 +8,10 @@ def mmrv(e: S, x: S) -> list[S]:
     elif e == x:
         list1: list[S] = [x]
         return list1
+    elif e.func == log:
+        arg0: S = e.args[0]
+        list2: list[S] = mmrv(arg0, x)
+        return list2
     else:
         raise
 
@@ -24,6 +28,13 @@ def test_mrv():
     ele1: S = ans2[0]
     print(ele1)
     assert ele1 == x
+    assert len(ans2) == 1
+
+    # Case 3
+    ans3: list[S] = mmrv(log(x), x)
+    ele2: S = ans3[0]
+    print(ele2)
+    assert ele2 == x
     assert len(ans2) == 1
 
 test_mrv()


### PR DESCRIPTION
What we are trying to do is address this [case ](https://github.com/sympy/sympy/blob/680fb21363e1ea685d6fc868d15069d80ac0c97f/sympy/series/gruntz.py#L285) and this [example](https://github.com/sympy/sympy/blob/680fb21363e1ea685d6fc868d15069d80ac0c97f/sympy/series/tests/test_gruntz.py#L253)

We already have the essential tools to support it so no changes are required in the ASR pass.
