### PR TITLE
Fixes #2490: Adds unescaping `\f` and the correct implementation of `isspace()` string method.

### DIFF
--- a/src/libasr/string_utils.cpp
+++ b/src/libasr/string_utils.cpp
@@ -192,16 +192,24 @@ char* str_unescape_c(Allocator &al, LCompilers::Str &s) {
         } else if (s[idx] == '\\' && s[idx+1] == 'v') {
             x += "\v";
             idx++;
-        } else if (s[idx] == '\\' && s[idx+1] == '\\') {
+        }
+        else if (s[idx] == '\\' && s[idx + 1] == 'f') {
+            x += "\f";
+            idx++;
+        }
+        else if (s[idx] == '\\' && s[idx + 1] == '\\') {
             x += "\\";
             idx++;
-        } else if (s[idx] == '\\' && s[idx+1] == '"') {
+        }
+        else if (s[idx] == '\\' && s[idx + 1] == '"') {
             x += '"';
             idx++;
-        } else if (s[idx] == '\\' && s[idx+1] == '\'') {
+        }
+        else if (s[idx] == '\\' && s[idx + 1] == '\'') {
             x += '\'';
             idx++;
-        } else {
+        }
+        else {
             x += s[idx];
         }
     }

--- a/src/runtime/lpython_builtin.py
+++ b/src/runtime/lpython_builtin.py
@@ -1,6 +1,7 @@
-from lpython import (i8, i16, i32, i64, f32, f64, c32, c64, overload, u8,
-                     u16, u32, u64)
-#from sys import exit
+from lpython import i8, i16, i32, i64, f32, f64, c32, c64, overload, u8, u16, u32, u64
+
+# from sys import exit
+
 
 #: abs() as a generic procedure.
 #: supported types for argument:
@@ -17,12 +18,14 @@ def abs(x: f64) -> f64:
         result = -x
     return result
 
+
 @overload
 def abs(x: f32) -> f32:
     if x >= f32(0.0):
         return x
     else:
         return -x
+
 
 @overload
 def abs(x: i8) -> i8:
@@ -31,12 +34,14 @@ def abs(x: i8) -> i8:
     else:
         return -x
 
+
 @overload
 def abs(x: i16) -> i16:
     if x >= i16(0):
         return x
     else:
         return -x
+
 
 @overload
 def abs(x: i32) -> i32:
@@ -45,12 +50,14 @@ def abs(x: i32) -> i32:
     else:
         return -x
 
+
 @overload
 def abs(x: i64) -> i64:
     if x >= i64(0):
         return x
     else:
         return -x
+
 
 @overload
 def abs(b: bool) -> i32:
@@ -59,13 +66,15 @@ def abs(b: bool) -> i32:
     else:
         return 0
 
+
 @overload
 def abs(c: c32) -> f32:
     a: f32
     b: f32
     a = c.real
     b = _lfortran_caimag(c)
-    return f32((a**f32(2) + b**f32(2))**f32(1/2))
+    return f32((a ** f32(2) + b ** f32(2)) ** f32(1 / 2))
+
 
 @overload
 def abs(c: c64) -> f64:
@@ -73,7 +82,8 @@ def abs(c: c64) -> f64:
     b: f64
     a = c.real
     b = _lfortran_zaimag(c)
-    return (a**2.0 + b**2.0)**(1/2)
+    return (a**2.0 + b**2.0) ** (1 / 2)
+
 
 @interface
 def len(s: str) -> i32:
@@ -81,6 +91,7 @@ def len(s: str) -> i32:
     Return the length of the string `s`.
     """
     pass
+
 
 #: pow() as a generic procedure.
 #: supported types for arguments:
@@ -94,13 +105,16 @@ def pow(x: i32, y: i32) -> f64:
     """
     return f64(x**y)
 
+
 @overload
 def pow(x: i64, y: i64) -> f64:
     return f64(x**y)
 
+
 @overload
 def pow(x: f32, y: f32) -> f32:
     return x**y
+
 
 @overload
 def pow(x: f64, y: f64) -> f64:
