### PR TITLE
Handling leading zeros in integer literals

### DIFF
--- a/src/lpython/parser/tokenizer.re
+++ b/src/lpython/parser/tokenizer.re
@@ -89,7 +89,7 @@ void lex_int(Allocator &al, const unsigned char *s,
         s = s + 2;
         uint64_t n = get_value((char*)s, 2, loc);
         u.from_smallint(n);
-    } else if ((std::tolower(s[1]) == 'o')) {
+    } else if (std::tolower(s[1]) == 'o') {
         // Oct
         s = s + 2;
         uint64_t n = get_value((char*)s, 8, loc);

--- a/src/lpython/parser/tokenizer.re
+++ b/src/lpython/parser/tokenizer.re
@@ -96,6 +96,10 @@ void lex_int(Allocator &al, const unsigned char *s,
         u.from_smallint(n);
     } else {
         lex_dec_int_large(al, s, e, u);
+        if (s[0] == '0' && u.n != 0) {            
+            throw parser_local::TokenizerError(
+                "Leading zeros in decimal integer are not allowed", {loc});
+        }
     }
     return;
 }

--- a/tests/errors/test_literal.py
+++ b/tests/errors/test_literal.py
@@ -1,0 +1,2 @@
+def test_literal1():
+    x: i32 = 0123

--- a/tests/reference/tokens-test_literal-e20c024.json
+++ b/tests/reference/tokens-test_literal-e20c024.json
@@ -1,0 +1,13 @@
+{
+    "basename": "tokens-test_literal-e20c024",
+    "cmd": "lpython --no-color --show-tokens {infile} -o {outfile}",
+    "infile": "tests/errors/test_literal.py",
+    "infile_hash": "ac9e219faa40c6554983087e8ac198c323f2e5af284b8689f5608f76",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "tokens-test_literal-e20c024.stderr",
+    "stderr_hash": "58fe8b74550bd6f81761b173626f3d45eaae346665862f1b085eebe8",
+    "returncode": 1
+}

--- a/tests/reference/tokens-test_literal-e20c024.stderr
+++ b/tests/reference/tokens-test_literal-e20c024.stderr
@@ -1,0 +1,5 @@
+tokenizer error: Leading zeros in decimal integer are not allowed
+ --> tests/errors/test_literal.py:2:14
+  |
+2 |     x: i32 = 0123
+  |              ^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1198,6 +1198,10 @@ filename = "tokens/errors/indent3.py"
 tokens = true
 
 [[test]]
+filename = "errors/test_literal.py"
+tokens = true
+
+[[test]]
 filename = "errors/kwargs_01_error.py"
 asr = true
 


### PR DESCRIPTION
Fixed #2002 

I catch this error in the tokenizer because it removes trailing zeros in `lex_int`. Also, to handle the case of all zeros, we must allow the tokenizer to process the number first.