### PR TITLE
refine input file missing msg

### DIFF
--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -1735,7 +1735,8 @@ int main(int argc, char *argv[])
         // the first:
         std::string arg_file = arg_files[0];
         if (CLI::NonexistentPath(arg_file).empty()){
-            throw LCompilers::LCompilersException("No such file or directory: " + arg_file);
+            std::cerr << "Your input file doesn't exist. file name is: " << arg_file << std::endl;
+            return 1;
         }
 
         std::string outfile;

--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -1735,7 +1735,7 @@ int main(int argc, char *argv[])
         // the first:
         std::string arg_file = arg_files[0];
         if (CLI::NonexistentPath(arg_file).empty()){
-            std::cerr << "Your input file doesn't exist. file name is: " << arg_file << std::endl;
+            std::cerr << "The input file does not exist: " << arg_file << std::endl;
             return 1;
         }
 


### PR DESCRIPTION
This PR fixs issue #2481 . It prints a more concrete err message and exits immediately instead of throwing an error.