### PR TITLE
Updated cmake version for windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Windows Conda Packages
         if: contains(matrix.os, 'windows')
         shell: bash -e -l {0}
-        run: conda install m2-bison=3.0.4
+        run: conda install m2-bison=3.0.4 cmake=3.21.1
 
       - name: Install Linux / macOS Conda Packages
         if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')


### PR DESCRIPTION
Fixes: https://github.com/lcompilers/lpython/issues/2561

For most of the recent PRs, the windows CI fails.
```
CMake Error at C:/Program Files/CMake/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR)
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  C:/Program Files/CMake/share/cmake-3.28/Modules/FindZLIB.cmake:199 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  cmake/FindStaticZLIB.cmake:7 (find_package)
  CMakeLists.txt:116 (find_package)


-- Configuring incomplete, errors occurred!
```

 The error is related to the default CMake installed on Windows.  I have updated windows cmake version to `cmake=3.21.1` in the `CI.yml` file.