### PR TITLE
Fixed visit_if for SymbolicCompare cases

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -728,6 +728,7 @@ RUN(NAME symbolics_14        LABELS cpython_sym c_sym llvm_sym NOFAST)
 RUN(NAME test_gruntz         LABELS cpython_sym c_sym llvm_sym NOFAST)
 RUN(NAME symbolics_15        LABELS c_sym llvm_sym NOFAST)
 RUN(NAME symbolics_16        LABELS cpython_sym c_sym llvm_sym NOFAST)
+RUN(NAME symbolics_17        LABELS cpython_sym c_sym llvm_sym NOFAST)
 
 RUN(NAME sizeof_01           LABELS llvm c
         EXTRAFILES sizeof_01b.c)

--- a/integration_tests/symbolics_17.py
+++ b/integration_tests/symbolics_17.py
@@ -1,0 +1,10 @@
+from lpython import S
+from sympy import Symbol, pi
+
+def test_main():
+    x: S = Symbol('x')
+    if x != pi:
+        print(x != pi)
+        assert x != pi
+
+test_main()

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -698,7 +698,9 @@ public:
             } else {
                 function_call = basic_compare(xx.base.base.loc, "basic_neq", s->m_left, s->m_right);
             }
-            xx.m_test = function_call;
+            ASR::stmt_t* stmt = ASRUtils::STMT(ASR::make_If_t(al, xx.base.base.loc, function_call,
+                xx.m_body, xx.n_body, xx.m_orelse, xx.n_orelse));
+            pass_result.push_back(al, stmt);
         }
     }
 


### PR DESCRIPTION
The way I addresssed #2532 is by creating a new `If` node instead of editing the `m_test` parameter of the old node itself and this works. I think the original code should itself be sufficient but we haven't been able to find the error hence using this.

I've added a test for the same.