### PR TITLE
Add support for accessing values from data-structures contained within `Const`

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1523,8 +1523,15 @@ public:
     }
 
     void visit_ListItem(const ASR::ListItem_t& x) {
-        ASR::ttype_t* el_type = ASRUtils::get_contained_type(
-                                        ASRUtils::expr_type(x.m_a));
+        /*  Check whether the `list` is a `Const[list[data_type]]`:
+              - If true, set the list `el_type` to `data_type` by first going to `Const`, then `list`.
+              - If false, we have a normal list - `list[data_type]`, go to `list` and get `data_type`.
+
+            We do the type checking through strings because `ASR::is_a<T>` throws an error.
+        */
+        ASR::ttype_t *el_type = ASRUtils::type_to_str(ASRUtils::expr_type(x.m_a)) == "list const"
+                                    ? ASRUtils::get_contained_type(ASRUtils::get_contained_type(ASRUtils::expr_type(x.m_a)))
+                                    : ASRUtils::get_contained_type(ASRUtils::expr_type(x.m_a));
         int64_t ptr_loads_copy = ptr_loads;
         ptr_loads = 0;
         this->visit_expr(*x.m_a);
@@ -1540,8 +1547,16 @@ public:
     }
 
     void visit_DictItem(const ASR::DictItem_t& x) {
-        ASR::Dict_t* dict_type = ASR::down_cast<ASR::Dict_t>(
-                                    ASRUtils::expr_type(x.m_a));
+        /*  Check whether the `dict` is a `Const[dict[key_type, value_type]]`:
+              - If true, set the `dict_type` to `dict[key_type, value_type]' by going to `Const`.
+              - If false, we have a normal dict - `dict[key_type, value_type]`.
+        
+            We do the type checking through strings because `ASR::is_a<T>` throws an error.
+        */
+        ASR::Dict_t *dict_type = ASRUtils::type_to_str(ASRUtils::expr_type(x.m_a)) == "dict const"
+                                     ? ASR::down_cast<ASR::Dict_t>(ASRUtils::get_contained_type(ASRUtils::expr_type(x.m_a)))
+                                     : ASR::down_cast<ASR::Dict_t>(ASRUtils::expr_type(x.m_a));
+
         int64_t ptr_loads_copy = ptr_loads;
         ptr_loads = 0;
         this->visit_expr(*x.m_a);

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -3733,10 +3733,6 @@ public:
                 {
                     throw SemanticError("slicing on a const list is not implemented till now", loc);
                 }
-                else if (ASRUtils::type_to_str(ASRUtils::get_contained_type(type)) == "character")
-                {
-                    throw SemanticError("slicing on a const string is not implemented till now", loc);
-                }
             }
             else if (ASR::is_a<ASR::List_t>(*type)) {
                 tmp = ASR::make_ListSection_t(al, loc, value, ai, type, nullptr);

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -3729,7 +3729,6 @@ public:
             }
             if (ASR::is_a<ASR::Const_t>(*type))
             {
-                std::cout << ASRUtils::type_to_str(ASRUtils::get_contained_type(type)) << std::endl;
                 if (ASRUtils::type_to_str(ASRUtils::get_contained_type(type)) == "list")
                 {
                     throw SemanticError("slicing on a const list is not implemented till now", loc);

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -3750,8 +3750,7 @@ public:
             }
         }
         else if (AST::is_a<AST::Tuple_t>(*m_slice) &&
-                 ASRUtils::is_array(type))
-        {
+                 ASRUtils::is_array(type)) {
             bool final_result = true;
             AST::Tuple_t* indices = AST::down_cast<AST::Tuple_t>(m_slice);
             for( size_t i = 0; i < indices->n_elts; i++ ) {


### PR DESCRIPTION
# Overview
Trying to access a key from a `Const dict` threw a `SemanticError` stating type mismatch. An `ASR pass error` was thrown when trying to access values from a `Const list`, `Const tuple` and `Const str`. This was chiefly because the case of a `Const` value was not addressed in handling subscript indices.

- ![Screenshot from 2024-02-26 12-21-43](https://github.com/lcompilers/lpython/assets/151380951/ea80cf72-698a-4009-8eb9-7bd41c93798c)

- ![Screenshot from 2024-02-29 19-25-04](https://github.com/lcompilers/lpython/assets/151380951/87a06d23-8b57-47da-b586-48304df42e08)

# Fix
- Check for `Const` when visiting subscript indices and handle item access through the _contained type_ in the `llvm` back-end.
- Throw a `SemanticError` for immutable types like `tuple` and `str`.

- ## Tuple
![Screenshot from 2024-02-29 20-27-55](https://github.com/lcompilers/lpython/assets/151380951/7bca8599-6766-4cb2-b990-5ddb03eb6da2)
- ## String
![Screenshot from 2024-02-29 20-37-10](https://github.com/lcompilers/lpython/assets/151380951/e6a31b9d-3566-408e-b350-87557fe6d07d)
- ## Dictionary
![Screenshot from 2024-02-29 20-28-35](https://github.com/lcompilers/lpython/assets/151380951/e4203dec-d4c9-4d52-9fd4-8ab6ac6e65ca)
- ## List
![Screenshot from 2024-02-29 20-29-00](https://github.com/lcompilers/lpython/assets/151380951/2e51a761-ae8d-4ffa-9047-213ed0d65211)

# Note
The `get` attribute of `Const dict` still throws a `SemanticError` now. I will push the fix for that in a separate PR.