### PR TITLE
Freeing variables correctly through visit_Return

### DIFF
--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -985,7 +985,9 @@ public:
                     ASRUtils::EXPR(ASR::make_Var_t(al, x.base.base.loc, symbol))));
             }
             symbolic_vars_to_free.clear();
-            pass_result.push_back(al, ASRUtils::STMT(ASR::make_Return_t(al, x.base.base.loc)));
+            for (ASR::symbol_t* symbol : symbolic_vars_to_omit) {
+                symbolic_vars_to_free.insert(symbol);
+            }
         }
     }
 };


### PR DESCRIPTION
Fixes #2533 

Currently on master as soon as we encountered the **return node**, we thought it was the end of the program and we could free out everything. But consider the following
```
from lpython import S
from sympy import Symbol, log

def mmrv(e: S, x: S) -> list[S]:
    print(e)
    print(x)
    if e == x:
        list1: list[S] = [x]
        return list1
    else:
        print(e)
        list2: list[S] = mmrv(x, x)
        return list2

def test_mrv():
    x: S = Symbol("x")
    ans3: list[S] = mmrv(log(x), x)
    ele2: S = ans3[0]
    print(ele2)

test_mrv()
```
Here we can't free the variable `e` till the function reaches an end (As it is being used in the **2nd if block**). So as shown in the issue this leads to [incorrect results](https://github.com/lcompilers/lpython/issues/2533#issuecomment-1945748986) 

This is now fixed and we get the correct output
```
log(x)
x
log(x)
x
x
x
```