@@ -109,21 +123,26 @@ def pow(x: f64, y: f64) -> f64:
     """
     return x**y
 
+
 @overload
 def pow(x: i32, y: f32) -> f32:
-    return f32(x)**y
+    return f32(x) ** y
+
 
 @overload
 def pow(x: f32, y: i32) -> f32:
-    return x**f32(y)
+    return x ** f32(y)
+
 
 @overload
 def pow(x: i32, y: f64) -> f64:
-    return f64(x)**y
+    return f64(x) ** y
+
 
 @overload
 def pow(x: f64, y: i32) -> f64:
-    return x**f64(y)
+    return x ** f64(y)
+
 
 @overload
 def pow(x: bool, y: bool) -> i32:
@@ -132,12 +151,15 @@ def pow(x: bool, y: bool) -> i32:
 
     return 1
 
+
 @overload
 def pow(c: c32, y: i32) -> c32:
-    return c**c32(y)
+    return c ** c32(y)
+
 
 # sum
 # supported data types: i32, i64, f32, f64
+
 
 @overload
 def sum(arr: list[i32]) -> i32:
@@ -152,6 +174,7 @@ def sum(arr: list[i32]) -> i32:
         sum += arr[i]
     return sum
 
+
 @overload
 def sum(arr: list[i64]) -> i64:
     """
@@ -164,6 +187,7 @@ def sum(arr: list[i64]) -> i64:
     for i in range(len(arr)):
         sum += arr[i]
     return sum
+
 
 @overload
 def sum(arr: list[f32]) -> f32:
@@ -178,6 +202,7 @@ def sum(arr: list[f32]) -> f32:
         sum += arr[i]
     return sum
 
+
 @overload
 def sum(arr: list[f64]) -> f64:
     """
@@ -191,31 +216,32 @@ def sum(arr: list[f64]) -> f64:
         sum += arr[i]
     return sum
 
+
 def bin(n: i32) -> str:
     """
     Returns the binary representation of an integer `n`.
     """
     if n == 0:
-        return '0b0'
+        return "0b0"
     prep: str
-    prep = '0b'
+    prep = "0b"
     n_: i32
     n_ = n
     if n_ < 0:
         n_ = -n_
-        prep = '-0b'
+        prep = "-0b"
     res: str
-    res = ''
-    if (n_ - (n_ // 2)*2) == 0:
-        res += '0'
+    res = ""
+    if (n_ - (n_ // 2) * 2) == 0:
+        res += "0"
     else:
-        res += '1'
+        res += "1"
     while n_ > 1:
-        n_ = (n_ // 2)
-        if (n_ - (n_ // 2)*2) == 0:
-            res += '0'
+        n_ = n_ // 2
+        if (n_ - (n_ // 2) * 2) == 0:
+            res += "0"
         else:
-            res += '1'
+            res += "1"
     return prep + res[::-1]
 
 
@@ -224,24 +250,40 @@ def hex(n: i32) -> str:
     Returns the hexadecimal representation of an integer `n`.
     """
     hex_values: list[str]
-    hex_values = ['0', '1', '2', '3', '4', '5', '6', '7',
-                  '8', '9', 'a', 'b', 'c', 'd', 'e', 'f']
+    hex_values = [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+    ]
     if n == 0:
-        return '0x0'
+        return "0x0"
     prep: str
-    prep = '0x'
+    prep = "0x"
     n_: i32
     n_ = n
     if n_ < 0:
-        prep = '-0x'
+        prep = "-0x"
         n_ = -n_
     res: str
     res = ""
     remainder: i32
     while n_ > 0:
