### PR TITLE
Add support for f-strings

### DIFF
--- a/src/lpython/parser/parser.yy
+++ b/src/lpython/parser/parser.yy
@@ -103,6 +103,9 @@ void yyerror(YYLTYPE *yyloc, LCompilers::LPython::Parser &p, const std::string &
 %token TK_CARET "^"
 %token TK_AT "@"
 %token <string> TK_STRING
+%token <string> TK_FSTRING_START
+%token <string> TK_FSTRING_MIDDLE
+%token <string> TK_FSTRING_END
 %token <string> TK_COMMENT
 %token <string> TK_EOLCOMMENT
 %token <string> TK_TYPE_COMMENT
@@ -260,6 +263,8 @@ void yyerror(YYLTYPE *yyloc, LCompilers::LPython::Parser &p, const std::string &
 %type <ast> sep_one
 %type <string> type_comment
 %type <ast> string
+%type <ast> fstring
+%type <ast> fstring_middle
 %type <ast> ternary_if_statement
 %type <ast> comprehension
 %type <vec_ast> id_list
@@ -1106,8 +1111,19 @@ subscript
 string
     : string TK_STRING { $$ = STRING2($1, $2, @$); } // TODO
     | string KW_STR_PREFIX TK_STRING { $$ = STRING4($1, STRING3($2, $3, @$), @$); }
+    | string fstring { $$ = CONCAT_FSTRING($1, $2, @$); }
     | TK_STRING { $$ = STRING1($1, @$); }
     | KW_STR_PREFIX TK_STRING { $$ = STRING3($1, $2, @$); }
+    | fstring
+    ;
+
+fstring_middle 
+    : fstring_middle TK_FSTRING_MIDDLE expr { $$ = FSTRING_MIDDLE($1, $2, $3, @$); }
+    | expr { $$ = FSTRING_MIDDLE1($1, @$); }
+    ;
+
+fstring
+    : TK_FSTRING_START fstring_middle TK_FSTRING_END { $$ = FSTRING($1, $2, $3, @$); }
     ;
 
 lambda_parameter

--- a/src/lpython/parser/tokenizer.re
+++ b/src/lpython/parser/tokenizer.re
@@ -290,6 +290,11 @@ int Tokenizer::lex(Allocator &al, YYSTYPE &yylval, Location &loc, diag::Diagnost
                             | ("''" | "''" "\\"+) [^'\x00\\]
                             | [^'\x00\\] )*
                       "'''";
+            
+            fstring_start = ([fF] | [fF][rR] | [rR][fF]) '"' ('\\'[^\x00{}] | [^"\x00\n\\{}])* '{';
+            fstring_middle = '}' ('\\'[^\x00{}] | [^"\x00\n\\{}])* '{';
+            fstring_end = '}' ('\\'[^\x00{}] | [^"\x00\n\\{}])* '"';
+
             type_ignore = "#" whitespace? "type:" whitespace? "ignore" [^\n\x00]*;
             type_comment = "#" whitespace? "type:" whitespace? [^\n\x00]*;
             comment = "#" [^\n\x00]*;
@@ -434,10 +439,8 @@ int Tokenizer::lex(Allocator &al, YYSTYPE &yylval, Location &loc, diag::Diagnost
                     RET(TK_NAME);
                 }
             }
-
             [rR][bB] | [bB][rR]
-            | [fF][rR] | [rR][fF]
-            | [rR] | [bB] | [fF] | [uU]
+            | [rR] | [bB] | [uU]
              {
                 if(cur[0] == '\'' || cur[0] == '"'){
                     KW(STR_PREFIX);
@@ -601,6 +604,10 @@ int Tokenizer::lex(Allocator &al, YYSTYPE &yylval, Location &loc, diag::Diagnost
             string3 { token_str3(yylval.string); RET(TK_STRING) }
             string4 { token_str3(yylval.string); RET(TK_STRING) }
 
+            fstring_start { token(yylval.string); RET(TK_FSTRING_START) }
+            fstring_middle { token_str(yylval.string); RET(TK_FSTRING_MIDDLE) }
+            fstring_end { token_str(yylval.string); RET(TK_FSTRING_END) }
+
             name { token(yylval.string); RET(TK_NAME) }
         */
     }
@@ -700,6 +707,9 @@ std::string token2text(const int token)
         T(TK_AT, "@")
 
         T(TK_STRING, "string")
+        T(TK_FSTRING_START, "fstring_start")
+        T(TK_FSTRING_MIDDLE, "fstring_middle")
+        T(TK_FSTRING_END, "fstring_end")
         T(TK_COMMENT, "comment")
         T(TK_EOLCOMMENT, "eolcomment")
         T(TK_TYPE_COMMENT, "type_comment")

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -3352,6 +3352,19 @@ public:
         }
         tmp = ASR::make_LogicalBinOp_t(al, x.base.base.loc, lhs, op, rhs, dest_type, value);
     }
+    
+    void visit_FormattedValue(const AST::FormattedValue_t &x){
+        this->visit_expr(*x.m_value);
+        // converting x as call_arg for the handle_intrinsic_str function
+        ASR::expr_t* expr = ASRUtils::EXPR(tmp);
+        ASR::call_arg_t arg;
+        arg.loc = expr->base.loc;
+        arg.m_value = expr;
+        Vec<ASR::call_arg_t> call_args;
+        call_args.reserve(al, 1);
+        call_args.push_back(al, arg);
+        tmp = intrinsic_node_handler.handle_intrinsic_str(al, call_args, x.base.base.loc);
+    }
 
     void visit_BinOp(const AST::BinOp_t &x) {
         this->visit_expr(*x.m_left);

--- a/tests/fstring1.py
+++ b/tests/fstring1.py
@@ -1,0 +1,8 @@
+a : str = "FooBar"
+b : i32 = 10
+c : i32 = 11
+print(f"{b} + 1 = {c}") # int inside fstring
+print(f"Say something! {a}") # string inside fstring
+print(f"do some calculation: {b*7+c}") # expression inside fstring
+print("9..." f"{b}...{c}") # concatenation of normal string with fstring
+print(f"{b} " f"{c}") # concatenation of fstrings


### PR DESCRIPTION
Support f-strings in lpython, because f-strings are awesome.
Previously, expression enclosed inside the f-strings was not parsed correctly. 
TODO:
 - [x] Add new tokens to handle f-strings.
     - Divide f-strings into three parts start, middle, end to allow parsing of enclosed expression.
- [x] Add grammar for f-strings.
- [x] Add semantics for f-strings to create correct AST.
     - All the parts of f-string are merged using recursively apply add operation.
- [x] Implement visit_FormattedValue in python_ast_to_asr.cpp
     - This uses handle_intrinsic_str to cast expression to string
 - [ ] Add tests and clean up code.