### PR TITLE
Fix duplicate read when paring python asr

### DIFF
--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -1735,7 +1735,8 @@ int main(int argc, char *argv[])
         // the first:
         std::string arg_file = arg_files[0];
         if (CLI::NonexistentPath(arg_file).empty()){
-            throw LCompilers::LCompilersException("No such file or directory: " + arg_file);
+            std::cerr << "Your input file doesn't exist. file name is: " << arg_file << std::endl;
+            return 1;
         }
 
         std::string outfile;

--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -53,6 +53,7 @@ namespace {
 using LCompilers::endswith;
 using LCompilers::CompilerOptions;
 using LCompilers::LPython::parse_python_file;
+using LCompilers::LPython::parse_python_source;
 
 enum class Backend {
     llvm, cpp, c, x86, wasm, wasm_x86, wasm_x64
@@ -190,16 +191,17 @@ int emit_asr(const std::string &infile,
     Allocator al(4*1024);
     LCompilers::diag::Diagnostics diagnostics;
     LCompilers::LocationManager lm;
+    std::string input;
     {
         LCompilers::LocationManager::FileLocations fl;
         fl.in_filename = infile;
         lm.files.push_back(fl);
-        std::string input = LCompilers::read_file(infile);
+        input = LCompilers::read_file(infile);
         lm.init_simple(input);
         lm.file_ends.push_back(input.size());
     }
-    LCompilers::Result<LCompilers::LPython::AST::ast_t*> r1 = parse_python_file(
-        al, runtime_library_dir, infile, diagnostics, 0, compiler_options.new_parser);
+    LCompilers::Result<LCompilers::LPython::AST::ast_t*> r1 = parse_python_source(
+        al, runtime_library_dir, input, diagnostics, 0, compiler_options.new_parser);
     std::cerr << diagnostics.render(lm, compiler_options);
     if (!r1.ok) {
         return 1;

--- a/src/lpython/parser/parser.cpp
+++ b/src/lpython/parser/parser.cpp
@@ -112,9 +112,9 @@ std::string unique_filename(const std::string &prefix) {
     return filename;
 }
 
-Result<LPython::AST::ast_t*> parse_python_file(Allocator &al,
+Result<LPython::AST::ast_t*> parse_python_source(Allocator &al,
         const std::string &/*runtime_library_dir*/,
-        const std::string &infile,
+        const std::string &source_code,
         diag::Diagnostics &diagnostics,
         uint32_t prev_loc,
         [[maybe_unused]] bool new_parser) {
@@ -122,8 +122,7 @@ Result<LPython::AST::ast_t*> parse_python_file(Allocator &al,
     // We will be using the new parser from now on
     new_parser = true;
     LCOMPILERS_ASSERT(new_parser)
-    std::string input = read_file(infile);
-    Result<LPython::AST::Module_t*> res = parse(al, input, prev_loc, diagnostics);
+    Result<LPython::AST::Module_t*> res = parse(al, source_code, prev_loc, diagnostics);
     if (res.ok) {
         ast = (LPython::AST::ast_t*)res.result;
     } else {
@@ -131,6 +130,16 @@ Result<LPython::AST::ast_t*> parse_python_file(Allocator &al,
         return Error();
     }
     return ast;
+}
+
+Result<LPython::AST::ast_t*> parse_python_file(Allocator &al,
+        const std::string &runtime_library_dir,
+        const std::string &infile,
+        diag::Diagnostics &diagnostics,
+        uint32_t prev_loc,
+        [[maybe_unused]] bool new_parser) {
+    std::string input_source_code = read_file(infile);
+    return parse_python_source(al, runtime_library_dir, input_source_code, diagnostics, prev_loc, new_parser);
 }
 
 

--- a/src/lpython/parser/parser.h
+++ b/src/lpython/parser/parser.h
@@ -41,6 +41,12 @@ Result<LPython::AST::ast_t*> parse_python_file(Allocator &al,
         diag::Diagnostics &diagnostics,
         uint32_t prev_loc, bool new_parser);
 
+Result<LPython::AST::ast_t*> parse_python_source(Allocator &al,
+        const std::string &runtime_library_dir,
+        const std::string &infile,
+        diag::Diagnostics &diagnostics,
+        uint32_t prev_loc, bool new_parser);
+
 } // namespace LCompilers::LPython
 
 #endif


### PR DESCRIPTION
fix issue #2475. I create `parse_python_source` to accept source code literal input to avoid additional file read.

Note that there are still mutiple codes sharing the similar logic, like https://github.com/lcompilers/lpython/blob/main/src/bin/lpython.cpp#L254 . If this modification is accepted, I will fix them in this PR later.