-        remainder = n_ - (n_ // 16)*16
+        remainder = n_ - (n_ // 16) * 16
         n_ -= remainder
-        n_ = (n_ // 16)
+        n_ = n_ // 16
         res += hex_values[remainder]
     return prep + res[::-1]
 
@@ -251,26 +293,43 @@ def oct(n: i32) -> str:
     Returns the octal representation of an integer `n`.
     """
     _values: list[str]
-    _values = ['0', '1', '2', '3', '4', '5', '6', '7',
-               '8', '9', 'a', 'b', 'c', 'd', 'e', 'f']
+    _values = [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+    ]
     if n == 0:
-        return '0o0'
+        return "0o0"
     prep: str
-    prep = '0o'
+    prep = "0o"
     n_: i32
     n_ = n
     if n_ < 0:
-        prep = '-0o'
+        prep = "-0o"
         n_ = -n_
     res: str
     res = ""
     remainder: i32
     while n_ > 0:
-        remainder = n_ - (n_ // 8)*8
+        remainder = n_ - (n_ // 8) * 8
         n_ -= remainder
-        n_ = (n_ // 8)
+        n_ = n_ // 8
         res += _values[remainder]
     return prep + res[::-1]
+
 
 #: round() as a generic procedure.
 #: supported types for argument:
@@ -294,6 +353,7 @@ def round(value: f64) -> i32:
         else:
             return i + 1
 
+
 @overload
 def round(value: f32) -> i32:
     i: i32
@@ -310,25 +370,31 @@ def round(value: f32) -> i32:
         else:
             return i + 1
 
+
 @overload
 def round(value: i32) -> i32:
     return value
+
 
 @overload
 def round(value: i64) -> i64:
     return value
 
+
 @overload
 def round(value: i8) -> i8:
     return value
+
 
 @overload
 def round(value: i16) -> i16:
     return value
 
+
 @overload
 def round(b: bool) -> i32:
     return abs(b)
+
 
 #: complex() as a generic procedure.
 #: supported types for arguments:
@@ -339,28 +405,32 @@ def round(b: bool) -> i32:
 @interface
 @overload
 def complex() -> c64:
-    return c64(0) + c64(0)*1j
+    return c64(0) + c64(0) * 1j
 
 
 @interface
 @overload
 def complex(x: f64) -> c64:
-    return c64(x) + c64(0)*1j
+    return c64(x) + c64(0) * 1j
+
 
 @interface
 @overload
 def complex(x: i32) -> c32:
-    return c32(x) + c32(0)*c32(1j)
+    return c32(x) + c32(0) * c32(1j)
+
 
 @interface
 @overload
 def complex(x: f32) -> c32:
-    return c32(x) + c32(0)*c32(1j)
+    return c32(x) + c32(0) * c32(1j)
+
 
 @interface
 @overload
 def complex(x: i64) -> c64:
-    return c64(x) + c64(0)*1j
+    return c64(x) + c64(0) * 1j
+
 
 @interface
 @overload
@@ -368,52 +438,62 @@ def complex(x: f64, y: f64) -> c64:
     """
     Return a complex number with the given real and imaginary parts.
     """
-    return c64(x) + c64(y)*1j
+    return c64(x) + c64(y) * 1j
+
 
 @interface
 @overload
 def complex(x: f32, y: f32) -> c32:
-    return c32(x) + c32(y)*c32(1j)
+    return c32(x) + c32(y) * c32(1j)
+
 
 @interface
 @overload
 def complex(x: f32, y: f64) -> c64:
-    return c64(x) + c64(y)*1j
+    return c64(x) + c64(y) * 1j
+
 
 @interface
 @overload
 def complex(x: f64, y: f32) -> c64:
-    return c64(x) + c64(y)*1j
+    return c64(x) + c64(y) * 1j
+
 
 @interface
 @overload
 def complex(x: i32, y: i32) -> c64:
-    return c64(x) + c64(y)*1j
+    return c64(x) + c64(y) * 1j
+
 
 @interface
 @overload
 def complex(x: i64, y: i64) -> c64:
-    return c64(x) + c64(y)*1j
+    return c64(x) + c64(y) * 1j
+
 
 @interface
 @overload
 def complex(x: i32, y: i64) -> c64:
-    return c64(x) + c64(y)*1j
+    return c64(x) + c64(y) * 1j
+
 
 @interface
 @overload
 def complex(x: i64, y: i32) -> c64:
-    return c64(x) + c64(y)*1j
+    return c64(x) + c64(y) * 1j
+
 
 @interface
 @overload
 def complex(x: i32, y: f64) -> c64:
-    return c64(x) + c64(y)*1j
+    return c64(x) + c64(y) * 1j
+
 
 @interface
 @overload
 def complex(x: f64, y: i32) -> c64:
-    return c64(x) + c64(y)*1j
+    return c64(x) + c64(y) * 1j
+
 
 @interface
 def divmod(x: i32, y: i32) -> tuple[i32, i32]:
@@ -439,13 +519,16 @@ def ubound(x: i32[:], dim: i32) -> i32:
 def _lfortran_caimag(x: c32) -> f32:
     pass
 
+
 @ccall
 def _lfortran_zaimag(x: c64) -> f64:
     pass
 
+
 @overload
 def _lpython_imag(x: c64) -> f64:
     return _lfortran_zaimag(x)
+
 
 @overload
 def _lpython_imag(x: c32) -> f32:
@@ -454,43 +537,52 @@ def _lpython_imag(x: c32) -> f32:
 
 @overload
 def _mod(a: i8, b: i8) -> i8:
-    return a - (a // b)*b
+    return a - (a // b) * b
+
 
 @overload
 def _mod(a: i16, b: i16) -> i16:
-    return a - (a // b)*b
+    return a - (a // b) * b
+
 
 @overload
 def _mod(a: i32, b: i32) -> i32:
-    return a - (a // b)*b
+    return a - (a // b) * b
+
 
 @overload
 def _mod(a: u8, b: u8) -> u8:
-    return a - (a // b)*b
+    return a - (a // b) * b
+
 
 @overload
 def _mod(a: u16, b: u16) -> u16:
-    return a - (a // b)*b
+    return a - (a // b) * b
+
 
 @overload
 def _mod(a: u32, b: u32) -> u32:
-    return a - (a // b)*b
+    return a - (a // b) * b
+
 
 @overload
 def _mod(a: f32, b: f32) -> f32:
-    return a - (a // b)*b
+    return a - (a // b) * b
+
 
 @overload
 def _mod(a: u64, b: u64) -> u64:
-    return a - (a // b)*b
+    return a - (a // b) * b
+
 
 @overload
 def _mod(a: i64, b: i64) -> i64:
-    return a - (a // b)*b
+    return a - (a // b) * b
+
 
 @overload
 def _mod(a: f64, b: f64) -> f64:
-    return a - (a // b)*b
+    return a - (a // b) * b
 
 
 @overload
@@ -499,6 +591,7 @@ def max(a: i32, b: i32) -> i32:
         return a
     else:
         return b
+
 
 @overload
 def max(a: i32, b: i32, c: i32) -> i32:
@@ -509,14 +602,16 @@ def max(a: i32, b: i32, c: i32) -> i32:
         res = c
     return res
 
+
 @overload
 def max(a: f64, b: f64, c: f64) -> f64:
-    res: f64 =a
+    res: f64 = a
     if b - res > 1e-6:
         res = b
     if c - res > 1e-6:
         res = c
     return res
+
 
 @overload
 def max(a: f64, b: f64) -> f64:
@@ -525,12 +620,14 @@ def max(a: f64, b: f64) -> f64:
     else:
         return b
 
+
 @overload
 def min(a: i32, b: i32) -> i32:
     if a < b:
         return a
     else:
         return b
+
 
 @overload
 def min(a: i32, b: i32, c: i32) -> i32:
@@ -541,6 +638,7 @@ def min(a: i32, b: i32, c: i32) -> i32:
         res = c
     return res
 
+
 @overload
 def min(a: f64, b: f64, c: f64) -> f64:
     res: f64 = a
@@ -549,6 +647,7 @@ def min(a: f64, b: f64, c: f64) -> f64:
     if res - c > 1e-6:
         res = c
     return res
+
 
 @overload
 def min(a: f64, b: f64) -> f64:
@@ -566,6 +665,7 @@ def _floor(x: f64) -> i64:
         return r
     return r - i64(1)
 
+
 @overload
 def _floor(x: f32) -> i32:
     r: i32
@@ -580,7 +680,7 @@ def _mod(a: i32, b: i32) -> i32:
     """
     Returns a%b
     """
-    return a - i32(_floor(a/b))*b
+    return a - i32(_floor(a / b)) * b
 
 
 @overload
@@ -589,8 +689,8 @@ def _mod(a: i64, b: i64) -> i64:
     Returns a%b
     """
     r: i64
-    r = _floor(a/b)
-    return a - r*b
+    r = _floor(a / b)
+    return a - r * b
 
 
 @overload
@@ -599,7 +699,7 @@ def pow(x: i32, y: i32, z: i32) -> i32:
     Return `x` raised to the power `y`.
     """
     if y < 0:
-        raise ValueError('y should be nonnegative')
+        raise ValueError("y should be nonnegative")
     result: i32
     result = _mod(x**y, z)
     return result
@@ -611,17 +711,18 @@ def pow(x: i64, y: i64, z: i64) -> i64:
     Return `x` raised to the power `y`.
     """
     if y < i64(0):
-        raise ValueError('y should be nonnegative')
+        raise ValueError("y should be nonnegative")
     result: i64
     result = _mod(x**y, z)
     return result
+
 
 @overload
 def _lpython_str_capitalize(x: str) -> str:
     if len(x) == 0:
         return x
-    i:str
-    res:str = ""
+    i: str
+    res: str = ""
     for i in x:
         if ord(i) >= 65 and ord(i) <= 90:  # Check if uppercase
             res += chr(ord(i) + 32)  # Convert to lowercase using ASCII values
@@ -630,7 +731,7 @@ def _lpython_str_capitalize(x: str) -> str:
 
     val: i32
     val = ord(res[0])
-    if val >= ord('a') and val <= ord('z'):
+    if val >= ord("a") and val <= ord("z"):
         val -= 32
     res = chr(val) + res[1:]
     return res
@@ -638,14 +739,18 @@ def _lpython_str_capitalize(x: str) -> str:
 
 @overload
 def _lpython_str_count(s: str, sub: str) -> i32:
-    s_len :i32; sub_len :i32; flag: bool; _len: i32;
-    count: i32; i: i32;
+    s_len: i32
+    sub_len: i32
+    flag: bool
+    _len: i32
+    count: i32
+    i: i32
     lps: list[i32] = []
     s_len = len(s)
     sub_len = len(sub)
 
     if sub_len == 0:
-        return s_len + 1 
+        return s_len + 1
 
     count = 0
 
@@ -689,38 +794,43 @@ def _lpython_str_count(s: str, sub: str) -> i32:
 def _lpython_str_lower(x: str) -> str:
     res: str
     res = ""
-    i:str
+    i: str
     for i in x:
-        if ord('A') <= ord(i) and ord(i) <= ord('Z'):
-            res += chr(ord(i) +32)
+        if ord("A") <= ord(i) and ord(i) <= ord("Z"):
+            res += chr(ord(i) + 32)
         else:
             res += i
     return res
+
 
 @overload
 def _lpython_str_upper(x: str) -> str:
     res: str
     res = ""
-    i:str
+    i: str
     for i in x:
-        if ord('a') <= ord(i) and ord(i) <= ord('z'):
-            res += chr(ord(i) -32)
+        if ord("a") <= ord(i) and ord(i) <= ord("z"):
+            res += chr(ord(i) - 32)
         else:
             res += i
     return res
 
+
 @overload
-def _lpython_str_join(s:str, lis:list[str]) -> str:
-    if len(lis) == 0: return ""
-    res:str = lis[0]
-    i:i32
+def _lpython_str_join(s: str, lis: list[str]) -> str:
+    if len(lis) == 0:
+        return ""
+    res: str = lis[0]
+    i: i32
     for i in range(1, len(lis)):
         res += s + lis[i]
     return res
 
+
 def _lpython_str_isalpha(s: str) -> bool:
     ch: str
-    if len(s) == 0: return False
+    if len(s) == 0:
+        return False
     for ch in s:
         ch_ord: i32 = ord(ch)
         if 65 <= ch_ord and ch_ord <= 90:
@@ -730,15 +840,16 @@ def _lpython_str_isalpha(s: str) -> bool:
         return False
     return True
 
+
 def _lpython_str_title(s: str) -> str:
     result: str = ""
     capitalize_next: bool = True
     ch: str
     for ch in s:
         ch_ord: i32 = ord(ch)
-        if ch_ord >= 97  and ch_ord <= 122:
+        if ch_ord >= 97 and ch_ord <= 122:
             if capitalize_next:
-                result += chr(ord(ch) - ord('a') + ord('A'))
+                result += chr(ord(ch) - ord("a") + ord("A"))
                 capitalize_next = False
             else:
                 result += ch
@@ -747,12 +858,13 @@ def _lpython_str_title(s: str) -> str:
                 result += ch
                 capitalize_next = False
             else:
-                result += chr(ord(ch) + ord('a') - ord('A'))
+                result += chr(ord(ch) + ord("a") - ord("A"))
         else:
             result += ch
             capitalize_next = True
 
     return result
+
 
 def _lpython_str_istitle(s: str) -> bool:
     length: i32 = len(s)
@@ -762,16 +874,16 @@ def _lpython_str_istitle(s: str) -> bool:
 
     word_start: bool = True  # Flag to track the start of a word
     ch: str
-    only_whitespace: bool = True 
+    only_whitespace: bool = True
     for ch in s:
-        if ch.isalpha() and (ord('A') <= ord(ch) and ord(ch) <= ord('Z')):
+        if ch.isalpha() and (ord("A") <= ord(ch) and ord(ch) <= ord("Z")):
             only_whitespace = False
             if word_start:
                 word_start = False
             else:
                 return False  # Found an uppercase character in the middle of a word
 
-        elif ch.isalpha() and (ord('a') <= ord(ch) and ord(ch) <= ord('z')):
+        elif ch.isalpha() and (ord("a") <= ord(ch) and ord(ch) <= ord("z")):
             only_whitespace = False
             if word_start:
                 return False  # Found a lowercase character in the middle of a word
@@ -782,11 +894,14 @@ def _lpython_str_istitle(s: str) -> bool:
     return True if not only_whitespace else False
 
 
-
 @overload
 def _lpython_str_find(s: str, sub: str) -> i32:
-    s_len :i32; sub_len :i32; flag: bool; _len: i32;
-    res: i32; i: i32;
+    s_len: i32
+    sub_len: i32
+    flag: bool
+    _len: i32
+    res: i32
+    i: i32
     lps: list[i32] = []
     s_len = len(s)
     sub_len = len(sub)
@@ -820,7 +935,7 @@ def _lpython_str_find(s: str, sub: str) -> i32:
             i += 1
             j += 1
         if j == sub_len:
-            res = i- j
+            res = i - j
             flag = True
             j = lps[j - 1]
         elif i < s_len and sub[j] != s[i]:
@@ -831,124 +946,137 @@ def _lpython_str_find(s: str, sub: str) -> i32:
 
     return res
 
+
 def _lpython_str_rstrip(x: str) -> str:
     ind: i32
     ind = len(x) - 1
-    while ind >= 0 and x[ind] == ' ':
+    while ind >= 0 and x[ind] == " ":
         ind -= 1
-    return x[0: ind + 1]
+    return x[0 : ind + 1]
+
 
 @overload
 def _lpython_str_lstrip(x: str) -> str:
-    ind :i32
+    ind: i32
     ind = 0
-    while ind < len(x) and x[ind] == ' ':
+    while ind < len(x) and x[ind] == " ":
         ind += 1
-    return x[ind :len(x)]
+    return x[ind : len(x)]
+
 
 @overload
 def _lpython_str_strip(x: str) -> str:
-    res :str
+    res: str
     res = _lpython_str_lstrip(x)
     res = _lpython_str_rstrip(res)
     return res
 
+
 @overload
 def _lpython_str_split(x: str) -> list[str]:
-    sep: str = ' '
+    sep: str = " "
     res: list[str] = []
-    start:i32 = 0
+    start: i32 = 0
     ind: i32
     x_strip: str = _lpython_str_strip(x)
-    if (x_strip == ""): 
+    if x_strip == "":
         return res
     while True:
-        while (start < len(x_strip) and x_strip[start] == ' '):
+        while start < len(x_strip) and x_strip[start] == " ":
             start += 1
-        ind = _lpython_str_find(x_strip[start:len(x_strip)], sep)
+        ind = _lpython_str_find(x_strip[start : len(x_strip)], sep)
         if ind == -1:
-            res.append(x_strip[start:len(x_strip)])
+            res.append(x_strip[start : len(x_strip)])
             break
         else:
-            res.append(x_strip[start:start + ind])
-            start += ind + len(sep)
-    return res
-    
-@overload
-def _lpython_str_split(x: str, sep:str) -> list[str]:
-    if len(sep) == 0:
-        raise ValueError('empty separator')
-    res: list[str] = []
-    start:i32 = 0
-    ind: i32
-    while True:
-        ind = _lpython_str_find(x[start:len(x)], sep)
-        if ind == -1:
-            res.append(x[start:len(x)])
-            break
-        else:
-            res.append(x[start:start + ind])
+            res.append(x_strip[start : start + ind])
             start += ind + len(sep)
     return res
 
+
+@overload
+def _lpython_str_split(x: str, sep: str) -> list[str]:
+    if len(sep) == 0:
+        raise ValueError("empty separator")
+    res: list[str] = []
+    start: i32 = 0
+    ind: i32
+    while True:
+        ind = _lpython_str_find(x[start : len(x)], sep)
+        if ind == -1:
+            res.append(x[start : len(x)])
+            break
+        else:
+            res.append(x[start : start + ind])
+            start += ind + len(sep)
+    return res
+
+
 @overload
 def _lpython_str_swapcase(s: str) -> str:
-    res :str = ""
+    res: str = ""
     cur: str
     for cur in s:
-        if ord(cur) >= ord('a') and ord(cur) <= ord('z'):
-            res += chr(ord(cur) - ord('a') + ord('A'))
-        elif ord(cur) >= ord('A') and ord(cur) <= ord('Z'):
-            res += chr(ord(cur) - ord('A') + ord('a'))
+        if ord(cur) >= ord("a") and ord(cur) <= ord("z"):
+            res += chr(ord(cur) - ord("a") + ord("A"))
+        elif ord(cur) >= ord("A") and ord(cur) <= ord("Z"):
+            res += chr(ord(cur) - ord("A") + ord("a"))
         else:
             res += cur
     return res
 
+
 @overload
-def _lpython_str_startswith(s: str ,sub: str) -> bool:
-    res :bool
+def _lpython_str_startswith(s: str, sub: str) -> bool:
+    res: bool
     res = not (len(s) == 0 and len(sub) > 0)
-    i: i32; j: i32
-    i = 0; j = 0
+    i: i32
+    j: i32
+    i = 0
+    j = 0
     while (i < len(s)) and ((j < len(sub)) and res):
         res = res and (s[i] == sub[j])
-        i += 1; j+=1
+        i += 1
+        j += 1
     if res:
         res = res and (j == len(sub))
     return res
 
+
 @overload
 def _lpython_str_endswith(s: str, suffix: str) -> bool:
 
-    if(len(suffix) > len(s)):
+    if len(suffix) > len(s):
         return False
 
-    i : i32
+    i: i32
     i = 0
-    while(i < len(suffix)):
-        if(suffix[len(suffix) - i - 1] != s[len(s) - i - 1]):
+    while i < len(suffix):
+        if suffix[len(suffix) - i - 1] != s[len(s) - i - 1]:
             return False
         i += 1
 
     return True
 
+
 @overload
-def _lpython_str_partition(s:str, sep: str) -> tuple[str, str, str]:
+def _lpython_str_partition(s: str, sep: str) -> tuple[str, str, str]:
     """
     Returns a 3-tuple splitted around seperator
     """
     if len(s) == 0:
-        raise ValueError('empty string cannot be partitioned')
+        raise ValueError("empty string cannot be partitioned")
     if len(sep) == 0:
-        raise ValueError('empty separator')
-    res : tuple[str, str, str]
-    ind : i32
+        raise ValueError("empty separator")
+    res: tuple[str, str, str]
+    ind: i32
     ind = _lpython_str_find(s, sep)
     if ind == -1:
         res = (s, "", "")
     else:
-        res = (s[0:ind], sep, s[ind+len(sep): len(s)])
+        res = (s[0:ind], sep, s[ind + len(sep) : len(s)])
     return res
+
 
 @overload
 def _lpython_str_islower(s: str) -> bool:
@@ -962,6 +1090,7 @@ def _lpython_str_islower(s: str) -> bool:
                 return False
     return is_cased_present
 
+
 @overload
 def _lpython_str_isupper(s: str) -> bool:
     is_cased_present: bool
@@ -974,15 +1103,17 @@ def _lpython_str_isupper(s: str) -> bool:
                 return False
     return is_cased_present
 
+
 @overload
 def _lpython_str_isdecimal(s: str) -> bool:
     if len(s) == 0:
         return False
-    i:str
+    i: str
     for i in s:
-        if (ord(i) < 48 or ord(i) > 57): # Implies it is not a digit
+        if ord(i) < 48 or ord(i) > 57:  # Implies it is not a digit
             return False
     return True
+
 
 @overload
 def _lpython_str_isascii(s: str) -> bool:
@@ -994,12 +1125,50 @@ def _lpython_str_isascii(s: str) -> bool:
             return False
     return True
 
-def _lpython_str_isspace(s:str) -> bool:
+
+def _lpython_str_isspace(s: str) -> bool:
     if len(s) == 0:
         return False
-    ch: str 
+    ch: str
+    ch_ord: i32
     for ch in s:
-        if ch != ' ' and ch != '\t' and ch != '\n' and ch != '\r' and ch != '\f' and ch != '\v':
+        ch_ord = ord(ch)
+        # A Unicode character is considered a 'whitespace' if it has has a bidirectional
+        # type 'WS', 'B' or 'S'; or the category 'Zs'.
+        # Check every character in the string to see if it is a whitespace.
+        # If none of the characters match, we have atleast one character which is not
+        # a whitespace, so we return `False`.
+        if (
+            ch_ord != 9
+            and ch_ord != 10
+            and ch_ord != 11
+            and ch_ord != 12
+            and ch_ord != 13
+            and ch_ord != 28
+            and ch_ord != 29
+            and ch_ord != 30
+            and ch_ord != 31
+            and ch_ord != 32
+            and ch_ord != 133
+            and ch_ord != 160
+            and ch_ord != 5760
+            and ch_ord != 8192
+            and ch_ord != 8193
+            and ch_ord != 8194
+            and ch_ord != 8195
+            and ch_ord != 8196
+            and ch_ord != 8197
+            and ch_ord != 8198
+            and ch_ord != 8199
+            and ch_ord != 8200
+            and ch_ord != 8201
+            and ch_ord != 8202
+            and ch_ord != 8232
+            and ch_ord != 8233
+            and ch_ord != 8239
+            and ch_ord != 8287
+            and ch_ord != 12288
+        ):
             return False
     return True
 


### PR DESCRIPTION
# Fix:
#2490 gave wrong output due to the incorrect handling of the escape sequence '\f'. Escaping the sequence was handled, but unescaping was missed. This led to the string `" \t\n\v\f\r"` being transformed as `" \t\n\v\\f\r"` in the AST. Note the extra "\\" after "v".
![Screenshot from 2024-02-21 17-30-11](https://github.com/lcompilers/lpython/assets/151380951/05ab86e7-053a-422f-b65e-a02d1ae90fe5)

Hence, the answer in #2490 was thus 'not actually' wrong as non-whitespace and lowercase characters did exist. Fixes #2490 
 
# Improvement
Though the error in the above case was due to incorrect string handling, the `isspace()` method was actually not implemented correctly. The definition of a 'whitespace' character is actually broad. The Python interpreter checks for all of them in it's implementation of the method. I incorporated checking for those characters.

A huge shout-out to @advikkabra for the clever testing. :tada: 

# Note
The Black formatter has automatically formatted the Python file I worked on. Please note that only change I made was the implementation of the `isspace()` method.

Last but not the least, I thoroughly enjoyed working on the issue. :smiley: 