### PR TITLE
Implemented `hypot` in numpy

### DIFF
--- a/integration_tests/elemental_06.py
+++ b/integration_tests/elemental_06.py
@@ -1,5 +1,5 @@
 from lpython import i32, f32, f64
-from numpy import empty, arcsin, arccos, sin, cos, sqrt, arctan, tan, degrees, radians, float32, float64
+from numpy import empty, arcsin, arccos, sin, cos, sqrt, arctan, tan, degrees, radians, hypot, float32, float64
 from math import pi
 
 def verify1d_same(array: f32[:], result: f32[:], size: i32):
@@ -56,6 +56,15 @@ def verify_arctan_2d(array: f64[:, :], result: f64[:, :], size1:i32, size2:i32):
     for i in range(size1):
         for j in range(size2):
             assert abs(arctan(array[i, j])**2.0 - result[i, j]) <= eps
+
+def verify_hypot_2d(array1: f64[:, :], array2: f64[:, :], result: f64[:, :], size1:i32, size2:i32):
+    i: i32
+    j: i32
+    eps: f64
+    eps = 1e-12
+    for i in range(size1):
+        for j in range(size2):
+            assert abs(hypot(array1[i, j], array2[i, j]) - result[i, j]) <= eps
 
 def elemental_arcsin():
     i: i32
@@ -222,6 +231,35 @@ def elemental_radians():
         for j in range(64):
             assert abs(radians2d[i, j] - cos(radians(array2d[i, j]))) <= eps_64
 
+def elemental_hypot():
+    i: i32
+    j: i32
+    eps_32: f32
+    eps_32 = f32(1e-6)
+
+    hypot1d: f32[200] = empty(200, dtype=float32)
+    array1d1: f32[200] = empty(200, dtype=float32)
+    array1d2: f32[200] = empty(200, dtype=float32)
+    for i in range(200):
+        array1d1[i] =  f32(i)
+        array1d2[i] =  f32(i+10)
+
+    hypot1d = hypot(array1d1, array1d2)
+
+    for i in range(200):
+        assert abs(hypot1d[i] - hypot(array1d1[i], array1d2[i])) <= eps_32
+
+    array2d1: f64[64, 64] = empty((64, 64), dtype=float64)
+    array2d2: f64[64, 64] = empty((64, 64), dtype=float64)
+    hypot2d: f64[64, 64] = empty((64, 64), dtype=float64)
+    for i in range(64):
+        for j in range(64):
+            array2d1[i,j]= float(i * j)
+            array2d2[i,j]= float(64*i + j - 2048)
+
+    hypot2d = hypot(array2d1, array2d2)
+    verify_hypot_2d(array2d1, array2d2, hypot2d, 64, 64)
+
 
 elemental_arcsin()
 elemental_arccos()
@@ -231,3 +269,4 @@ elemental_radians()
 elemental_trig_identity()
 elemental_reverse()
 elemental_trig_identity_extra()
+elemental_hypot()

--- a/src/runtime/lpython_intrinsic_numpy.py
+++ b/src/runtime/lpython_intrinsic_numpy.py
@@ -411,6 +411,19 @@ def ceil(x: f32) -> f32:
         return resultf
     return resultf + f32(1)
 
+########## hypot ##########
+
+
+@overload
+@vectorize
+def hypot(x: f64, y: f64) -> f64:
+    return sqrt(f64(1.0)*f64(x**f64(2) + y**f64(2)))
+
+@overload
+@vectorize
+def hypot(x: f32, y: f32) -> f32:
+    return sqrt(f32(1)*(x**f32(2) + y**f32(2)))
+
 ########## trunc ##########
 
 @ccall

--- a/tests/reference/asr-array_01_decl-39cf894.json
+++ b/tests/reference/asr-array_01_decl-39cf894.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_01_decl-39cf894.stdout",
-    "stdout_hash": "5d4751789e2ddcd882c4d6026f801ba32cfc227fafff7395a788bdd9",
+    "stdout_hash": "d167f932ab4a4bb559ae3b4bb3b983cd6153a105cfb6180474e64ae2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_01_decl-39cf894.stdout
+++ b/tests/reference/asr-array_01_decl-39cf894.stdout
@@ -10,11 +10,11 @@
                             ArraySizes:
                                 (EnumType
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             SIZE_10:
                                                 (Variable
-                                                    211
+                                                    213
                                                     SIZE_10
                                                     []
                                                     Local
@@ -30,7 +30,7 @@
                                                 ),
                                             SIZE_3:
                                                 (Variable
-                                                    211
+                                                    213
                                                     SIZE_3
                                                     []
                                                     Local
@@ -58,7 +58,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        220
                                         {
                                             
                                         })
@@ -94,11 +94,11 @@
                             accept_f32_array:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        217
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    215
+                                                    217
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -114,7 +114,7 @@
                                                 ),
                                             xf32:
                                                 (Variable
-                                                    215
+                                                    217
                                                     xf32
                                                     []
                                                     InOut
@@ -155,10 +155,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 215 xf32)]
+                                    [(Var 217 xf32)]
                                     [(=
                                         (ArrayItem
-                                            (Var 215 xf32)
+                                            (Var 217 xf32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -181,9 +181,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 _lpython_return_variable)
+                                        (Var 217 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 215 xf32)
+                                            (Var 217 xf32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -194,7 +194,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 215 _lpython_return_variable)
+                                    (Var 217 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -203,11 +203,11 @@
                             accept_f64_array:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        218
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    216
+                                                    218
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -223,7 +223,7 @@
                                                 ),
                                             xf64:
                                                 (Variable
-                                                    216
+                                                    218
                                                     xf64
                                                     []
                                                     InOut
@@ -264,10 +264,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 216 xf64)]
+                                    [(Var 218 xf64)]
                                     [(=
                                         (ArrayItem
-                                            (Var 216 xf64)
+                                            (Var 218 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -282,9 +282,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 216 _lpython_return_variable)
+                                        (Var 218 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 216 xf64)
+                                            (Var 218 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -295,7 +295,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 216 _lpython_return_variable)
+                                    (Var 218 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -304,11 +304,11 @@
                             accept_i16_array:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    212
+                                                    214
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -324,7 +324,7 @@
                                                 ),
                                             xi16:
                                                 (Variable
-                                                    212
+                                                    214
                                                     xi16
                                                     []
                                                     InOut
@@ -365,10 +365,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 xi16)]
+                                    [(Var 214 xi16)]
                                     [(=
                                         (ArrayItem
-                                            (Var 212 xi16)
+                                            (Var 214 xi16)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -385,9 +385,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 _lpython_return_variable)
+                                        (Var 214 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 212 xi16)
+                                            (Var 214 xi16)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -398,7 +398,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 212 _lpython_return_variable)
+                                    (Var 214 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -407,11 +407,11 @@
                             accept_i32_array:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    215
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -427,7 +427,7 @@
                                                 ),
                                             xi32:
                                                 (Variable
-                                                    213
+                                                    215
                                                     xi32
                                                     []
                                                     InOut
@@ -468,10 +468,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 xi32)]
+                                    [(Var 215 xi32)]
                                     [(=
                                         (ArrayItem
-                                            (Var 213 xi32)
+                                            (Var 215 xi32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -483,9 +483,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 215 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 213 xi32)
+                                            (Var 215 xi32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -496,7 +496,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 215 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -505,11 +505,11 @@
                             accept_i64_array:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        216
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    214
+                                                    216
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -525,7 +525,7 @@
                                                 ),
                                             xi64:
                                                 (Variable
-                                                    214
+                                                    216
                                                     xi64
                                                     []
                                                     InOut
@@ -566,10 +566,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 xi64)]
+                                    [(Var 216 xi64)]
                                     [(=
                                         (ArrayItem
-                                            (Var 214 xi64)
+                                            (Var 216 xi64)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -586,9 +586,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 _lpython_return_variable)
+                                        (Var 216 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 214 xi64)
+                                            (Var 216 xi64)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -599,7 +599,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 214 _lpython_return_variable)
+                                    (Var 216 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -608,11 +608,11 @@
                             declare_arrays:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        219
                                         {
                                             ac32:
                                                 (Variable
-                                                    217
+                                                    219
                                                     ac32
                                                     []
                                                     Local
@@ -633,7 +633,7 @@
                                                 ),
                                             ac64:
                                                 (Variable
-                                                    217
+                                                    219
                                                     ac64
                                                     []
                                                     Local
@@ -654,7 +654,7 @@
                                                 ),
                                             af32:
                                                 (Variable
-                                                    217
+                                                    219
                                                     af32
                                                     []
                                                     Local
@@ -675,7 +675,7 @@
                                                 ),
                                             af64:
                                                 (Variable
-                                                    217
+                                                    219
                                                     af64
                                                     []
                                                     Local
@@ -696,7 +696,7 @@
                                                 ),
                                             ai16:
                                                 (Variable
-                                                    217
+                                                    219
                                                     ai16
                                                     []
                                                     Local
@@ -717,7 +717,7 @@
                                                 ),
                                             ai32:
                                                 (Variable
-                                                    217
+                                                    219
                                                     ai32
                                                     []
                                                     Local
@@ -738,7 +738,7 @@
                                                 ),
                                             ai64:
                                                 (Variable
-                                                    217
+                                                    219
                                                     ai64
                                                     []
                                                     Local
@@ -780,7 +780,7 @@
                                     accept_f64_array]
                                     []
                                     [(=
-                                        (Var 217 ai16)
+                                        (Var 219 ai16)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -794,7 +794,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 ai32)
+                                        (Var 219 ai32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -808,7 +808,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 ai64)
+                                        (Var 219 ai64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -822,7 +822,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 af32)
+                                        (Var 219 af32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -836,7 +836,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 af64)
+                                        (Var 219 af64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -850,7 +850,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 ac32)
+                                        (Var 219 ac32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -864,7 +864,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 ac64)
+                                        (Var 219 ac64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -882,7 +882,7 @@
                                             2 accept_i16_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 ai16)
+                                                (Var 219 ai16)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -905,7 +905,7 @@
                                             2 accept_i32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 ai32)
+                                                (Var 219 ai32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -928,7 +928,7 @@
                                             2 accept_i64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 ai64)
+                                                (Var 219 ai64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -951,7 +951,7 @@
                                             2 accept_f32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 af32)
+                                                (Var 219 af32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -974,7 +974,7 @@
                                             2 accept_f64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 af64)
+                                                (Var 219 af64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -1009,11 +1009,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        219
+                        221
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    219
+                                    221
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1025,7 +1025,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        219 __main__global_stmts
+                        221 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-array_02_decl-e8f6874.json
+++ b/tests/reference/asr-array_02_decl-e8f6874.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_02_decl-e8f6874.stdout",
-    "stdout_hash": "b75476498ff1c6620f1cdafe5c25e26006b5e47e3ad06663d288feb5",
+    "stdout_hash": "a85bf9e005195a013607a8f2b7492215183cbae4b1e52882d47b8b02",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_02_decl-e8f6874.stdout
+++ b/tests/reference/asr-array_02_decl-e8f6874.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        218
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             accept_multidim_f32_array:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    215
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -66,7 +66,7 @@
                                                 ),
                                             xf32:
                                                 (Variable
-                                                    213
+                                                    215
                                                     xf32
                                                     []
                                                     InOut
@@ -107,11 +107,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 xf32)]
+                                    [(Var 215 xf32)]
                                     [(=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 215 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 213 xf32)
+                                            (Var 215 xf32)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -122,7 +122,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 215 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -131,11 +131,11 @@
                             accept_multidim_f64_array:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        216
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    214
+                                                    216
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -151,7 +151,7 @@
                                                 ),
                                             xf64:
                                                 (Variable
-                                                    214
+                                                    216
                                                     xf64
                                                     []
                                                     InOut
@@ -196,11 +196,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 xf64)]
+                                    [(Var 216 xf64)]
                                     [(=
-                                        (Var 214 _lpython_return_variable)
+                                        (Var 216 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 214 xf64)
+                                            (Var 216 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -214,7 +214,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 214 _lpython_return_variable)
+                                    (Var 216 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -223,11 +223,11 @@
                             accept_multidim_i32_array:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    213
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -243,7 +243,7 @@
                                                 ),
                                             xi32:
                                                 (Variable
-                                                    211
+                                                    213
                                                     xi32
                                                     []
                                                     InOut
@@ -288,11 +288,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 xi32)]
+                                    [(Var 213 xi32)]
                                     [(=
-                                        (Var 211 _lpython_return_variable)
+                                        (Var 213 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 211 xi32)
+                                            (Var 213 xi32)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -306,7 +306,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 213 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -315,11 +315,11 @@
                             accept_multidim_i64_array:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    212
+                                                    214
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -335,7 +335,7 @@
                                                 ),
                                             xi64:
                                                 (Variable
-                                                    212
+                                                    214
                                                     xi64
                                                     []
                                                     InOut
@@ -384,11 +384,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 xi64)]
+                                    [(Var 214 xi64)]
                                     [(=
-                                        (Var 212 _lpython_return_variable)
+                                        (Var 214 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 212 xi64)
+                                            (Var 214 xi64)
                                             [(()
                                             (IntegerConstant 9 (Integer 4))
                                             ())
@@ -405,7 +405,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 212 _lpython_return_variable)
+                                    (Var 214 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -414,11 +414,11 @@
                             declare_arrays:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        217
                                         {
                                             ac32:
                                                 (Variable
-                                                    215
+                                                    217
                                                     ac32
                                                     []
                                                     Local
@@ -443,7 +443,7 @@
                                                 ),
                                             ac64:
                                                 (Variable
-                                                    215
+                                                    217
                                                     ac64
                                                     []
                                                     Local
@@ -470,7 +470,7 @@
                                                 ),
                                             af32:
                                                 (Variable
-                                                    215
+                                                    217
                                                     af32
                                                     []
                                                     Local
@@ -491,7 +491,7 @@
                                                 ),
                                             af64:
                                                 (Variable
-                                                    215
+                                                    217
                                                     af64
                                                     []
                                                     Local
@@ -514,7 +514,7 @@
                                                 ),
                                             ai32:
                                                 (Variable
-                                                    215
+                                                    217
                                                     ai32
                                                     []
                                                     Local
@@ -537,7 +537,7 @@
                                                 ),
                                             ai64:
                                                 (Variable
-                                                    215
+                                                    217
                                                     ai64
                                                     []
                                                     Local
@@ -582,7 +582,7 @@
                                     accept_multidim_f64_array]
                                     []
                                     [(=
-                                        (Var 215 ai32)
+                                        (Var 217 ai32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -598,7 +598,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 ai64)
+                                        (Var 217 ai64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -616,7 +616,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 af32)
+                                        (Var 217 af32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -630,7 +630,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 af64)
+                                        (Var 217 af64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -646,7 +646,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 ac32)
+                                        (Var 217 ac32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -664,7 +664,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 ac64)
+                                        (Var 217 ac64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -688,7 +688,7 @@
                                             2 accept_multidim_i32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 ai32)
+                                                (Var 217 ai32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -713,7 +713,7 @@
                                             2 accept_multidim_i64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 ai64)
+                                                (Var 217 ai64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -740,7 +740,7 @@
                                             2 accept_multidim_f32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 af32)
+                                                (Var 217 af32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -763,7 +763,7 @@
                                             2 accept_multidim_f64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 215 af64)
+                                                (Var 217 af64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -800,11 +800,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        217
+                        219
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    217
+                                    219
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -816,7 +816,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        217 __main__global_stmts
+                        219 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-bindc_02-bc1a7ea.json
+++ b/tests/reference/asr-bindc_02-bc1a7ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-bindc_02-bc1a7ea.stdout",
-    "stdout_hash": "b0061b776455e9077daa9d47fecc543d08c919c9dad365ad2c3f6b33",
+    "stdout_hash": "dcbadfda0430682f5e14ae9eb1ddccb91f68b3def7cb8218c2fc9c06",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-bindc_02-bc1a7ea.stdout
+++ b/tests/reference/asr-bindc_02-bc1a7ea.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             
                                         })
@@ -76,11 +76,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             y:
                                                 (Variable
-                                                    211
+                                                    213
                                                     y
                                                     []
                                                     Local
@@ -101,7 +101,7 @@
                                                 ),
                                             yptr1:
                                                 (Variable
-                                                    211
+                                                    213
                                                     yptr1
                                                     []
                                                     Local
@@ -124,7 +124,7 @@
                                                 ),
                                             yq:
                                                 (Variable
-                                                    211
+                                                    213
                                                     yq
                                                     []
                                                     Local
@@ -157,14 +157,14 @@
                                     []
                                     []
                                     [(=
-                                        (Var 211 yq)
+                                        (Var 213 yq)
                                         (PointerNullConstant
                                             (CPtr)
                                         )
                                         ()
                                     )
                                     (=
-                                        (Var 211 y)
+                                        (Var 213 y)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -179,7 +179,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 211 y)
+                                            (Var 213 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -197,7 +197,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 211 y)
+                                            (Var 213 y)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -214,9 +214,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 yptr1)
+                                        (Var 213 yptr1)
                                         (GetPointer
-                                            (Var 211 y)
+                                            (Var 213 y)
                                             (Pointer
                                                 (Array
                                                     (Integer 2)
@@ -231,7 +231,7 @@
                                     )
                                     (Print
                                         [(GetPointer
-                                            (Var 211 y)
+                                            (Var 213 y)
                                             (Pointer
                                                 (Array
                                                     (Integer 2)
@@ -242,13 +242,13 @@
                                             )
                                             ()
                                         )
-                                        (Var 211 yptr1)]
+                                        (Var 213 yptr1)]
                                         ()
                                         ()
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 211 yptr1)
+                                            (Var 213 yptr1)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -257,7 +257,7 @@
                                             ()
                                         )
                                         (ArrayItem
-                                            (Var 211 yptr1)
+                                            (Var 213 yptr1)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -271,7 +271,7 @@
                                     (Assert
                                         (IntegerCompare
                                             (ArrayItem
-                                                (Var 211 yptr1)
+                                                (Var 213 yptr1)
                                                 [(()
                                                 (IntegerConstant 0 (Integer 4))
                                                 ())]
@@ -294,7 +294,7 @@
                                     (Assert
                                         (IntegerCompare
                                             (ArrayItem
-                                                (Var 211 yptr1)
+                                                (Var 213 yptr1)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -315,8 +315,8 @@
                                         ()
                                     )
                                     (CPtrToPointer
-                                        (Var 211 yq)
-                                        (Var 211 yptr1)
+                                        (Var 213 yq)
+                                        (Var 213 yptr1)
                                         (ArrayConstant
                                             [(IntegerConstant 2 (Integer 4))]
                                             (Array
@@ -339,8 +339,8 @@
                                         )
                                     )
                                     (Print
-                                        [(Var 211 yq)
-                                        (Var 211 yptr1)]
+                                        [(Var 213 yq)
+                                        (Var 213 yptr1)]
                                         ()
                                         ()
                                     )]
@@ -404,11 +404,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        213
+                        215
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    213
+                                    215
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -420,7 +420,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        213 __main__global_stmts
+                        215 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-elemental_01-b58df26.json
+++ b/tests/reference/asr-elemental_01-b58df26.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-elemental_01-b58df26.stdout",
-    "stdout_hash": "11322144ccc20362db9bf290de89fdbaaa0436821aa5377f20218dae",
+    "stdout_hash": "3d90c8b22b8857e98ea441b7224d8e5104cefd038cbd72353a82babf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-elemental_01-b58df26.stdout
+++ b/tests/reference/asr-elemental_01-b58df26.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        244
+                                        246
                                         {
                                             
                                         })
@@ -84,11 +84,11 @@
                             elemental_cos:
                                 (Function
                                     (SymbolTable
-                                        219
+                                        221
                                         {
                                             array2d:
                                                 (Variable
-                                                    219
+                                                    221
                                                     array2d
                                                     []
                                                     Local
@@ -111,7 +111,7 @@
                                                 ),
                                             cos2d:
                                                 (Variable
-                                                    219
+                                                    221
                                                     cos2d
                                                     []
                                                     Local
@@ -134,7 +134,7 @@
                                                 ),
                                             cos@__lpython_overloaded_0__cos:
                                                 (ExternalSymbol
-                                                    219
+                                                    221
                                                     cos@__lpython_overloaded_0__cos
                                                     3 __lpython_overloaded_0__cos
                                                     numpy
@@ -144,7 +144,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    219
+                                                    221
                                                     i
                                                     []
                                                     Local
@@ -160,7 +160,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    219
+                                                    221
                                                     j
                                                     []
                                                     Local
@@ -193,7 +193,7 @@
                                     [verify2d]
                                     []
                                     [(=
-                                        (Var 219 array2d)
+                                        (Var 221 array2d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -209,7 +209,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 219 cos2d)
+                                        (Var 221 cos2d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -226,7 +226,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 219 i)
+                                        ((Var 221 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -238,7 +238,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 219 j)
+                                            ((Var 221 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 64 (Integer 4))
@@ -250,12 +250,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 219 array2d)
+                                                    (Var 221 array2d)
                                                     [(()
-                                                    (Var 219 i)
+                                                    (Var 221 i)
                                                     ())
                                                     (()
-                                                    (Var 219 j)
+                                                    (Var 221 j)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -263,9 +263,9 @@
                                                 )
                                                 (Cast
                                                     (IntegerBinOp
-                                                        (Var 219 i)
+                                                        (Var 221 i)
                                                         Add
-                                                        (Var 219 j)
+                                                        (Var 221 j)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -278,12 +278,12 @@
                                         )]
                                     )
                                     (=
-                                        (Var 219 cos2d)
+                                        (Var 221 cos2d)
                                         (RealBinOp
                                             (FunctionCall
-                                                219 cos@__lpython_overloaded_0__cos
+                                                221 cos@__lpython_overloaded_0__cos
                                                 2 cos
-                                                [((Var 219 array2d))]
+                                                [((Var 221 array2d))]
                                                 (Array
                                                     (Real 8)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -316,7 +316,7 @@
                                         2 verify2d
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 219 array2d)
+                                            (Var 221 array2d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -330,7 +330,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 219 cos2d)
+                                            (Var 221 cos2d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -356,11 +356,11 @@
                             elemental_mul:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        219
                                         {
                                             array_a:
                                                 (Variable
-                                                    217
+                                                    219
                                                     array_a
                                                     []
                                                     Local
@@ -381,7 +381,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    217
+                                                    219
                                                     array_b
                                                     []
                                                     Local
@@ -402,7 +402,7 @@
                                                 ),
                                             array_c:
                                                 (Variable
-                                                    217
+                                                    219
                                                     array_c
                                                     []
                                                     Local
@@ -423,7 +423,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    217
+                                                    219
                                                     i
                                                     []
                                                     Local
@@ -439,7 +439,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    217
+                                                    219
                                                     j
                                                     []
                                                     Local
@@ -455,7 +455,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    217
+                                                    219
                                                     k
                                                     []
                                                     Local
@@ -488,7 +488,7 @@
                                     [verify1d_mul]
                                     []
                                     [(=
-                                        (Var 217 array_a)
+                                        (Var 219 array_a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -502,7 +502,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 array_b)
+                                        (Var 219 array_b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -516,7 +516,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 array_c)
+                                        (Var 219 array_c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -531,7 +531,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 217 i)
+                                        ((Var 219 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -543,16 +543,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 217 array_a)
+                                                (Var 219 array_a)
                                                 [(()
-                                                (Var 217 i)
+                                                (Var 219 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 217 i)
+                                                (Var 219 i)
                                                 IntegerToReal
                                                 (Real 8)
                                                 ()
@@ -562,7 +562,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 217 j)
+                                        ((Var 219 j)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -574,9 +574,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 217 array_b)
+                                                (Var 219 array_b)
                                                 [(()
-                                                (Var 217 j)
+                                                (Var 219 j)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -584,7 +584,7 @@
                                             )
                                             (Cast
                                                 (IntegerBinOp
-                                                    (Var 217 j)
+                                                    (Var 219 j)
                                                     Add
                                                     (IntegerConstant 5 (Integer 4))
                                                     (Integer 4)
@@ -598,11 +598,11 @@
                                         )]
                                     )
                                     (=
-                                        (Var 217 array_c)
+                                        (Var 219 array_c)
                                         (RealBinOp
                                             (RealBinOp
                                                 (RealBinOp
-                                                    (Var 217 array_a)
+                                                    (Var 219 array_a)
                                                     Pow
                                                     (RealConstant
                                                         2.000000
@@ -631,7 +631,7 @@
                                             )
                                             Mul
                                             (RealBinOp
-                                                (Var 217 array_b)
+                                                (Var 219 array_b)
                                                 Pow
                                                 (RealConstant
                                                     3.000000
@@ -659,7 +659,7 @@
                                         2 verify1d_mul
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 217 array_a)
+                                            (Var 219 array_a)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -671,7 +671,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 217 array_b)
+                                            (Var 219 array_b)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -683,7 +683,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 217 array_c)
+                                            (Var 219 array_c)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -706,11 +706,11 @@
                             elemental_sin:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        220
                                         {
                                             array1d:
                                                 (Variable
-                                                    218
+                                                    220
                                                     array1d
                                                     []
                                                     Local
@@ -731,7 +731,7 @@
                                                 ),
                                             arraynd:
                                                 (Variable
-                                                    218
+                                                    220
                                                     arraynd
                                                     []
                                                     Local
@@ -756,7 +756,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    218
+                                                    220
                                                     i
                                                     []
                                                     Local
@@ -772,7 +772,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    218
+                                                    220
                                                     j
                                                     []
                                                     Local
@@ -788,7 +788,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    218
+                                                    220
                                                     k
                                                     []
                                                     Local
@@ -804,7 +804,7 @@
                                                 ),
                                             sin1d:
                                                 (Variable
-                                                    218
+                                                    220
                                                     sin1d
                                                     []
                                                     Local
@@ -825,7 +825,7 @@
                                                 ),
                                             sin@__lpython_overloaded_0__sin:
                                                 (ExternalSymbol
-                                                    218
+                                                    220
                                                     sin@__lpython_overloaded_0__sin
                                                     3 __lpython_overloaded_0__sin
                                                     numpy
@@ -835,7 +835,7 @@
                                                 ),
                                             sin@__lpython_overloaded_1__sin:
                                                 (ExternalSymbol
-                                                    218
+                                                    220
                                                     sin@__lpython_overloaded_1__sin
                                                     3 __lpython_overloaded_1__sin
                                                     numpy
@@ -845,7 +845,7 @@
                                                 ),
                                             sinnd:
                                                 (Variable
-                                                    218
+                                                    220
                                                     sinnd
                                                     []
                                                     Local
@@ -888,7 +888,7 @@
                                     verifynd]
                                     []
                                     [(=
-                                        (Var 218 array1d)
+                                        (Var 220 array1d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -902,7 +902,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 sin1d)
+                                        (Var 220 sin1d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -917,7 +917,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 218 i)
+                                        ((Var 220 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -929,16 +929,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 218 array1d)
+                                                (Var 220 array1d)
                                                 [(()
-                                                (Var 218 i)
+                                                (Var 220 i)
                                                 ())]
                                                 (Real 4)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 218 i)
+                                                (Var 220 i)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -947,14 +947,14 @@
                                         )]
                                     )
                                     (=
-                                        (Var 218 sin1d)
+                                        (Var 220 sin1d)
                                         (FunctionCall
-                                            218 sin@__lpython_overloaded_1__sin
+                                            220 sin@__lpython_overloaded_1__sin
                                             2 sin
                                             [((FunctionCall
-                                                218 sin@__lpython_overloaded_1__sin
+                                                220 sin@__lpython_overloaded_1__sin
                                                 2 sin
-                                                [((Var 218 array1d))]
+                                                [((Var 220 array1d))]
                                                 (Array
                                                     (Real 4)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -979,7 +979,7 @@
                                         2 verify1d
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 218 array1d)
+                                            (Var 220 array1d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -991,7 +991,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 218 sin1d)
+                                            (Var 220 sin1d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1006,7 +1006,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 arraynd)
+                                        (Var 220 arraynd)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1024,7 +1024,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 sinnd)
+                                        (Var 220 sinnd)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1043,7 +1043,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 218 i)
+                                        ((Var 220 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 200 (Integer 4))
@@ -1055,7 +1055,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 218 j)
+                                            ((Var 220 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 64 (Integer 4))
@@ -1067,7 +1067,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 218 k)
+                                                ((Var 220 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 16 (Integer 4))
@@ -1079,15 +1079,15 @@
                                                 (IntegerConstant 1 (Integer 4)))
                                                 [(=
                                                     (ArrayItem
-                                                        (Var 218 arraynd)
+                                                        (Var 220 arraynd)
                                                         [(()
-                                                        (Var 218 i)
+                                                        (Var 220 i)
                                                         ())
                                                         (()
-                                                        (Var 218 j)
+                                                        (Var 220 j)
                                                         ())
                                                         (()
-                                                        (Var 218 k)
+                                                        (Var 220 k)
                                                         ())]
                                                         (Real 8)
                                                         RowMajor
@@ -1096,14 +1096,14 @@
                                                     (Cast
                                                         (IntegerBinOp
                                                             (IntegerBinOp
-                                                                (Var 218 i)
+                                                                (Var 220 i)
                                                                 Add
-                                                                (Var 218 j)
+                                                                (Var 220 j)
                                                                 (Integer 4)
                                                                 ()
                                                             )
                                                             Add
-                                                            (Var 218 k)
+                                                            (Var 220 k)
                                                             (Integer 4)
                                                             ()
                                                         )
@@ -1117,12 +1117,12 @@
                                         )]
                                     )
                                     (=
-                                        (Var 218 sinnd)
+                                        (Var 220 sinnd)
                                         (RealBinOp
                                             (FunctionCall
-                                                218 sin@__lpython_overloaded_0__sin
+                                                220 sin@__lpython_overloaded_0__sin
                                                 2 sin
-                                                [((Var 218 arraynd))]
+                                                [((Var 220 arraynd))]
                                                 (Array
                                                     (Real 8)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -1159,7 +1159,7 @@
                                         2 verifynd
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 218 arraynd)
+                                            (Var 220 arraynd)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1175,7 +1175,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 218 sinnd)
+                                            (Var 220 sinnd)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1204,11 +1204,11 @@
                             elemental_sum:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        218
                                         {
                                             array_a:
                                                 (Variable
-                                                    216
+                                                    218
                                                     array_a
                                                     []
                                                     Local
@@ -1229,7 +1229,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    216
+                                                    218
                                                     array_b
                                                     []
                                                     Local
@@ -1250,7 +1250,7 @@
                                                 ),
                                             array_c:
                                                 (Variable
-                                                    216
+                                                    218
                                                     array_c
                                                     []
                                                     Local
@@ -1271,7 +1271,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    216
+                                                    218
                                                     i
                                                     []
                                                     Local
@@ -1287,7 +1287,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    216
+                                                    218
                                                     j
                                                     []
                                                     Local
@@ -1303,7 +1303,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    216
+                                                    218
                                                     k
                                                     []
                                                     Local
@@ -1336,7 +1336,7 @@
                                     [verify1d_sum]
                                     []
                                     [(=
-                                        (Var 216 array_a)
+                                        (Var 218 array_a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1350,7 +1350,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 216 array_b)
+                                        (Var 218 array_b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1364,7 +1364,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 216 array_c)
+                                        (Var 218 array_c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1379,7 +1379,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 216 i)
+                                        ((Var 218 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -1391,16 +1391,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 216 array_a)
+                                                (Var 218 array_a)
                                                 [(()
-                                                (Var 216 i)
+                                                (Var 218 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 216 i)
+                                                (Var 218 i)
                                                 IntegerToReal
                                                 (Real 8)
                                                 ()
@@ -1410,7 +1410,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 216 j)
+                                        ((Var 218 j)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -1422,9 +1422,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 216 array_b)
+                                                (Var 218 array_b)
                                                 [(()
-                                                (Var 216 j)
+                                                (Var 218 j)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -1432,7 +1432,7 @@
                                             )
                                             (Cast
                                                 (IntegerBinOp
-                                                    (Var 216 j)
+                                                    (Var 218 j)
                                                     Add
                                                     (IntegerConstant 5 (Integer 4))
                                                     (Integer 4)
@@ -1446,10 +1446,10 @@
                                         )]
                                     )
                                     (=
-                                        (Var 216 array_c)
+                                        (Var 218 array_c)
                                         (RealBinOp
                                             (RealBinOp
-                                                (Var 216 array_a)
+                                                (Var 218 array_a)
                                                 Pow
                                                 (RealConstant
                                                     2.000000
@@ -1471,7 +1471,7 @@
                                                 )
                                                 Mul
                                                 (RealBinOp
-                                                    (Var 216 array_b)
+                                                    (Var 218 array_b)
                                                     Pow
                                                     (RealConstant
                                                         3.000000
@@ -1507,7 +1507,7 @@
                                         2 verify1d_sum
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 216 array_a)
+                                            (Var 218 array_a)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1519,7 +1519,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 216 array_b)
+                                            (Var 218 array_b)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1531,7 +1531,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 216 array_c)
+                                            (Var 218 array_c)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1554,11 +1554,11 @@
                             elemental_trig_identity:
                                 (Function
                                     (SymbolTable
-                                        220
+                                        222
                                         {
                                             arraynd:
                                                 (Variable
-                                                    220
+                                                    222
                                                     arraynd
                                                     []
                                                     Local
@@ -1585,7 +1585,7 @@
                                                 ),
                                             cos@__lpython_overloaded_1__cos:
                                                 (ExternalSymbol
-                                                    220
+                                                    222
                                                     cos@__lpython_overloaded_1__cos
                                                     3 __lpython_overloaded_1__cos
                                                     numpy
@@ -1595,7 +1595,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    220
+                                                    222
                                                     eps
                                                     []
                                                     Local
@@ -1611,7 +1611,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    220
+                                                    222
                                                     i
                                                     []
                                                     Local
@@ -1627,7 +1627,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    220
+                                                    222
                                                     j
                                                     []
                                                     Local
@@ -1643,7 +1643,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    220
+                                                    222
                                                     k
                                                     []
                                                     Local
@@ -1659,7 +1659,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    220
+                                                    222
                                                     l
                                                     []
                                                     Local
@@ -1675,7 +1675,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    220
+                                                    222
                                                     newshape
                                                     []
                                                     Local
@@ -1696,7 +1696,7 @@
                                                 ),
                                             observed:
                                                 (Variable
-                                                    220
+                                                    222
                                                     observed
                                                     []
                                                     Local
@@ -1723,7 +1723,7 @@
                                                 ),
                                             observed1d:
                                                 (Variable
-                                                    220
+                                                    222
                                                     observed1d
                                                     []
                                                     Local
@@ -1744,7 +1744,7 @@
                                                 ),
                                             sin@__lpython_overloaded_1__sin:
                                                 (ExternalSymbol
-                                                    220
+                                                    222
                                                     sin@__lpython_overloaded_1__sin
                                                     3 __lpython_overloaded_1__sin
                                                     numpy
@@ -1771,7 +1771,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 220 eps)
+                                        (Var 222 eps)
                                         (Cast
                                             (RealConstant
                                                 0.000001
@@ -1787,7 +1787,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 arraynd)
+                                        (Var 222 arraynd)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1807,7 +1807,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 observed)
+                                        (Var 222 observed)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1827,7 +1827,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 observed1d)
+                                        (Var 222 observed1d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1842,7 +1842,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 220 i)
+                                        ((Var 222 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 64 (Integer 4))
@@ -1854,7 +1854,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 220 j)
+                                            ((Var 222 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 32 (Integer 4))
@@ -1866,7 +1866,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 220 k)
+                                                ((Var 222 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 8 (Integer 4))
@@ -1878,7 +1878,7 @@
                                                 (IntegerConstant 1 (Integer 4)))
                                                 [(DoLoop
                                                     ()
-                                                    ((Var 220 l)
+                                                    ((Var 222 l)
                                                     (IntegerConstant 0 (Integer 4))
                                                     (IntegerBinOp
                                                         (IntegerConstant 4 (Integer 4))
@@ -1890,18 +1890,18 @@
                                                     (IntegerConstant 1 (Integer 4)))
                                                     [(=
                                                         (ArrayItem
-                                                            (Var 220 arraynd)
+                                                            (Var 222 arraynd)
                                                             [(()
-                                                            (Var 220 i)
+                                                            (Var 222 i)
                                                             ())
                                                             (()
-                                                            (Var 220 j)
+                                                            (Var 222 j)
                                                             ())
                                                             (()
-                                                            (Var 220 k)
+                                                            (Var 222 k)
                                                             ())
                                                             (()
-                                                            (Var 220 l)
+                                                            (Var 222 l)
                                                             ())]
                                                             (Real 4)
                                                             RowMajor
@@ -1911,19 +1911,19 @@
                                                             (IntegerBinOp
                                                                 (IntegerBinOp
                                                                     (IntegerBinOp
-                                                                        (Var 220 i)
+                                                                        (Var 222 i)
                                                                         Add
-                                                                        (Var 220 j)
+                                                                        (Var 222 j)
                                                                         (Integer 4)
                                                                         ()
                                                                     )
                                                                     Add
-                                                                    (Var 220 k)
+                                                                    (Var 222 k)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
                                                                 Add
-                                                                (Var 220 l)
+                                                                (Var 222 l)
                                                                 (Integer 4)
                                                                 ()
                                                             )
@@ -1938,13 +1938,13 @@
                                         )]
                                     )
                                     (=
-                                        (Var 220 observed)
+                                        (Var 222 observed)
                                         (RealBinOp
                                             (RealBinOp
                                                 (FunctionCall
-                                                    220 sin@__lpython_overloaded_1__sin
+                                                    222 sin@__lpython_overloaded_1__sin
                                                     2 sin
-                                                    [((Var 220 arraynd))]
+                                                    [((Var 222 arraynd))]
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
@@ -1987,9 +1987,9 @@
                                             Add
                                             (RealBinOp
                                                 (FunctionCall
-                                                    220 cos@__lpython_overloaded_1__cos
+                                                    222 cos@__lpython_overloaded_1__cos
                                                     2 cos
-                                                    [((Var 220 arraynd))]
+                                                    [((Var 222 arraynd))]
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
@@ -2046,7 +2046,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 newshape)
+                                        (Var 222 newshape)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -2061,7 +2061,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 220 newshape)
+                                            (Var 222 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -2073,11 +2073,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 observed1d)
+                                        (Var 222 observed1d)
                                         (ArrayReshape
-                                            (Var 220 observed)
+                                            (Var 222 observed)
                                             (ArrayPhysicalCast
-                                                (Var 220 newshape)
+                                                (Var 222 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -2100,7 +2100,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 220 i)
+                                        ((Var 222 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 65536 (Integer 4))
@@ -2116,9 +2116,9 @@
                                                     Abs
                                                     [(RealBinOp
                                                         (ArrayItem
-                                                            (Var 220 observed1d)
+                                                            (Var 222 observed1d)
                                                             [(()
-                                                            (Var 220 i)
+                                                            (Var 222 i)
                                                             ())]
                                                             (Real 4)
                                                             RowMajor
@@ -2145,7 +2145,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 220 eps)
+                                                (Var 222 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2171,11 +2171,11 @@
                             verify1d:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             array:
                                                 (Variable
-                                                    211
+                                                    213
                                                     array
                                                     []
                                                     InOut
@@ -2197,11 +2197,11 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        221
+                                                        223
                                                         {
                                                             sin@__lpython_overloaded_1__sin:
                                                                 (ExternalSymbol
-                                                                    221
+                                                                    223
                                                                     sin@__lpython_overloaded_1__sin
                                                                     3 __lpython_overloaded_1__sin
                                                                     numpy
@@ -2217,15 +2217,15 @@
                                                                 Abs
                                                                 [(RealBinOp
                                                                     (FunctionCall
-                                                                        221 sin@__lpython_overloaded_1__sin
+                                                                        223 sin@__lpython_overloaded_1__sin
                                                                         2 sin
                                                                         [((FunctionCall
-                                                                            221 sin@__lpython_overloaded_1__sin
+                                                                            223 sin@__lpython_overloaded_1__sin
                                                                             2 sin
                                                                             [((ArrayItem
-                                                                                (Var 211 array)
+                                                                                (Var 213 array)
                                                                                 [(()
-                                                                                (Var 211 i)
+                                                                                (Var 213 i)
                                                                                 ())]
                                                                                 (Real 4)
                                                                                 RowMajor
@@ -2241,9 +2241,9 @@
                                                                     )
                                                                     Sub
                                                                     (ArrayItem
-                                                                        (Var 211 result)
+                                                                        (Var 213 result)
                                                                         [(()
-                                                                        (Var 211 i)
+                                                                        (Var 213 i)
                                                                         ())]
                                                                         (Real 4)
                                                                         RowMajor
@@ -2257,7 +2257,7 @@
                                                                 ()
                                                             )
                                                             LtE
-                                                            (Var 211 eps)
+                                                            (Var 213 eps)
                                                             (Logical 4)
                                                             ()
                                                         )
@@ -2266,7 +2266,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    211
+                                                    213
                                                     eps
                                                     []
                                                     Local
@@ -2282,7 +2282,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    211
+                                                    213
                                                     i
                                                     []
                                                     Local
@@ -2298,7 +2298,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    211
+                                                    213
                                                     result
                                                     []
                                                     InOut
@@ -2319,7 +2319,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    211
+                                                    213
                                                     size
                                                     []
                                                     In
@@ -2362,11 +2362,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 array)
-                                    (Var 211 result)
-                                    (Var 211 size)]
+                                    [(Var 213 array)
+                                    (Var 213 result)
+                                    (Var 213 size)]
                                     [(=
-                                        (Var 211 eps)
+                                        (Var 213 eps)
                                         (Cast
                                             (RealConstant
                                                 0.000001
@@ -2383,10 +2383,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 213 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 211 size)
+                                            (Var 213 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2395,7 +2395,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            211 block
+                                            213 block
                                         )]
                                     )]
                                     ()
@@ -2407,11 +2407,11 @@
                             verify1d_mul:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        217
                                         {
                                             array_a:
                                                 (Variable
-                                                    215
+                                                    217
                                                     array_a
                                                     []
                                                     InOut
@@ -2432,7 +2432,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    215
+                                                    217
                                                     array_b
                                                     []
                                                     InOut
@@ -2453,7 +2453,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    215
+                                                    217
                                                     eps
                                                     []
                                                     Local
@@ -2469,7 +2469,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    215
+                                                    217
                                                     i
                                                     []
                                                     Local
@@ -2485,7 +2485,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    215
+                                                    217
                                                     result
                                                     []
                                                     InOut
@@ -2506,7 +2506,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    215
+                                                    217
                                                     size
                                                     []
                                                     In
@@ -2555,12 +2555,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 215 array_a)
-                                    (Var 215 array_b)
-                                    (Var 215 result)
-                                    (Var 215 size)]
+                                    [(Var 217 array_a)
+                                    (Var 217 array_b)
+                                    (Var 217 result)
+                                    (Var 217 size)]
                                     [(=
-                                        (Var 215 eps)
+                                        (Var 217 eps)
                                         (RealConstant
                                             0.000010
                                             (Real 8)
@@ -2569,10 +2569,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 215 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 215 size)
+                                            (Var 217 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2588,9 +2588,9 @@
                                                             (RealBinOp
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 215 array_a)
+                                                                        (Var 217 array_a)
                                                                         [(()
-                                                                        (Var 215 i)
+                                                                        (Var 217 i)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -2615,9 +2615,9 @@
                                                             Mul
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 215 array_b)
+                                                                    (Var 217 array_b)
                                                                     [(()
-                                                                    (Var 215 i)
+                                                                    (Var 217 i)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -2636,9 +2636,9 @@
                                                         )
                                                         Sub
                                                         (ArrayItem
-                                                            (Var 215 result)
+                                                            (Var 217 result)
                                                             [(()
-                                                            (Var 215 i)
+                                                            (Var 217 i)
                                                             ())]
                                                             (Real 8)
                                                             RowMajor
@@ -2652,7 +2652,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 215 eps)
+                                                (Var 217 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2668,11 +2668,11 @@
                             verify1d_sum:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        216
                                         {
                                             array_a:
                                                 (Variable
-                                                    214
+                                                    216
                                                     array_a
                                                     []
                                                     InOut
@@ -2693,7 +2693,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    214
+                                                    216
                                                     array_b
                                                     []
                                                     InOut
@@ -2714,7 +2714,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    214
+                                                    216
                                                     eps
                                                     []
                                                     Local
@@ -2730,7 +2730,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    214
+                                                    216
                                                     i
                                                     []
                                                     Local
@@ -2746,7 +2746,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    214
+                                                    216
                                                     result
                                                     []
                                                     InOut
@@ -2767,7 +2767,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    214
+                                                    216
                                                     size
                                                     []
                                                     In
@@ -2816,12 +2816,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 array_a)
-                                    (Var 214 array_b)
-                                    (Var 214 result)
-                                    (Var 214 size)]
+                                    [(Var 216 array_a)
+                                    (Var 216 array_b)
+                                    (Var 216 result)
+                                    (Var 216 size)]
                                     [(=
-                                        (Var 214 eps)
+                                        (Var 216 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -2830,10 +2830,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 214 i)
+                                        ((Var 216 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 214 size)
+                                            (Var 216 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2848,9 +2848,9 @@
                                                         (RealBinOp
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 214 array_a)
+                                                                    (Var 216 array_a)
                                                                     [(()
-                                                                    (Var 214 i)
+                                                                    (Var 216 i)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -2873,9 +2873,9 @@
                                                                 Mul
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 214 array_b)
+                                                                        (Var 216 array_b)
                                                                         [(()
-                                                                        (Var 214 i)
+                                                                        (Var 216 i)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -2897,9 +2897,9 @@
                                                         )
                                                         Sub
                                                         (ArrayItem
-                                                            (Var 214 result)
+                                                            (Var 216 result)
                                                             [(()
-                                                            (Var 214 i)
+                                                            (Var 216 i)
                                                             ())]
                                                             (Real 8)
                                                             RowMajor
@@ -2913,7 +2913,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 214 eps)
+                                                (Var 216 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2929,11 +2929,11 @@
                             verify2d:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             array:
                                                 (Variable
-                                                    213
+                                                    215
                                                     array
                                                     []
                                                     InOut
@@ -2957,16 +2957,16 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        225
+                                                        227
                                                         {
                                                             block:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        226
+                                                                        228
                                                                         {
                                                                             cos@__lpython_overloaded_0__cos:
                                                                                 (ExternalSymbol
-                                                                                    226
+                                                                                    228
                                                                                     cos@__lpython_overloaded_0__cos
                                                                                     3 __lpython_overloaded_0__cos
                                                                                     numpy
@@ -2983,15 +2983,15 @@
                                                                                 [(RealBinOp
                                                                                     (RealBinOp
                                                                                         (FunctionCall
-                                                                                            226 cos@__lpython_overloaded_0__cos
+                                                                                            228 cos@__lpython_overloaded_0__cos
                                                                                             2 cos
                                                                                             [((ArrayItem
-                                                                                                (Var 213 array)
+                                                                                                (Var 215 array)
                                                                                                 [(()
-                                                                                                (Var 213 i)
+                                                                                                (Var 215 i)
                                                                                                 ())
                                                                                                 (()
-                                                                                                (Var 213 j)
+                                                                                                (Var 215 j)
                                                                                                 ())]
                                                                                                 (Real 8)
                                                                                                 RowMajor
@@ -3011,12 +3011,12 @@
                                                                                     )
                                                                                     Sub
                                                                                     (ArrayItem
-                                                                                        (Var 213 result)
+                                                                                        (Var 215 result)
                                                                                         [(()
-                                                                                        (Var 213 i)
+                                                                                        (Var 215 i)
                                                                                         ())
                                                                                         (()
-                                                                                        (Var 213 j)
+                                                                                        (Var 215 j)
                                                                                         ())]
                                                                                         (Real 8)
                                                                                         RowMajor
@@ -3030,7 +3030,7 @@
                                                                                 ()
                                                                             )
                                                                             LtE
-                                                                            (Var 213 eps)
+                                                                            (Var 215 eps)
                                                                             (Logical 4)
                                                                             ()
                                                                         )
@@ -3041,10 +3041,10 @@
                                                     block
                                                     [(DoLoop
                                                         ()
-                                                        ((Var 213 j)
+                                                        ((Var 215 j)
                                                         (IntegerConstant 0 (Integer 4))
                                                         (IntegerBinOp
-                                                            (Var 213 size2)
+                                                            (Var 215 size2)
                                                             Sub
                                                             (IntegerConstant 1 (Integer 4))
                                                             (Integer 4)
@@ -3053,13 +3053,13 @@
                                                         (IntegerConstant 1 (Integer 4)))
                                                         [(BlockCall
                                                             -1
-                                                            225 block
+                                                            227 block
                                                         )]
                                                     )]
                                                 ),
                                             eps:
                                                 (Variable
-                                                    213
+                                                    215
                                                     eps
                                                     []
                                                     Local
@@ -3075,7 +3075,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    213
+                                                    215
                                                     i
                                                     []
                                                     Local
@@ -3091,7 +3091,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    213
+                                                    215
                                                     j
                                                     []
                                                     Local
@@ -3107,7 +3107,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    213
+                                                    215
                                                     result
                                                     []
                                                     InOut
@@ -3130,7 +3130,7 @@
                                                 ),
                                             size1:
                                                 (Variable
-                                                    213
+                                                    215
                                                     size1
                                                     []
                                                     In
@@ -3146,7 +3146,7 @@
                                                 ),
                                             size2:
                                                 (Variable
-                                                    213
+                                                    215
                                                     size2
                                                     []
                                                     In
@@ -3194,12 +3194,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 array)
-                                    (Var 213 result)
-                                    (Var 213 size1)
-                                    (Var 213 size2)]
+                                    [(Var 215 array)
+                                    (Var 215 result)
+                                    (Var 215 size1)
+                                    (Var 215 size2)]
                                     [(=
-                                        (Var 213 eps)
+                                        (Var 215 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -3208,10 +3208,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 i)
+                                        ((Var 215 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 213 size1)
+                                            (Var 215 size1)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -3220,7 +3220,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            213 block
+                                            215 block
                                         )]
                                     )]
                                     ()
@@ -3232,11 +3232,11 @@
                             verifynd:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             array:
                                                 (Variable
-                                                    212
+                                                    214
                                                     array
                                                     []
                                                     InOut
@@ -3262,21 +3262,21 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        222
+                                                        224
                                                         {
                                                             block:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        223
+                                                                        225
                                                                         {
                                                                             block:
                                                                                 (Block
                                                                                     (SymbolTable
-                                                                                        224
+                                                                                        226
                                                                                         {
                                                                                             sin@__lpython_overloaded_0__sin:
                                                                                                 (ExternalSymbol
-                                                                                                    224
+                                                                                                    226
                                                                                                     sin@__lpython_overloaded_0__sin
                                                                                                     3 __lpython_overloaded_0__sin
                                                                                                     numpy
@@ -3293,18 +3293,18 @@
                                                                                                 [(RealBinOp
                                                                                                     (RealBinOp
                                                                                                         (FunctionCall
-                                                                                                            224 sin@__lpython_overloaded_0__sin
+                                                                                                            226 sin@__lpython_overloaded_0__sin
                                                                                                             2 sin
                                                                                                             [((ArrayItem
-                                                                                                                (Var 212 array)
+                                                                                                                (Var 214 array)
                                                                                                                 [(()
-                                                                                                                (Var 212 i)
+                                                                                                                (Var 214 i)
                                                                                                                 ())
                                                                                                                 (()
-                                                                                                                (Var 212 j)
+                                                                                                                (Var 214 j)
                                                                                                                 ())
                                                                                                                 (()
-                                                                                                                (Var 212 k)
+                                                                                                                (Var 214 k)
                                                                                                                 ())]
                                                                                                                 (Real 8)
                                                                                                                 RowMajor
@@ -3324,15 +3324,15 @@
                                                                                                     )
                                                                                                     Sub
                                                                                                     (ArrayItem
-                                                                                                        (Var 212 result)
+                                                                                                        (Var 214 result)
                                                                                                         [(()
-                                                                                                        (Var 212 i)
+                                                                                                        (Var 214 i)
                                                                                                         ())
                                                                                                         (()
-                                                                                                        (Var 212 j)
+                                                                                                        (Var 214 j)
                                                                                                         ())
                                                                                                         (()
-                                                                                                        (Var 212 k)
+                                                                                                        (Var 214 k)
                                                                                                         ())]
                                                                                                         (Real 8)
                                                                                                         RowMajor
@@ -3346,7 +3346,7 @@
                                                                                                 ()
                                                                                             )
                                                                                             LtE
-                                                                                            (Var 212 eps)
+                                                                                            (Var 214 eps)
                                                                                             (Logical 4)
                                                                                             ()
                                                                                         )
@@ -3357,10 +3357,10 @@
                                                                     block
                                                                     [(DoLoop
                                                                         ()
-                                                                        ((Var 212 k)
+                                                                        ((Var 214 k)
                                                                         (IntegerConstant 0 (Integer 4))
                                                                         (IntegerBinOp
-                                                                            (Var 212 size3)
+                                                                            (Var 214 size3)
                                                                             Sub
                                                                             (IntegerConstant 1 (Integer 4))
                                                                             (Integer 4)
@@ -3369,7 +3369,7 @@
                                                                         (IntegerConstant 1 (Integer 4)))
                                                                         [(BlockCall
                                                                             -1
-                                                                            223 block
+                                                                            225 block
                                                                         )]
                                                                     )]
                                                                 )
@@ -3377,10 +3377,10 @@
                                                     block
                                                     [(DoLoop
                                                         ()
-                                                        ((Var 212 j)
+                                                        ((Var 214 j)
                                                         (IntegerConstant 0 (Integer 4))
                                                         (IntegerBinOp
-                                                            (Var 212 size2)
+                                                            (Var 214 size2)
                                                             Sub
                                                             (IntegerConstant 1 (Integer 4))
                                                             (Integer 4)
@@ -3389,13 +3389,13 @@
                                                         (IntegerConstant 1 (Integer 4)))
                                                         [(BlockCall
                                                             -1
-                                                            222 block
+                                                            224 block
                                                         )]
                                                     )]
                                                 ),
                                             eps:
                                                 (Variable
-                                                    212
+                                                    214
                                                     eps
                                                     []
                                                     Local
@@ -3411,7 +3411,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    212
+                                                    214
                                                     i
                                                     []
                                                     Local
@@ -3427,7 +3427,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    212
+                                                    214
                                                     j
                                                     []
                                                     Local
@@ -3443,7 +3443,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    212
+                                                    214
                                                     k
                                                     []
                                                     Local
@@ -3459,7 +3459,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    212
+                                                    214
                                                     result
                                                     []
                                                     InOut
@@ -3484,7 +3484,7 @@
                                                 ),
                                             size1:
                                                 (Variable
-                                                    212
+                                                    214
                                                     size1
                                                     []
                                                     In
@@ -3500,7 +3500,7 @@
                                                 ),
                                             size2:
                                                 (Variable
-                                                    212
+                                                    214
                                                     size2
                                                     []
                                                     In
@@ -3516,7 +3516,7 @@
                                                 ),
                                             size3:
                                                 (Variable
-                                                    212
+                                                    214
                                                     size3
                                                     []
                                                     In
@@ -3569,13 +3569,13 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 array)
-                                    (Var 212 result)
-                                    (Var 212 size1)
-                                    (Var 212 size2)
-                                    (Var 212 size3)]
+                                    [(Var 214 array)
+                                    (Var 214 result)
+                                    (Var 214 size1)
+                                    (Var 214 size2)
+                                    (Var 214 size3)]
                                     [(=
-                                        (Var 212 eps)
+                                        (Var 214 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -3584,10 +3584,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 212 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 212 size1)
+                                            (Var 214 size1)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -3596,7 +3596,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            212 block
+                                            214 block
                                         )]
                                     )]
                                     ()
@@ -3616,11 +3616,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        245
+                        247
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    245
+                                    247
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -3632,7 +3632,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        245 __main__global_stmts
+                        247 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_01-682b1b2.json
+++ b/tests/reference/asr-generics_array_01-682b1b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_01-682b1b2.stdout",
-    "stdout_hash": "c4e52ae547d6c1e2d120fe108b5c332d2ec5155a275fc76da9dee893",
+    "stdout_hash": "084f48e82e0e32123a6da2aa362f36f0b19de8db5b8d2d9682cfa481",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_01-682b1b2.stdout
+++ b/tests/reference/asr-generics_array_01-682b1b2.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_f_0:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    215
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -48,7 +48,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    213
+                                                    215
                                                     i
                                                     []
                                                     In
@@ -64,7 +64,7 @@
                                                 ),
                                             lst:
                                                 (Variable
-                                                    213
+                                                    215
                                                     lst
                                                     []
                                                     InOut
@@ -106,11 +106,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 lst)
-                                    (Var 213 i)]
+                                    [(Var 215 lst)
+                                    (Var 215 i)]
                                     [(=
                                         (ArrayItem
-                                            (Var 213 lst)
+                                            (Var 215 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -118,13 +118,13 @@
                                             RowMajor
                                             ()
                                         )
-                                        (Var 213 i)
+                                        (Var 215 i)
                                         ()
                                     )
                                     (=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 215 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 213 lst)
+                                            (Var 215 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -135,7 +135,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 215 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -144,7 +144,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        216
                                         {
                                             
                                         })
@@ -180,11 +180,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    213
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -202,7 +202,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    211
+                                                    213
                                                     i
                                                     []
                                                     In
@@ -220,7 +220,7 @@
                                                 ),
                                             lst:
                                                 (Variable
-                                                    211
+                                                    213
                                                     lst
                                                     []
                                                     InOut
@@ -270,11 +270,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 lst)
-                                    (Var 211 i)]
+                                    [(Var 213 lst)
+                                    (Var 213 i)]
                                     [(=
                                         (ArrayItem
-                                            (Var 211 lst)
+                                            (Var 213 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -284,13 +284,13 @@
                                             RowMajor
                                             ()
                                         )
-                                        (Var 211 i)
+                                        (Var 213 i)
                                         ()
                                     )
                                     (=
-                                        (Var 211 _lpython_return_variable)
+                                        (Var 213 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 211 lst)
+                                            (Var 213 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -303,7 +303,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 213 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -312,11 +312,11 @@
                             use_array:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             array:
                                                 (Variable
-                                                    212
+                                                    214
                                                     array
                                                     []
                                                     Local
@@ -337,7 +337,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    212
+                                                    214
                                                     x
                                                     []
                                                     Local
@@ -370,7 +370,7 @@
                                     [__asr_generic_f_0]
                                     []
                                     [(=
-                                        (Var 212 array)
+                                        (Var 214 array)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -384,7 +384,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 x)
+                                        (Var 214 x)
                                         (IntegerConstant 69 (Integer 4))
                                         ()
                                     )
@@ -393,7 +393,7 @@
                                             2 __asr_generic_f_0
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 212 array)
+                                                (Var 214 array)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -404,7 +404,7 @@
                                                 )
                                                 ()
                                             ))
-                                            ((Var 212 x))]
+                                            ((Var 214 x))]
                                             (Integer 4)
                                             ()
                                             ()
@@ -429,11 +429,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        215
+                        217
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    215
+                                    217
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -445,7 +445,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        215 __main__global_stmts
+                        217 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_02-22c8dc1.json
+++ b/tests/reference/asr-generics_array_02-22c8dc1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_02-22c8dc1.stdout",
-    "stdout_hash": "75ccb4ee0e075aa0ed2e7da482eb1afe58c4bd1028306f083047014d",
+    "stdout_hash": "d6bb6357752ee916c8a45c47c759770f8a8f7f068ec588d28058b208",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_02-22c8dc1.stdout
+++ b/tests/reference/asr-generics_array_02-22c8dc1.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_g_0:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        219
                                         {
                                             a:
                                                 (Variable
-                                                    217
+                                                    219
                                                     a
                                                     [n]
                                                     InOut
@@ -42,7 +42,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 n))]
+                                                        (Var 219 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -53,7 +53,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    217
+                                                    219
                                                     b
                                                     [n]
                                                     InOut
@@ -63,7 +63,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 n))]
+                                                        (Var 219 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -74,7 +74,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    217
+                                                    219
                                                     i
                                                     []
                                                     Local
@@ -90,7 +90,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    217
+                                                    219
                                                     n
                                                     []
                                                     In
@@ -106,7 +106,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    217
+                                                    219
                                                     r
                                                     [n]
                                                     Local
@@ -116,7 +116,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 217 n))]
+                                                        (Var 219 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -162,17 +162,17 @@
                                         .false.
                                     )
                                     [add_integer]
-                                    [(Var 217 n)
-                                    (Var 217 a)
-                                    (Var 217 b)]
+                                    [(Var 219 n)
+                                    (Var 219 a)
+                                    (Var 219 b)]
                                     [(=
-                                        (Var 217 r)
+                                        (Var 219 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Integer 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 217 n))]
+                                                (Var 219 n))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -181,10 +181,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 217 i)
+                                        ((Var 219 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 217 n)
+                                            (Var 219 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -193,9 +193,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 217 r)
+                                                (Var 219 r)
                                                 [(()
-                                                (Var 217 i)
+                                                (Var 219 i)
                                                 ())]
                                                 (Integer 4)
                                                 RowMajor
@@ -205,18 +205,18 @@
                                                 2 add_integer
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 217 a)
+                                                    (Var 219 a)
                                                     [(()
-                                                    (Var 217 i)
+                                                    (Var 219 i)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 217 b)
+                                                    (Var 219 b)
                                                     [(()
-                                                    (Var 217 i)
+                                                    (Var 219 i)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
@@ -231,7 +231,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 217 r)
+                                            (Var 219 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -251,11 +251,11 @@
                             __asr_generic_g_1:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        220
                                         {
                                             a:
                                                 (Variable
-                                                    218
+                                                    220
                                                     a
                                                     [n]
                                                     InOut
@@ -265,7 +265,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))]
+                                                        (Var 220 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -276,7 +276,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    218
+                                                    220
                                                     b
                                                     [n]
                                                     InOut
@@ -286,7 +286,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))]
+                                                        (Var 220 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -297,7 +297,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    218
+                                                    220
                                                     i
                                                     []
                                                     Local
@@ -313,7 +313,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    218
+                                                    220
                                                     n
                                                     []
                                                     In
@@ -329,7 +329,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    218
+                                                    220
                                                     r
                                                     [n]
                                                     Local
@@ -339,7 +339,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))]
+                                                        (Var 220 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -385,17 +385,17 @@
                                         .false.
                                     )
                                     [add_float]
-                                    [(Var 218 n)
-                                    (Var 218 a)
-                                    (Var 218 b)]
+                                    [(Var 220 n)
+                                    (Var 220 a)
+                                    (Var 220 b)]
                                     [(=
-                                        (Var 218 r)
+                                        (Var 220 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Real 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 218 n))]
+                                                (Var 220 n))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -404,10 +404,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 218 i)
+                                        ((Var 220 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 218 n)
+                                            (Var 220 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -416,9 +416,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 218 r)
+                                                (Var 220 r)
                                                 [(()
-                                                (Var 218 i)
+                                                (Var 220 i)
                                                 ())]
                                                 (Real 4)
                                                 RowMajor
@@ -428,18 +428,18 @@
                                                 2 add_float
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 218 a)
+                                                    (Var 220 a)
                                                     [(()
-                                                    (Var 218 i)
+                                                    (Var 220 i)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 218 b)
+                                                    (Var 220 b)
                                                     [(()
-                                                    (Var 218 i)
+                                                    (Var 220 i)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
@@ -454,7 +454,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 218 r)
+                                            (Var 220 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -474,7 +474,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        219
+                                        221
                                         {
                                             
                                         })
@@ -510,11 +510,11 @@
                             add:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    213
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -532,7 +532,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    211
+                                                    213
                                                     x
                                                     []
                                                     In
@@ -550,7 +550,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    211
+                                                    213
                                                     y
                                                     []
                                                     In
@@ -590,10 +590,10 @@
                                         .true.
                                     )
                                     []
-                                    [(Var 211 x)
-                                    (Var 211 y)]
+                                    [(Var 213 x)
+                                    (Var 213 y)]
                                     []
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 213 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -602,11 +602,11 @@
                             add_float:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    215
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -622,7 +622,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    213
+                                                    215
                                                     x
                                                     []
                                                     In
@@ -638,7 +638,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    213
+                                                    215
                                                     y
                                                     []
                                                     In
@@ -670,21 +670,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 x)
-                                    (Var 213 y)]
+                                    [(Var 215 x)
+                                    (Var 215 y)]
                                     [(=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 215 _lpython_return_variable)
                                         (RealBinOp
-                                            (Var 213 x)
+                                            (Var 215 x)
                                             Add
-                                            (Var 213 y)
+                                            (Var 215 y)
                                             (Real 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 215 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -693,11 +693,11 @@
                             add_integer:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    212
+                                                    214
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -713,7 +713,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    212
+                                                    214
                                                     x
                                                     []
                                                     In
@@ -729,7 +729,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    212
+                                                    214
                                                     y
                                                     []
                                                     In
@@ -761,21 +761,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 x)
-                                    (Var 212 y)]
+                                    [(Var 214 x)
+                                    (Var 214 y)]
                                     [(=
-                                        (Var 212 _lpython_return_variable)
+                                        (Var 214 _lpython_return_variable)
                                         (IntegerBinOp
-                                            (Var 212 x)
+                                            (Var 214 x)
                                             Add
-                                            (Var 212 y)
+                                            (Var 214 y)
                                             (Integer 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 212 _lpython_return_variable)
+                                    (Var 214 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -784,11 +784,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        216
                                         {
                                             a:
                                                 (Variable
-                                                    214
+                                                    216
                                                     a
                                                     [n]
                                                     InOut
@@ -800,7 +800,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))]
+                                                        (Var 216 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -811,7 +811,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    214
+                                                    216
                                                     b
                                                     [n]
                                                     InOut
@@ -823,7 +823,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))]
+                                                        (Var 216 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -834,7 +834,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    214
+                                                    216
                                                     i
                                                     []
                                                     Local
@@ -850,7 +850,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    214
+                                                    216
                                                     n
                                                     []
                                                     In
@@ -866,7 +866,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    214
+                                                    216
                                                     r
                                                     [n]
                                                     Local
@@ -878,7 +878,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))]
+                                                        (Var 216 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -928,11 +928,11 @@
                                         .false.
                                     )
                                     [add]
-                                    [(Var 214 n)
-                                    (Var 214 a)
-                                    (Var 214 b)]
+                                    [(Var 216 n)
+                                    (Var 216 a)
+                                    (Var 216 b)]
                                     [(=
-                                        (Var 214 r)
+                                        (Var 216 r)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -940,7 +940,7 @@
                                                     T
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 214 n))]
+                                                (Var 216 n))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -949,10 +949,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 214 i)
+                                        ((Var 216 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 214 n)
+                                            (Var 216 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -961,9 +961,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 214 r)
+                                                (Var 216 r)
                                                 [(()
-                                                (Var 214 i)
+                                                (Var 216 i)
                                                 ())]
                                                 (TypeParameter
                                                     T
@@ -975,9 +975,9 @@
                                                 2 add
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 214 a)
+                                                    (Var 216 a)
                                                     [(()
-                                                    (Var 214 i)
+                                                    (Var 216 i)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -986,9 +986,9 @@
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 214 b)
+                                                    (Var 216 b)
                                                     [(()
-                                                    (Var 214 i)
+                                                    (Var 216 i)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -1007,7 +1007,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 214 r)
+                                            (Var 216 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1029,11 +1029,11 @@
                             main:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        217
                                         {
                                             a_float:
                                                 (Variable
-                                                    215
+                                                    217
                                                     a_float
                                                     []
                                                     Local
@@ -1054,7 +1054,7 @@
                                                 ),
                                             a_int:
                                                 (Variable
-                                                    215
+                                                    217
                                                     a_int
                                                     []
                                                     Local
@@ -1075,7 +1075,7 @@
                                                 ),
                                             b_float:
                                                 (Variable
-                                                    215
+                                                    217
                                                     b_float
                                                     []
                                                     Local
@@ -1096,7 +1096,7 @@
                                                 ),
                                             b_int:
                                                 (Variable
-                                                    215
+                                                    217
                                                     b_int
                                                     []
                                                     Local
@@ -1135,7 +1135,7 @@
                                     __asr_generic_g_1]
                                     []
                                     [(=
-                                        (Var 215 a_int)
+                                        (Var 217 a_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1150,7 +1150,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 a_int)
+                                            (Var 217 a_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1162,7 +1162,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 b_int)
+                                        (Var 217 b_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1177,7 +1177,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 b_int)
+                                            (Var 217 b_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1193,7 +1193,7 @@
                                         ()
                                         [((IntegerConstant 1 (Integer 4)))
                                         ((ArrayPhysicalCast
-                                            (Var 215 a_int)
+                                            (Var 217 a_int)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1205,7 +1205,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 215 b_int)
+                                            (Var 217 b_int)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1219,7 +1219,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 a_float)
+                                        (Var 217 a_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1234,7 +1234,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 a_float)
+                                            (Var 217 a_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1257,7 +1257,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 b_float)
+                                        (Var 217 b_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1272,7 +1272,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 b_float)
+                                            (Var 217 b_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1299,7 +1299,7 @@
                                         ()
                                         [((IntegerConstant 1 (Integer 4)))
                                         ((ArrayPhysicalCast
-                                            (Var 215 a_float)
+                                            (Var 217 a_float)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1311,7 +1311,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 215 b_float)
+                                            (Var 217 b_float)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1359,11 +1359,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        220
+                        222
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    220
+                                    222
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1375,7 +1375,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        220 __main__global_stmts
+                        222 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_03-fb3706c.json
+++ b/tests/reference/asr-generics_array_03-fb3706c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_03-fb3706c.stdout",
-    "stdout_hash": "604160a697a7d9fb44eb61417d9f9363a16563e903f31c861a5e7bf6",
+    "stdout_hash": "23993ae97006859db7166e0fc85bfb998136623d6fbbe48ca89fb450",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_03-fb3706c.stdout
+++ b/tests/reference/asr-generics_array_03-fb3706c.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_g_0:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        220
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    218
+                                                    220
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -43,9 +43,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))
+                                                        (Var 220 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 m))]
+                                                        (Var 220 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -56,7 +56,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    218
+                                                    220
                                                     a
                                                     [n
                                                     m]
@@ -67,9 +67,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))
+                                                        (Var 220 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 m))]
+                                                        (Var 220 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -80,7 +80,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    218
+                                                    220
                                                     b
                                                     [n
                                                     m]
@@ -91,9 +91,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))
+                                                        (Var 220 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 m))]
+                                                        (Var 220 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -104,7 +104,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    218
+                                                    220
                                                     i
                                                     []
                                                     Local
@@ -120,7 +120,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    218
+                                                    220
                                                     j
                                                     []
                                                     Local
@@ -136,7 +136,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    218
+                                                    220
                                                     m
                                                     []
                                                     In
@@ -152,7 +152,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    218
+                                                    220
                                                     n
                                                     []
                                                     In
@@ -168,7 +168,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    218
+                                                    220
                                                     r
                                                     [n
                                                     m]
@@ -179,9 +179,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 n))
+                                                        (Var 220 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 218 m))]
+                                                        (Var 220 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -255,20 +255,20 @@
                                         .false.
                                     )
                                     [add_integer]
-                                    [(Var 218 n)
-                                    (Var 218 m)
-                                    (Var 218 a)
-                                    (Var 218 b)]
+                                    [(Var 220 n)
+                                    (Var 220 m)
+                                    (Var 220 a)
+                                    (Var 220 b)]
                                     [(=
-                                        (Var 218 r)
+                                        (Var 220 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Integer 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 218 n))
+                                                (Var 220 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 218 m))]
+                                                (Var 220 m))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -277,10 +277,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 218 i)
+                                        ((Var 220 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 218 n)
+                                            (Var 220 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -289,10 +289,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 218 j)
+                                            ((Var 220 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 218 m)
+                                                (Var 220 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -301,12 +301,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 218 r)
+                                                    (Var 220 r)
                                                     [(()
-                                                    (Var 218 i)
+                                                    (Var 220 i)
                                                     ())
                                                     (()
-                                                    (Var 218 j)
+                                                    (Var 220 j)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
@@ -316,24 +316,24 @@
                                                     2 add_integer
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 218 a)
+                                                        (Var 220 a)
                                                         [(()
-                                                        (Var 218 i)
+                                                        (Var 220 i)
                                                         ())
                                                         (()
-                                                        (Var 218 j)
+                                                        (Var 220 j)
                                                         ())]
                                                         (Integer 4)
                                                         RowMajor
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 218 b)
+                                                        (Var 220 b)
                                                         [(()
-                                                        (Var 218 i)
+                                                        (Var 220 i)
                                                         ())
                                                         (()
-                                                        (Var 218 j)
+                                                        (Var 220 j)
                                                         ())]
                                                         (Integer 4)
                                                         RowMajor
@@ -349,7 +349,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 218 r)
+                                            (Var 220 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -363,7 +363,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 218 _lpython_return_variable)
+                                    (Var 220 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -372,11 +372,11 @@
                             __asr_generic_g_1:
                                 (Function
                                     (SymbolTable
-                                        219
+                                        221
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    219
+                                                    221
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -387,9 +387,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 n))
+                                                        (Var 221 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 m))]
+                                                        (Var 221 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -400,7 +400,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    219
+                                                    221
                                                     a
                                                     [n
                                                     m]
@@ -411,9 +411,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 n))
+                                                        (Var 221 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 m))]
+                                                        (Var 221 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -424,7 +424,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    219
+                                                    221
                                                     b
                                                     [n
                                                     m]
@@ -435,9 +435,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 n))
+                                                        (Var 221 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 m))]
+                                                        (Var 221 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -448,7 +448,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    219
+                                                    221
                                                     i
                                                     []
                                                     Local
@@ -464,7 +464,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    219
+                                                    221
                                                     j
                                                     []
                                                     Local
@@ -480,7 +480,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    219
+                                                    221
                                                     m
                                                     []
                                                     In
@@ -496,7 +496,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    219
+                                                    221
                                                     n
                                                     []
                                                     In
@@ -512,7 +512,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    219
+                                                    221
                                                     r
                                                     [n
                                                     m]
@@ -523,9 +523,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 n))
+                                                        (Var 221 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 m))]
+                                                        (Var 221 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -599,20 +599,20 @@
                                         .false.
                                     )
                                     [add_float]
-                                    [(Var 219 n)
-                                    (Var 219 m)
-                                    (Var 219 a)
-                                    (Var 219 b)]
+                                    [(Var 221 n)
+                                    (Var 221 m)
+                                    (Var 221 a)
+                                    (Var 221 b)]
                                     [(=
-                                        (Var 219 r)
+                                        (Var 221 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Real 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 219 n))
+                                                (Var 221 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 219 m))]
+                                                (Var 221 m))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -621,10 +621,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 219 i)
+                                        ((Var 221 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 219 n)
+                                            (Var 221 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -633,10 +633,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 219 j)
+                                            ((Var 221 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 219 m)
+                                                (Var 221 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -645,12 +645,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 219 r)
+                                                    (Var 221 r)
                                                     [(()
-                                                    (Var 219 i)
+                                                    (Var 221 i)
                                                     ())
                                                     (()
-                                                    (Var 219 j)
+                                                    (Var 221 j)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
@@ -660,24 +660,24 @@
                                                     2 add_float
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 219 a)
+                                                        (Var 221 a)
                                                         [(()
-                                                        (Var 219 i)
+                                                        (Var 221 i)
                                                         ())
                                                         (()
-                                                        (Var 219 j)
+                                                        (Var 221 j)
                                                         ())]
                                                         (Real 4)
                                                         RowMajor
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 219 b)
+                                                        (Var 221 b)
                                                         [(()
-                                                        (Var 219 i)
+                                                        (Var 221 i)
                                                         ())
                                                         (()
-                                                        (Var 219 j)
+                                                        (Var 221 j)
                                                         ())]
                                                         (Real 4)
                                                         RowMajor
@@ -693,7 +693,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 219 r)
+                                            (Var 221 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -707,7 +707,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 219 _lpython_return_variable)
+                                    (Var 221 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -716,7 +716,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        220
+                                        222
                                         {
                                             
                                         })
@@ -752,11 +752,11 @@
                             add:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    211
+                                                    213
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -774,7 +774,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    211
+                                                    213
                                                     x
                                                     []
                                                     In
@@ -792,7 +792,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    211
+                                                    213
                                                     y
                                                     []
                                                     In
@@ -832,10 +832,10 @@
                                         .true.
                                     )
                                     []
-                                    [(Var 211 x)
-                                    (Var 211 y)]
+                                    [(Var 213 x)
+                                    (Var 213 y)]
                                     []
-                                    (Var 211 _lpython_return_variable)
+                                    (Var 213 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -844,11 +844,11 @@
                             add_float:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    215
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -864,7 +864,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    213
+                                                    215
                                                     x
                                                     []
                                                     In
@@ -880,7 +880,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    213
+                                                    215
                                                     y
                                                     []
                                                     In
@@ -912,21 +912,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 x)
-                                    (Var 213 y)]
+                                    [(Var 215 x)
+                                    (Var 215 y)]
                                     [(=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 215 _lpython_return_variable)
                                         (RealBinOp
-                                            (Var 213 x)
+                                            (Var 215 x)
                                             Add
-                                            (Var 213 y)
+                                            (Var 215 y)
                                             (Real 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 215 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -935,11 +935,11 @@
                             add_integer:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    212
+                                                    214
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -955,7 +955,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    212
+                                                    214
                                                     x
                                                     []
                                                     In
@@ -971,7 +971,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    212
+                                                    214
                                                     y
                                                     []
                                                     In
@@ -1003,21 +1003,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 x)
-                                    (Var 212 y)]
+                                    [(Var 214 x)
+                                    (Var 214 y)]
                                     [(=
-                                        (Var 212 _lpython_return_variable)
+                                        (Var 214 _lpython_return_variable)
                                         (IntegerBinOp
-                                            (Var 212 x)
+                                            (Var 214 x)
                                             Add
-                                            (Var 212 y)
+                                            (Var 214 y)
                                             (Integer 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 212 _lpython_return_variable)
+                                    (Var 214 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -1026,11 +1026,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        216
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    214
+                                                    216
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -1043,9 +1043,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))
+                                                        (Var 216 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 m))]
+                                                        (Var 216 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1056,7 +1056,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    214
+                                                    216
                                                     a
                                                     [n
                                                     m]
@@ -1069,9 +1069,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))
+                                                        (Var 216 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 m))]
+                                                        (Var 216 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1082,7 +1082,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    214
+                                                    216
                                                     b
                                                     [n
                                                     m]
@@ -1095,9 +1095,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))
+                                                        (Var 216 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 m))]
+                                                        (Var 216 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1108,7 +1108,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    214
+                                                    216
                                                     i
                                                     []
                                                     Local
@@ -1124,7 +1124,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    214
+                                                    216
                                                     j
                                                     []
                                                     Local
@@ -1140,7 +1140,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    214
+                                                    216
                                                     m
                                                     []
                                                     In
@@ -1156,7 +1156,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    214
+                                                    216
                                                     n
                                                     []
                                                     In
@@ -1172,7 +1172,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    214
+                                                    216
                                                     r
                                                     [n
                                                     m]
@@ -1185,9 +1185,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 n))
+                                                        (Var 216 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 214 m))]
+                                                        (Var 216 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1267,12 +1267,12 @@
                                         .false.
                                     )
                                     [add]
-                                    [(Var 214 n)
-                                    (Var 214 m)
-                                    (Var 214 a)
-                                    (Var 214 b)]
+                                    [(Var 216 n)
+                                    (Var 216 m)
+                                    (Var 216 a)
+                                    (Var 216 b)]
                                     [(=
-                                        (Var 214 r)
+                                        (Var 216 r)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1280,9 +1280,9 @@
                                                     T
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 214 n))
+                                                (Var 216 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 214 m))]
+                                                (Var 216 m))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -1291,10 +1291,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 214 i)
+                                        ((Var 216 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 214 n)
+                                            (Var 216 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -1303,10 +1303,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 214 j)
+                                            ((Var 216 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 214 m)
+                                                (Var 216 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -1315,12 +1315,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 214 r)
+                                                    (Var 216 r)
                                                     [(()
-                                                    (Var 214 i)
+                                                    (Var 216 i)
                                                     ())
                                                     (()
-                                                    (Var 214 j)
+                                                    (Var 216 j)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -1332,12 +1332,12 @@
                                                     2 add
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 214 a)
+                                                        (Var 216 a)
                                                         [(()
-                                                        (Var 214 i)
+                                                        (Var 216 i)
                                                         ())
                                                         (()
-                                                        (Var 214 j)
+                                                        (Var 216 j)
                                                         ())]
                                                         (TypeParameter
                                                             T
@@ -1346,12 +1346,12 @@
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 214 b)
+                                                        (Var 216 b)
                                                         [(()
-                                                        (Var 214 i)
+                                                        (Var 216 i)
                                                         ())
                                                         (()
-                                                        (Var 214 j)
+                                                        (Var 216 j)
                                                         ())]
                                                         (TypeParameter
                                                             T
@@ -1371,7 +1371,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 214 r)
+                                            (Var 216 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1387,7 +1387,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 214 _lpython_return_variable)
+                                    (Var 216 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -1414,11 +1414,11 @@
                             main:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        217
                                         {
                                             __lcompilers_dummy:
                                                 (Variable
-                                                    215
+                                                    217
                                                     __lcompilers_dummy
                                                     []
                                                     Local
@@ -1441,7 +1441,7 @@
                                                 ),
                                             __lcompilers_dummy1:
                                                 (Variable
-                                                    215
+                                                    217
                                                     __lcompilers_dummy1
                                                     []
                                                     Local
@@ -1464,7 +1464,7 @@
                                                 ),
                                             a_float:
                                                 (Variable
-                                                    215
+                                                    217
                                                     a_float
                                                     []
                                                     Local
@@ -1487,7 +1487,7 @@
                                                 ),
                                             a_int:
                                                 (Variable
-                                                    215
+                                                    217
                                                     a_int
                                                     []
                                                     Local
@@ -1510,7 +1510,7 @@
                                                 ),
                                             b_float:
                                                 (Variable
-                                                    215
+                                                    217
                                                     b_float
                                                     []
                                                     Local
@@ -1533,7 +1533,7 @@
                                                 ),
                                             b_int:
                                                 (Variable
-                                                    215
+                                                    217
                                                     b_int
                                                     []
                                                     Local
@@ -1574,7 +1574,7 @@
                                     __asr_generic_g_1]
                                     []
                                     [(=
-                                        (Var 215 a_int)
+                                        (Var 217 a_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1591,7 +1591,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 a_int)
+                                            (Var 217 a_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1606,7 +1606,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 b_int)
+                                        (Var 217 b_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1623,7 +1623,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 b_int)
+                                            (Var 217 b_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1638,14 +1638,14 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 __lcompilers_dummy)
+                                        (Var 217 __lcompilers_dummy)
                                         (FunctionCall
                                             2 __asr_generic_g_0
                                             ()
                                             [((IntegerConstant 1 (Integer 4)))
                                             ((IntegerConstant 1 (Integer 4)))
                                             ((ArrayPhysicalCast
-                                                (Var 215 a_int)
+                                                (Var 217 a_int)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1659,7 +1659,7 @@
                                                 ()
                                             ))
                                             ((ArrayPhysicalCast
-                                                (Var 215 b_int)
+                                                (Var 217 b_int)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1686,7 +1686,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 a_float)
+                                        (Var 217 a_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1703,7 +1703,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 a_float)
+                                            (Var 217 a_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1726,7 +1726,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 b_float)
+                                        (Var 217 b_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1743,7 +1743,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 b_float)
+                                            (Var 217 b_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1766,14 +1766,14 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 __lcompilers_dummy1)
+                                        (Var 217 __lcompilers_dummy1)
                                         (FunctionCall
                                             2 __asr_generic_g_1
                                             ()
                                             [((IntegerConstant 1 (Integer 4)))
                                             ((IntegerConstant 1 (Integer 4)))
                                             ((ArrayPhysicalCast
-                                                (Var 215 a_float)
+                                                (Var 217 a_float)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1787,7 +1787,7 @@
                                                 ()
                                             ))
                                             ((ArrayPhysicalCast
-                                                (Var 215 b_float)
+                                                (Var 217 b_float)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1848,11 +1848,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        221
+                        223
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    221
+                                    223
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1864,7 +1864,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        221 __main__global_stmts
+                        223 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-structs_05-fa98307.json
+++ b/tests/reference/asr-structs_05-fa98307.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_05-fa98307.stdout",
-    "stdout_hash": "370ee356dca208792b4f44a5657e7f2ce3da67e9ec213d3664139c70",
+    "stdout_hash": "a45fe6fa95d8afe6d018d68f32834ab3b1d6a56bb3d35b96300d95b2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_05-fa98307.stdout
+++ b/tests/reference/asr-structs_05-fa98307.stdout
@@ -10,11 +10,11 @@
                             A:
                                 (StructType
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             a:
                                                 (Variable
-                                                    211
+                                                    213
                                                     a
                                                     []
                                                     Local
@@ -30,7 +30,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    211
+                                                    213
                                                     b
                                                     []
                                                     Local
@@ -46,7 +46,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    211
+                                                    213
                                                     c
                                                     []
                                                     Local
@@ -62,7 +62,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    211
+                                                    213
                                                     d
                                                     []
                                                     Local
@@ -78,7 +78,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    211
+                                                    213
                                                     x
                                                     []
                                                     Local
@@ -94,7 +94,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    211
+                                                    213
                                                     y
                                                     []
                                                     Local
@@ -110,7 +110,7 @@
                                                 ),
                                             z:
                                                 (Variable
-                                                    211
+                                                    213
                                                     z
                                                     []
                                                     Local
@@ -151,7 +151,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        219
                                         {
                                             
                                         })
@@ -187,11 +187,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        217
                                         {
                                             y:
                                                 (Variable
-                                                    215
+                                                    217
                                                     y
                                                     []
                                                     Local
@@ -233,7 +233,7 @@
                                     update_2]
                                     []
                                     [(=
-                                        (Var 215 y)
+                                        (Var 217 y)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -250,7 +250,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 y)
+                                            (Var 217 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -310,7 +310,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 215 y)
+                                            (Var 217 y)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -372,7 +372,7 @@
                                         2 verify
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 215 y)
+                                            (Var 217 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -401,7 +401,7 @@
                                         2 update_1
                                         ()
                                         [((ArrayItem
-                                            (Var 215 y)
+                                            (Var 217 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -417,7 +417,7 @@
                                         2 update_2
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 215 y)
+                                            (Var 217 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -436,7 +436,7 @@
                                         2 verify
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 215 y)
+                                            (Var 217 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -470,11 +470,11 @@
                             update_1:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             s:
                                                 (Variable
-                                                    213
+                                                    215
                                                     s
                                                     []
                                                     InOut
@@ -509,11 +509,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 s)]
+                                    [(Var 215 s)]
                                     [(=
                                         (StructInstanceMember
-                                            (Var 213 s)
-                                            211 x
+                                            (Var 215 s)
+                                            213 x
                                             (Integer 4)
                                             ()
                                         )
@@ -522,8 +522,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 213 s)
-                                            211 y
+                                            (Var 215 s)
+                                            213 y
                                             (Real 8)
                                             ()
                                         )
@@ -535,8 +535,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 213 s)
-                                            211 z
+                                            (Var 215 s)
+                                            213 z
                                             (Integer 8)
                                             ()
                                         )
@@ -550,8 +550,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 213 s)
-                                            211 a
+                                            (Var 215 s)
+                                            213 a
                                             (Real 4)
                                             ()
                                         )
@@ -571,8 +571,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 213 s)
-                                            211 b
+                                            (Var 215 s)
+                                            213 b
                                             (Integer 2)
                                             ()
                                         )
@@ -586,8 +586,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 213 s)
-                                            211 c
+                                            (Var 215 s)
+                                            213 c
                                             (Integer 1)
                                             ()
                                         )
@@ -608,11 +608,11 @@
                             update_2:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        216
                                         {
                                             s:
                                                 (Variable
-                                                    214
+                                                    216
                                                     s
                                                     []
                                                     InOut
@@ -657,11 +657,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 s)]
+                                    [(Var 216 s)]
                                     [(=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 214 s)
+                                                (Var 216 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -671,7 +671,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            211 x
+                                            213 x
                                             (Integer 4)
                                             ()
                                         )
@@ -681,7 +681,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 214 s)
+                                                (Var 216 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -691,7 +691,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            211 y
+                                            213 y
                                             (Real 8)
                                             ()
                                         )
@@ -704,7 +704,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 214 s)
+                                                (Var 216 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -714,7 +714,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            211 z
+                                            213 z
                                             (Integer 8)
                                             ()
                                         )
@@ -729,7 +729,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 214 s)
+                                                (Var 216 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -739,7 +739,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            211 a
+                                            213 a
                                             (Real 4)
                                             ()
                                         )
@@ -760,7 +760,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 214 s)
+                                                (Var 216 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -770,7 +770,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            211 b
+                                            213 b
                                             (Integer 2)
                                             ()
                                         )
@@ -785,7 +785,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 214 s)
+                                                (Var 216 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -795,7 +795,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            211 c
+                                            213 c
                                             (Integer 1)
                                             ()
                                         )
@@ -816,11 +816,11 @@
                             verify:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             eps:
                                                 (Variable
-                                                    212
+                                                    214
                                                     eps
                                                     []
                                                     Local
@@ -836,7 +836,7 @@
                                                 ),
                                             s:
                                                 (Variable
-                                                    212
+                                                    214
                                                     s
                                                     []
                                                     InOut
@@ -859,7 +859,7 @@
                                                 ),
                                             s0:
                                                 (Variable
-                                                    212
+                                                    214
                                                     s0
                                                     []
                                                     Local
@@ -877,7 +877,7 @@
                                                 ),
                                             s1:
                                                 (Variable
-                                                    212
+                                                    214
                                                     s1
                                                     []
                                                     Local
@@ -895,7 +895,7 @@
                                                 ),
                                             x1:
                                                 (Variable
-                                                    212
+                                                    214
                                                     x1
                                                     []
                                                     In
@@ -911,7 +911,7 @@
                                                 ),
                                             x2:
                                                 (Variable
-                                                    212
+                                                    214
                                                     x2
                                                     []
                                                     In
@@ -927,7 +927,7 @@
                                                 ),
                                             y1:
                                                 (Variable
-                                                    212
+                                                    214
                                                     y1
                                                     []
                                                     In
@@ -943,7 +943,7 @@
                                                 ),
                                             y2:
                                                 (Variable
-                                                    212
+                                                    214
                                                     y2
                                                     []
                                                     In
@@ -985,13 +985,13 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 s)
-                                    (Var 212 x1)
-                                    (Var 212 y1)
-                                    (Var 212 x2)
-                                    (Var 212 y2)]
+                                    [(Var 214 s)
+                                    (Var 214 x1)
+                                    (Var 214 y1)
+                                    (Var 214 x2)
+                                    (Var 214 y2)]
                                     [(=
-                                        (Var 212 eps)
+                                        (Var 214 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -999,9 +999,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 s0)
+                                        (Var 214 s0)
                                         (ArrayItem
-                                            (Var 212 s)
+                                            (Var 214 s)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1015,44 +1015,44 @@
                                     )
                                     (Print
                                         [(StructInstanceMember
-                                            (Var 212 s0)
-                                            211 x
+                                            (Var 214 s0)
+                                            213 x
                                             (Integer 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 y
+                                            (Var 214 s0)
+                                            213 y
                                             (Real 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 z
+                                            (Var 214 s0)
+                                            213 z
                                             (Integer 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 a
+                                            (Var 214 s0)
+                                            213 a
                                             (Real 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 b
+                                            (Var 214 s0)
+                                            213 b
                                             (Integer 2)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 c
+                                            (Var 214 s0)
+                                            213 c
                                             (Integer 1)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 d
+                                            (Var 214 s0)
+                                            213 d
                                             (Logical 4)
                                             ()
                                         )]
@@ -1062,13 +1062,13 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s0)
-                                                211 x
+                                                (Var 214 s0)
+                                                213 x
                                                 (Integer 4)
                                                 ()
                                             )
                                             Eq
-                                            (Var 212 x1)
+                                            (Var 214 x1)
                                             (Logical 4)
                                             ()
                                         )
@@ -1080,13 +1080,13 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 212 s0)
-                                                        211 y
+                                                        (Var 214 s0)
+                                                        213 y
                                                         (Real 8)
                                                         ()
                                                     )
                                                     Sub
-                                                    (Var 212 y1)
+                                                    (Var 214 y1)
                                                     (Real 8)
                                                     ()
                                                 )]
@@ -1095,7 +1095,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 212 eps)
+                                            (Var 214 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -1104,14 +1104,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s0)
-                                                211 z
+                                                (Var 214 s0)
+                                                213 z
                                                 (Integer 8)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 212 x1)
+                                                (Var 214 x1)
                                                 IntegerToInteger
                                                 (Integer 8)
                                                 ()
@@ -1127,14 +1127,14 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 212 s0)
-                                                        211 a
+                                                        (Var 214 s0)
+                                                        213 a
                                                         (Real 4)
                                                         ()
                                                     )
                                                     Sub
                                                     (Cast
-                                                        (Var 212 y1)
+                                                        (Var 214 y1)
                                                         RealToReal
                                                         (Real 4)
                                                         ()
@@ -1167,14 +1167,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s0)
-                                                211 b
+                                                (Var 214 s0)
+                                                213 b
                                                 (Integer 2)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 212 x1)
+                                                (Var 214 x1)
                                                 IntegerToInteger
                                                 (Integer 2)
                                                 ()
@@ -1187,14 +1187,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s0)
-                                                211 c
+                                                (Var 214 s0)
+                                                213 c
                                                 (Integer 1)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 212 x1)
+                                                (Var 214 x1)
                                                 IntegerToInteger
                                                 (Integer 1)
                                                 ()
@@ -1206,17 +1206,17 @@
                                     )
                                     (Assert
                                         (StructInstanceMember
-                                            (Var 212 s0)
-                                            211 d
+                                            (Var 214 s0)
+                                            213 d
                                             (Logical 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (=
-                                        (Var 212 s1)
+                                        (Var 214 s1)
                                         (ArrayItem
-                                            (Var 212 s)
+                                            (Var 214 s)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -1230,44 +1230,44 @@
                                     )
                                     (Print
                                         [(StructInstanceMember
-                                            (Var 212 s1)
-                                            211 x
+                                            (Var 214 s1)
+                                            213 x
                                             (Integer 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 y
+                                            (Var 214 s1)
+                                            213 y
                                             (Real 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 z
+                                            (Var 214 s1)
+                                            213 z
                                             (Integer 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 a
+                                            (Var 214 s1)
+                                            213 a
                                             (Real 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 b
+                                            (Var 214 s1)
+                                            213 b
                                             (Integer 2)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 c
+                                            (Var 214 s1)
+                                            213 c
                                             (Integer 1)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 d
+                                            (Var 214 s1)
+                                            213 d
                                             (Logical 4)
                                             ()
                                         )]
@@ -1277,13 +1277,13 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s1)
-                                                211 x
+                                                (Var 214 s1)
+                                                213 x
                                                 (Integer 4)
                                                 ()
                                             )
                                             Eq
-                                            (Var 212 x2)
+                                            (Var 214 x2)
                                             (Logical 4)
                                             ()
                                         )
@@ -1295,13 +1295,13 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 212 s1)
-                                                        211 y
+                                                        (Var 214 s1)
+                                                        213 y
                                                         (Real 8)
                                                         ()
                                                     )
                                                     Sub
-                                                    (Var 212 y2)
+                                                    (Var 214 y2)
                                                     (Real 8)
                                                     ()
                                                 )]
@@ -1310,7 +1310,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 212 eps)
+                                            (Var 214 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -1319,14 +1319,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s1)
-                                                211 z
+                                                (Var 214 s1)
+                                                213 z
                                                 (Integer 8)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 212 x2)
+                                                (Var 214 x2)
                                                 IntegerToInteger
                                                 (Integer 8)
                                                 ()
@@ -1342,14 +1342,14 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 212 s1)
-                                                        211 a
+                                                        (Var 214 s1)
+                                                        213 a
                                                         (Real 4)
                                                         ()
                                                     )
                                                     Sub
                                                     (Cast
-                                                        (Var 212 y2)
+                                                        (Var 214 y2)
                                                         RealToReal
                                                         (Real 4)
                                                         ()
@@ -1382,14 +1382,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s1)
-                                                211 b
+                                                (Var 214 s1)
+                                                213 b
                                                 (Integer 2)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 212 x2)
+                                                (Var 214 x2)
                                                 IntegerToInteger
                                                 (Integer 2)
                                                 ()
@@ -1402,14 +1402,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 212 s1)
-                                                211 c
+                                                (Var 214 s1)
+                                                213 c
                                                 (Integer 1)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 212 x2)
+                                                (Var 214 x2)
                                                 IntegerToInteger
                                                 (Integer 1)
                                                 ()
@@ -1421,8 +1421,8 @@
                                     )
                                     (Assert
                                         (StructInstanceMember
-                                            (Var 212 s1)
-                                            211 d
+                                            (Var 214 s1)
+                                            213 d
                                             (Logical 4)
                                             ()
                                         )
@@ -1445,11 +1445,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        218
+                        220
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    218
+                                    220
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1461,7 +1461,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        218 __main__global_stmts
+                        220 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_numpy_03-e600a49.json
+++ b/tests/reference/asr-test_numpy_03-e600a49.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_03-e600a49.stdout",
-    "stdout_hash": "7f77da6be087aeb05ea730aeac6010a55558cfde8497bbbda2940736",
+    "stdout_hash": "114211056524f1f918fbf9d494aafeae75c1a95278fc3b38bae57916",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_03-e600a49.stdout
+++ b/tests/reference/asr-test_numpy_03-e600a49.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        228
+                                        230
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             test_1d_to_nd:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             a:
                                                 (Variable
-                                                    212
+                                                    214
                                                     a
                                                     []
                                                     Local
@@ -73,7 +73,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    212
+                                                    214
                                                     b
                                                     []
                                                     Local
@@ -94,7 +94,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    212
+                                                    214
                                                     c
                                                     []
                                                     Local
@@ -119,7 +119,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    212
+                                                    214
                                                     d
                                                     []
                                                     InOut
@@ -140,7 +140,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    212
+                                                    214
                                                     eps
                                                     []
                                                     Local
@@ -156,7 +156,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    212
+                                                    214
                                                     i
                                                     []
                                                     Local
@@ -172,7 +172,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    212
+                                                    214
                                                     j
                                                     []
                                                     Local
@@ -188,7 +188,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    212
+                                                    214
                                                     k
                                                     []
                                                     Local
@@ -204,7 +204,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    212
+                                                    214
                                                     l
                                                     []
                                                     Local
@@ -220,7 +220,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    212
+                                                    214
                                                     newshape
                                                     []
                                                     Local
@@ -241,7 +241,7 @@
                                                 ),
                                             newshape1:
                                                 (Variable
-                                                    212
+                                                    214
                                                     newshape1
                                                     []
                                                     Local
@@ -282,9 +282,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 212 d)]
+                                    [(Var 214 d)]
                                     [(=
-                                        (Var 212 eps)
+                                        (Var 214 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -292,7 +292,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 b)
+                                        (Var 214 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -307,7 +307,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 212 k)
+                                        ((Var 214 k)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -318,10 +318,10 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
-                                            (Var 212 i)
+                                            (Var 214 i)
                                             (IntrinsicScalarFunction
                                                 FloorDiv
-                                                [(Var 212 k)
+                                                [(Var 214 k)
                                                 (IntegerConstant 16 (Integer 4))]
                                                 0
                                                 (Integer 4)
@@ -330,12 +330,12 @@
                                             ()
                                         )
                                         (=
-                                            (Var 212 j)
+                                            (Var 214 j)
                                             (IntegerBinOp
-                                                (Var 212 k)
+                                                (Var 214 k)
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 212 i)
+                                                    (Var 214 i)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -348,9 +348,9 @@
                                         )
                                         (=
                                             (ArrayItem
-                                                (Var 212 b)
+                                                (Var 214 b)
                                                 [(()
-                                                (Var 212 k)
+                                                (Var 214 k)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -359,9 +359,9 @@
                                             (RealBinOp
                                                 (Cast
                                                     (IntegerBinOp
-                                                        (Var 212 i)
+                                                        (Var 214 i)
                                                         Add
-                                                        (Var 212 j)
+                                                        (Var 214 j)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -381,7 +381,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 212 a)
+                                        (Var 214 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -397,7 +397,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 newshape)
+                                        (Var 214 newshape)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -412,7 +412,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 212 newshape)
+                                            (Var 214 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -425,7 +425,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 212 newshape)
+                                            (Var 214 newshape)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -437,11 +437,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 a)
+                                        (Var 214 a)
                                         (ArrayReshape
-                                            (Var 212 b)
+                                            (Var 214 b)
                                             (ArrayPhysicalCast
-                                                (Var 212 newshape)
+                                                (Var 214 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -464,7 +464,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 212 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -476,7 +476,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 212 j)
+                                            ((Var 214 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -493,12 +493,12 @@
                                                         [(RealBinOp
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 212 a)
+                                                                    (Var 214 a)
                                                                     [(()
-                                                                    (Var 212 i)
+                                                                    (Var 214 i)
                                                                     ())
                                                                     (()
-                                                                    (Var 212 j)
+                                                                    (Var 214 j)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -507,9 +507,9 @@
                                                                 Sub
                                                                 (Cast
                                                                     (IntegerBinOp
-                                                                        (Var 212 i)
+                                                                        (Var 214 i)
                                                                         Add
-                                                                        (Var 212 j)
+                                                                        (Var 214 j)
                                                                         (Integer 4)
                                                                         ()
                                                                     )
@@ -533,7 +533,7 @@
                                                         ()
                                                     )
                                                     LtE
-                                                    (Var 212 eps)
+                                                    (Var 214 eps)
                                                     (Logical 4)
                                                     ()
                                                 )
@@ -542,7 +542,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 212 c)
+                                        (Var 214 c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -560,7 +560,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 newshape1)
+                                        (Var 214 newshape1)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -575,7 +575,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 212 newshape1)
+                                            (Var 214 newshape1)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -588,7 +588,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 212 newshape1)
+                                            (Var 214 newshape1)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -601,7 +601,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 212 newshape1)
+                                            (Var 214 newshape1)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -613,11 +613,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 c)
+                                        (Var 214 c)
                                         (ArrayReshape
-                                            (Var 212 d)
+                                            (Var 214 d)
                                             (ArrayPhysicalCast
-                                                (Var 212 newshape1)
+                                                (Var 214 newshape1)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -640,7 +640,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 212 i)
+                                        ((Var 214 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -652,7 +652,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 212 j)
+                                            ((Var 214 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -664,7 +664,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 212 k)
+                                                ((Var 214 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 16 (Integer 4))
@@ -681,15 +681,15 @@
                                                             [(RealBinOp
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 212 c)
+                                                                        (Var 214 c)
                                                                         [(()
-                                                                        (Var 212 i)
+                                                                        (Var 214 i)
                                                                         ())
                                                                         (()
-                                                                        (Var 212 j)
+                                                                        (Var 214 j)
                                                                         ())
                                                                         (()
-                                                                        (Var 212 k)
+                                                                        (Var 214 k)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -699,14 +699,14 @@
                                                                     (Cast
                                                                         (IntegerBinOp
                                                                             (IntegerBinOp
-                                                                                (Var 212 i)
+                                                                                (Var 214 i)
                                                                                 Add
-                                                                                (Var 212 j)
+                                                                                (Var 214 j)
                                                                                 (Integer 4)
                                                                                 ()
                                                                             )
                                                                             Add
-                                                                            (Var 212 k)
+                                                                            (Var 214 k)
                                                                             (Integer 4)
                                                                             ()
                                                                         )
@@ -730,7 +730,7 @@
                                                             ()
                                                         )
                                                         LtE
-                                                        (Var 212 eps)
+                                                        (Var 214 eps)
                                                         (Logical 4)
                                                         ()
                                                     )
@@ -748,11 +748,11 @@
                             test_nd_to_1d:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             a:
                                                 (Variable
-                                                    211
+                                                    213
                                                     a
                                                     []
                                                     InOut
@@ -775,7 +775,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    211
+                                                    213
                                                     b
                                                     []
                                                     Local
@@ -796,7 +796,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    211
+                                                    213
                                                     c
                                                     []
                                                     Local
@@ -821,7 +821,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    211
+                                                    213
                                                     d
                                                     []
                                                     Local
@@ -842,7 +842,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    211
+                                                    213
                                                     eps
                                                     []
                                                     Local
@@ -858,7 +858,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    211
+                                                    213
                                                     i
                                                     []
                                                     Local
@@ -874,7 +874,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    211
+                                                    213
                                                     j
                                                     []
                                                     Local
@@ -890,7 +890,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    211
+                                                    213
                                                     k
                                                     []
                                                     Local
@@ -906,7 +906,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    211
+                                                    213
                                                     l
                                                     []
                                                     Local
@@ -922,7 +922,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    211
+                                                    213
                                                     newshape
                                                     []
                                                     Local
@@ -943,7 +943,7 @@
                                                 ),
                                             newshape1:
                                                 (Variable
-                                                    211
+                                                    213
                                                     newshape1
                                                     []
                                                     Local
@@ -986,9 +986,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 211 a)]
+                                    [(Var 213 a)]
                                     [(=
-                                        (Var 211 eps)
+                                        (Var 213 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -996,7 +996,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 b)
+                                        (Var 213 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1010,7 +1010,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 newshape)
+                                        (Var 213 newshape)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1025,7 +1025,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 211 newshape)
+                                            (Var 213 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1037,11 +1037,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 b)
+                                        (Var 213 b)
                                         (ArrayReshape
-                                            (Var 211 a)
+                                            (Var 213 a)
                                             (ArrayPhysicalCast
-                                                (Var 211 newshape)
+                                                (Var 213 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -1064,7 +1064,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 k)
+                                        ((Var 213 k)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -1075,10 +1075,10 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
-                                            (Var 211 i)
+                                            (Var 213 i)
                                             (IntrinsicScalarFunction
                                                 FloorDiv
-                                                [(Var 211 k)
+                                                [(Var 213 k)
                                                 (IntegerConstant 16 (Integer 4))]
                                                 0
                                                 (Integer 4)
@@ -1087,12 +1087,12 @@
                                             ()
                                         )
                                         (=
-                                            (Var 211 j)
+                                            (Var 213 j)
                                             (IntegerBinOp
-                                                (Var 211 k)
+                                                (Var 213 k)
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 211 i)
+                                                    (Var 213 i)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -1110,9 +1110,9 @@
                                                     [(RealBinOp
                                                         (RealBinOp
                                                             (ArrayItem
-                                                                (Var 211 b)
+                                                                (Var 213 b)
                                                                 [(()
-                                                                (Var 211 k)
+                                                                (Var 213 k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
@@ -1121,9 +1121,9 @@
                                                             Sub
                                                             (Cast
                                                                 (IntegerBinOp
-                                                                    (Var 211 i)
+                                                                    (Var 213 i)
                                                                     Add
-                                                                    (Var 211 j)
+                                                                    (Var 213 j)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
@@ -1147,7 +1147,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 211 eps)
+                                                (Var 213 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -1155,7 +1155,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 211 c)
+                                        (Var 213 c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1173,7 +1173,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 c)
+                                        (Var 213 c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1181,462 +1181,6 @@
                                                 [((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 16 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 16 (Integer 4)))
-                                                ((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 16 (Integer 4)))]
-                                                FixedSizeArray
-                                            )
-                                            RowMajor
-                                        )
-                                        ()
-                                    )
-                                    (DoLoop
-                                        ()
-                                        ((Var 211 i)
-                                        (IntegerConstant 0 (Integer 4))
-                                        (IntegerBinOp
-                                            (IntegerConstant 16 (Integer 4))
-                                            Sub
-                                            (IntegerConstant 1 (Integer 4))
-                                            (Integer 4)
-                                            (IntegerConstant 15 (Integer 4))
-                                        )
-                                        (IntegerConstant 1 (Integer 4)))
-                                        [(DoLoop
-                                            ()
-                                            ((Var 211 j)
-                                            (IntegerConstant 0 (Integer 4))
-                                            (IntegerBinOp
-                                                (IntegerConstant 16 (Integer 4))
-                                                Sub
-                                                (IntegerConstant 1 (Integer 4))
-                                                (Integer 4)
-                                                (IntegerConstant 15 (Integer 4))
-                                            )
-                                            (IntegerConstant 1 (Integer 4)))
-                                            [(DoLoop
-                                                ()
-                                                ((Var 211 k)
-                                                (IntegerConstant 0 (Integer 4))
-                                                (IntegerBinOp
-                                                    (IntegerConstant 16 (Integer 4))
-                                                    Sub
-                                                    (IntegerConstant 1 (Integer 4))
-                                                    (Integer 4)
-                                                    (IntegerConstant 15 (Integer 4))
-                                                )
-                                                (IntegerConstant 1 (Integer 4)))
-                                                [(=
-                                                    (ArrayItem
-                                                        (Var 211 c)
-                                                        [(()
-                                                        (Var 211 i)
-                                                        ())
-                                                        (()
-                                                        (Var 211 j)
-                                                        ())
-                                                        (()
-                                                        (Var 211 k)
-                                                        ())]
-                                                        (Real 8)
-                                                        RowMajor
-                                                        ()
-                                                    )
-                                                    (RealBinOp
-                                                        (Cast
-                                                            (IntegerBinOp
-                                                                (IntegerBinOp
-                                                                    (Var 211 i)
-                                                                    Add
-                                                                    (Var 211 j)
-                                                                    (Integer 4)
-                                                                    ()
-                                                                )
-                                                                Add
-                                                                (Var 211 k)
-                                                                (Integer 4)
-                                                                ()
-                                                            )
-                                                            IntegerToReal
-                                                            (Real 8)
-                                                            ()
-                                                        )
-                                                        Add
-                                                        (RealConstant
-                                                            0.500000
-                                                            (Real 8)
-                                                        )
-                                                        (Real 8)
-                                                        ()
-                                                    )
-                                                    ()
-                                                )]
-                                            )]
-                                        )]
-                                    )
-                                    (=
-                                        (Var 211 d)
-                                        (ArrayConstant
-                                            []
-                                            (Array
-                                                (Real 8)
-                                                [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 4096 (Integer 4)))]
-                                                FixedSizeArray
-                                            )
-                                            RowMajor
-                                        )
-                                        ()
-                                    )
-                                    (=
-                                        (Var 211 newshape1)
-                                        (ArrayConstant
-                                            []
-                                            (Array
-                                                (Integer 4)
-                                                [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 1 (Integer 4)))]
-                                                FixedSizeArray
-                                            )
-                                            RowMajor
-                                        )
-                                        ()
-                                    )
-                                    (=
-                                        (ArrayItem
-                                            (Var 211 newshape1)
-                                            [(()
-                                            (IntegerConstant 0 (Integer 4))
-                                            ())]
-                                            (Integer 4)
-                                            RowMajor
-                                            ()
-                                        )
-                                        (IntegerConstant 4096 (Integer 4))
-                                        ()
-                                    )
-                                    (=
-                                        (Var 211 d)
-                                        (ArrayReshape
-                                            (Var 211 c)
-                                            (ArrayPhysicalCast
-                                                (Var 211 newshape1)
-                                                FixedSizeArray
-                                                DescriptorArray
-                                                (Array
-                                                    (Integer 4)
-                                                    [((IntegerConstant 0 (Integer 4))
-                                                    (IntegerConstant 1 (Integer 4)))]
-                                                    DescriptorArray
-                                                )
-                                                ()
-                                            )
-                                            (Array
-                                                (Real 8)
-                                                [(()
-                                                ())]
-                                                FixedSizeArray
-                                            )
-                                            ()
-                                        )
-                                        ()
-                                    )
-                                    (DoLoop
-                                        ()
-                                        ((Var 211 l)
-                                        (IntegerConstant 0 (Integer 4))
-                                        (IntegerBinOp
-                                            (IntegerConstant 4096 (Integer 4))
-                                            Sub
-                                            (IntegerConstant 1 (Integer 4))
-                                            (Integer 4)
-                                            (IntegerConstant 4095 (Integer 4))
-                                        )
-                                        (IntegerConstant 1 (Integer 4)))
-                                        [(=
-                                            (Var 211 i)
-                                            (Cast
-                                                (RealBinOp
-                                                    (Cast
-                                                        (Var 211 l)
-                                                        IntegerToReal
-                                                        (Real 8)
-                                                        ()
-                                                    )
-                                                    Div
-                                                    (Cast
-                                                        (IntegerConstant 256 (Integer 4))
-                                                        IntegerToReal
-                                                        (Real 8)
-                                                        (RealConstant
-                                                            256.000000
-                                                            (Real 8)
-                                                        )
-                                                    )
-                                                    (Real 8)
-                                                    ()
-                                                )
-                                                RealToInteger
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            ()
-                                        )
-                                        (=
-                                            (Var 211 j)
-                                            (IntrinsicScalarFunction
-                                                FloorDiv
-                                                [(IntegerBinOp
-                                                    (Var 211 l)
-                                                    Sub
-                                                    (IntegerBinOp
-                                                        (Var 211 i)
-                                                        Mul
-                                                        (IntegerConstant 256 (Integer 4))
-                                                        (Integer 4)
-                                                        ()
-                                                    )
-                                                    (Integer 4)
-                                                    ()
-                                                )
-                                                (IntegerConstant 16 (Integer 4))]
-                                                0
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            ()
-                                        )
-                                        (=
-                                            (Var 211 k)
-                                            (IntegerBinOp
-                                                (IntegerBinOp
-                                                    (Var 211 l)
-                                                    Sub
-                                                    (IntegerBinOp
-                                                        (Var 211 i)
-                                                        Mul
-                                                        (IntegerConstant 256 (Integer 4))
-                                                        (Integer 4)
-                                                        ()
-                                                    )
-                                                    (Integer 4)
-                                                    ()
-                                                )
-                                                Sub
-                                                (IntegerBinOp
-                                                    (Var 211 j)
-                                                    Mul
-                                                    (IntegerConstant 16 (Integer 4))
-                                                    (Integer 4)
-                                                    ()
-                                                )
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            ()
-                                        )
-                                        (Assert
-                                            (RealCompare
-                                                (IntrinsicScalarFunction
-                                                    Abs
-                                                    [(RealBinOp
-                                                        (RealBinOp
-                                                            (ArrayItem
-                                                                (Var 211 d)
-                                                                [(()
-                                                                (Var 211 l)
-                                                                ())]
-                                                                (Real 8)
-                                                                RowMajor
-                                                                ()
-                                                            )
-                                                            Sub
-                                                            (Cast
-                                                                (IntegerBinOp
-                                                                    (IntegerBinOp
-                                                                        (Var 211 i)
-                                                                        Add
-                                                                        (Var 211 j)
-                                                                        (Integer 4)
-                                                                        ()
-                                                                    )
-                                                                    Add
-                                                                    (Var 211 k)
-                                                                    (Integer 4)
-                                                                    ()
-                                                                )
-                                                                IntegerToReal
-                                                                (Real 8)
-                                                                ()
-                                                            )
-                                                            (Real 8)
-                                                            ()
-                                                        )
-                                                        Sub
-                                                        (RealConstant
-                                                            0.500000
-                                                            (Real 8)
-                                                        )
-                                                        (Real 8)
-                                                        ()
-                                                    )]
-                                                    0
-                                                    (Real 8)
-                                                    ()
-                                                )
-                                                LtE
-                                                (Var 211 eps)
-                                                (Logical 4)
-                                                ()
-                                            )
-                                            ()
-                                        )]
-                                    )]
-                                    ()
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            test_reshape_with_argument:
-                                (Function
-                                    (SymbolTable
-                                        213
-                                        {
-                                            a:
-                                                (Variable
-                                                    213
-                                                    a
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Array
-                                                        (Real 8)
-                                                        [((IntegerConstant 0 (Integer 4))
-                                                        (IntegerConstant 16 (Integer 4)))
-                                                        ((IntegerConstant 0 (Integer 4))
-                                                        (IntegerConstant 16 (Integer 4)))]
-                                                        FixedSizeArray
-                                                    )
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            d:
-                                                (Variable
-                                                    213
-                                                    d
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Array
-                                                        (Real 8)
-                                                        [((IntegerConstant 0 (Integer 4))
-                                                        (IntegerConstant 4096 (Integer 4)))]
-                                                        FixedSizeArray
-                                                    )
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            i:
-                                                (Variable
-                                                    213
-                                                    i
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            j:
-                                                (Variable
-                                                    213
-                                                    j
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            k:
-                                                (Variable
-                                                    213
-                                                    k
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            l:
-                                                (Variable
-                                                    213
-                                                    l
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                )
-                                        })
-                                    test_reshape_with_argument
-                                    (FunctionType
-                                        []
-                                        ()
-                                        Source
-                                        Implementation
-                                        ()
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        []
-                                        .false.
-                                    )
-                                    [test_nd_to_1d
-                                    test_1d_to_nd]
-                                    []
-                                    [(=
-                                        (Var 213 a)
-                                        (ArrayConstant
-                                            []
-                                            (Array
-                                                (Real 8)
-                                                [((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 16 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 16 (Integer 4)))]
@@ -1670,62 +1214,65 @@
                                                 (IntegerConstant 15 (Integer 4))
                                             )
                                             (IntegerConstant 1 (Integer 4)))
-                                            [(=
-                                                (ArrayItem
-                                                    (Var 213 a)
-                                                    [(()
-                                                    (Var 213 i)
-                                                    ())
-                                                    (()
-                                                    (Var 213 j)
-                                                    ())]
-                                                    (Real 8)
-                                                    RowMajor
-                                                    ()
+                                            [(DoLoop
+                                                ()
+                                                ((Var 213 k)
+                                                (IntegerConstant 0 (Integer 4))
+                                                (IntegerBinOp
+                                                    (IntegerConstant 16 (Integer 4))
+                                                    Sub
+                                                    (IntegerConstant 1 (Integer 4))
+                                                    (Integer 4)
+                                                    (IntegerConstant 15 (Integer 4))
                                                 )
-                                                (RealBinOp
-                                                    (Cast
-                                                        (IntegerBinOp
-                                                            (Var 213 i)
-                                                            Add
-                                                            (Var 213 j)
-                                                            (Integer 4)
+                                                (IntegerConstant 1 (Integer 4)))
+                                                [(=
+                                                    (ArrayItem
+                                                        (Var 213 c)
+                                                        [(()
+                                                        (Var 213 i)
+                                                        ())
+                                                        (()
+                                                        (Var 213 j)
+                                                        ())
+                                                        (()
+                                                        (Var 213 k)
+                                                        ())]
+                                                        (Real 8)
+                                                        RowMajor
+                                                        ()
+                                                    )
+                                                    (RealBinOp
+                                                        (Cast
+                                                            (IntegerBinOp
+                                                                (IntegerBinOp
+                                                                    (Var 213 i)
+                                                                    Add
+                                                                    (Var 213 j)
+                                                                    (Integer 4)
+                                                                    ()
+                                                                )
+                                                                Add
+                                                                (Var 213 k)
+                                                                (Integer 4)
+                                                                ()
+                                                            )
+                                                            IntegerToReal
+                                                            (Real 8)
                                                             ()
                                                         )
-                                                        IntegerToReal
+                                                        Add
+                                                        (RealConstant
+                                                            0.500000
+                                                            (Real 8)
+                                                        )
                                                         (Real 8)
                                                         ()
                                                     )
-                                                    Add
-                                                    (RealConstant
-                                                        0.500000
-                                                        (Real 8)
-                                                    )
-                                                    (Real 8)
                                                     ()
-                                                )
-                                                ()
+                                                )]
                                             )]
                                         )]
-                                    )
-                                    (SubroutineCall
-                                        2 test_nd_to_1d
-                                        ()
-                                        [((ArrayPhysicalCast
-                                            (Var 213 a)
-                                            FixedSizeArray
-                                            DescriptorArray
-                                            (Array
-                                                (Real 8)
-                                                [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 16 (Integer 4)))
-                                                ((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 16 (Integer 4)))]
-                                                DescriptorArray
-                                            )
-                                            ()
-                                        ))]
-                                        ()
                                     )
                                     (=
                                         (Var 213 d)
@@ -1738,6 +1285,59 @@
                                                 FixedSizeArray
                                             )
                                             RowMajor
+                                        )
+                                        ()
+                                    )
+                                    (=
+                                        (Var 213 newshape1)
+                                        (ArrayConstant
+                                            []
+                                            (Array
+                                                (Integer 4)
+                                                [((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 1 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            RowMajor
+                                        )
+                                        ()
+                                    )
+                                    (=
+                                        (ArrayItem
+                                            (Var 213 newshape1)
+                                            [(()
+                                            (IntegerConstant 0 (Integer 4))
+                                            ())]
+                                            (Integer 4)
+                                            RowMajor
+                                            ()
+                                        )
+                                        (IntegerConstant 4096 (Integer 4))
+                                        ()
+                                    )
+                                    (=
+                                        (Var 213 d)
+                                        (ArrayReshape
+                                            (Var 213 c)
+                                            (ArrayPhysicalCast
+                                                (Var 213 newshape1)
+                                                FixedSizeArray
+                                                DescriptorArray
+                                                (Array
+                                                    (Integer 4)
+                                                    [((IntegerConstant 0 (Integer 4))
+                                                    (IntegerConstant 1 (Integer 4)))]
+                                                    DescriptorArray
+                                                )
+                                                ()
+                                            )
+                                            (Array
+                                                (Real 8)
+                                                [(()
+                                                ())]
+                                                FixedSizeArray
+                                            )
+                                            ()
                                         )
                                         ()
                                     )
@@ -1835,11 +1435,411 @@
                                             )
                                             ()
                                         )
+                                        (Assert
+                                            (RealCompare
+                                                (IntrinsicScalarFunction
+                                                    Abs
+                                                    [(RealBinOp
+                                                        (RealBinOp
+                                                            (ArrayItem
+                                                                (Var 213 d)
+                                                                [(()
+                                                                (Var 213 l)
+                                                                ())]
+                                                                (Real 8)
+                                                                RowMajor
+                                                                ()
+                                                            )
+                                                            Sub
+                                                            (Cast
+                                                                (IntegerBinOp
+                                                                    (IntegerBinOp
+                                                                        (Var 213 i)
+                                                                        Add
+                                                                        (Var 213 j)
+                                                                        (Integer 4)
+                                                                        ()
+                                                                    )
+                                                                    Add
+                                                                    (Var 213 k)
+                                                                    (Integer 4)
+                                                                    ()
+                                                                )
+                                                                IntegerToReal
+                                                                (Real 8)
+                                                                ()
+                                                            )
+                                                            (Real 8)
+                                                            ()
+                                                        )
+                                                        Sub
+                                                        (RealConstant
+                                                            0.500000
+                                                            (Real 8)
+                                                        )
+                                                        (Real 8)
+                                                        ()
+                                                    )]
+                                                    0
+                                                    (Real 8)
+                                                    ()
+                                                )
+                                                LtE
+                                                (Var 213 eps)
+                                                (Logical 4)
+                                                ()
+                                            )
+                                            ()
+                                        )]
+                                    )]
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            test_reshape_with_argument:
+                                (Function
+                                    (SymbolTable
+                                        215
+                                        {
+                                            a:
+                                                (Variable
+                                                    215
+                                                    a
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 8)
+                                                        [((IntegerConstant 0 (Integer 4))
+                                                        (IntegerConstant 16 (Integer 4)))
+                                                        ((IntegerConstant 0 (Integer 4))
+                                                        (IntegerConstant 16 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            d:
+                                                (Variable
+                                                    215
+                                                    d
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 8)
+                                                        [((IntegerConstant 0 (Integer 4))
+                                                        (IntegerConstant 4096 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            i:
+                                                (Variable
+                                                    215
+                                                    i
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            j:
+                                                (Variable
+                                                    215
+                                                    j
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            k:
+                                                (Variable
+                                                    215
+                                                    k
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            l:
+                                                (Variable
+                                                    215
+                                                    l
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    test_reshape_with_argument
+                                    (FunctionType
+                                        []
+                                        ()
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    [test_nd_to_1d
+                                    test_1d_to_nd]
+                                    []
+                                    [(=
+                                        (Var 215 a)
+                                        (ArrayConstant
+                                            []
+                                            (Array
+                                                (Real 8)
+                                                [((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 16 (Integer 4)))
+                                                ((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 16 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            RowMajor
+                                        )
+                                        ()
+                                    )
+                                    (DoLoop
+                                        ()
+                                        ((Var 215 i)
+                                        (IntegerConstant 0 (Integer 4))
+                                        (IntegerBinOp
+                                            (IntegerConstant 16 (Integer 4))
+                                            Sub
+                                            (IntegerConstant 1 (Integer 4))
+                                            (Integer 4)
+                                            (IntegerConstant 15 (Integer 4))
+                                        )
+                                        (IntegerConstant 1 (Integer 4)))
+                                        [(DoLoop
+                                            ()
+                                            ((Var 215 j)
+                                            (IntegerConstant 0 (Integer 4))
+                                            (IntegerBinOp
+                                                (IntegerConstant 16 (Integer 4))
+                                                Sub
+                                                (IntegerConstant 1 (Integer 4))
+                                                (Integer 4)
+                                                (IntegerConstant 15 (Integer 4))
+                                            )
+                                            (IntegerConstant 1 (Integer 4)))
+                                            [(=
+                                                (ArrayItem
+                                                    (Var 215 a)
+                                                    [(()
+                                                    (Var 215 i)
+                                                    ())
+                                                    (()
+                                                    (Var 215 j)
+                                                    ())]
+                                                    (Real 8)
+                                                    RowMajor
+                                                    ()
+                                                )
+                                                (RealBinOp
+                                                    (Cast
+                                                        (IntegerBinOp
+                                                            (Var 215 i)
+                                                            Add
+                                                            (Var 215 j)
+                                                            (Integer 4)
+                                                            ()
+                                                        )
+                                                        IntegerToReal
+                                                        (Real 8)
+                                                        ()
+                                                    )
+                                                    Add
+                                                    (RealConstant
+                                                        0.500000
+                                                        (Real 8)
+                                                    )
+                                                    (Real 8)
+                                                    ()
+                                                )
+                                                ()
+                                            )]
+                                        )]
+                                    )
+                                    (SubroutineCall
+                                        2 test_nd_to_1d
+                                        ()
+                                        [((ArrayPhysicalCast
+                                            (Var 215 a)
+                                            FixedSizeArray
+                                            DescriptorArray
+                                            (Array
+                                                (Real 8)
+                                                [((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 16 (Integer 4)))
+                                                ((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 16 (Integer 4)))]
+                                                DescriptorArray
+                                            )
+                                            ()
+                                        ))]
+                                        ()
+                                    )
+                                    (=
+                                        (Var 215 d)
+                                        (ArrayConstant
+                                            []
+                                            (Array
+                                                (Real 8)
+                                                [((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 4096 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            RowMajor
+                                        )
+                                        ()
+                                    )
+                                    (DoLoop
+                                        ()
+                                        ((Var 215 l)
+                                        (IntegerConstant 0 (Integer 4))
+                                        (IntegerBinOp
+                                            (IntegerConstant 4096 (Integer 4))
+                                            Sub
+                                            (IntegerConstant 1 (Integer 4))
+                                            (Integer 4)
+                                            (IntegerConstant 4095 (Integer 4))
+                                        )
+                                        (IntegerConstant 1 (Integer 4)))
+                                        [(=
+                                            (Var 215 i)
+                                            (Cast
+                                                (RealBinOp
+                                                    (Cast
+                                                        (Var 215 l)
+                                                        IntegerToReal
+                                                        (Real 8)
+                                                        ()
+                                                    )
+                                                    Div
+                                                    (Cast
+                                                        (IntegerConstant 256 (Integer 4))
+                                                        IntegerToReal
+                                                        (Real 8)
+                                                        (RealConstant
+                                                            256.000000
+                                                            (Real 8)
+                                                        )
+                                                    )
+                                                    (Real 8)
+                                                    ()
+                                                )
+                                                RealToInteger
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            ()
+                                        )
+                                        (=
+                                            (Var 215 j)
+                                            (IntrinsicScalarFunction
+                                                FloorDiv
+                                                [(IntegerBinOp
+                                                    (Var 215 l)
+                                                    Sub
+                                                    (IntegerBinOp
+                                                        (Var 215 i)
+                                                        Mul
+                                                        (IntegerConstant 256 (Integer 4))
+                                                        (Integer 4)
+                                                        ()
+                                                    )
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (IntegerConstant 16 (Integer 4))]
+                                                0
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            ()
+                                        )
+                                        (=
+                                            (Var 215 k)
+                                            (IntegerBinOp
+                                                (IntegerBinOp
+                                                    (Var 215 l)
+                                                    Sub
+                                                    (IntegerBinOp
+                                                        (Var 215 i)
+                                                        Mul
+                                                        (IntegerConstant 256 (Integer 4))
+                                                        (Integer 4)
+                                                        ()
+                                                    )
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                Sub
+                                                (IntegerBinOp
+                                                    (Var 215 j)
+                                                    Mul
+                                                    (IntegerConstant 16 (Integer 4))
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            ()
+                                        )
                                         (=
                                             (ArrayItem
-                                                (Var 213 d)
+                                                (Var 215 d)
                                                 [(()
-                                                (Var 213 l)
+                                                (Var 215 l)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -1849,14 +1849,14 @@
                                                 (Cast
                                                     (IntegerBinOp
                                                         (IntegerBinOp
-                                                            (Var 213 i)
+                                                            (Var 215 i)
                                                             Add
-                                                            (Var 213 j)
+                                                            (Var 215 j)
                                                             (Integer 4)
                                                             ()
                                                         )
                                                         Add
-                                                        (Var 213 k)
+                                                        (Var 215 k)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -1879,7 +1879,7 @@
                                         2 test_1d_to_nd
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 213 d)
+                                            (Var 215 d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1909,11 +1909,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        229
+                        231
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    229
+                                    231
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1925,7 +1925,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        229 __main__global_stmts
+                        231 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_numpy_04-ecbb614.json
+++ b/tests/reference/asr-test_numpy_04-ecbb614.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_04-ecbb614.stdout",
-    "stdout_hash": "1da36df6cdd76caa08790fe22f8bff306736f6f61ca8c0e9535528ed",
+    "stdout_hash": "24066681e1eb081bc9287e3065e2938a40ce102e83756f71c7464b60",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_04-ecbb614.stdout
+++ b/tests/reference/asr-test_numpy_04-ecbb614.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        216
                                         {
                                             
                                         })
@@ -46,7 +46,7 @@
                             check:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        215
                                         {
                                             
                                         })
@@ -89,11 +89,11 @@
                             test_array_01:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             eps:
                                                 (Variable
-                                                    211
+                                                    213
                                                     eps
                                                     []
                                                     Local
@@ -109,7 +109,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    211
+                                                    213
                                                     x
                                                     []
                                                     Local
@@ -147,7 +147,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 211 x)
+                                        (Var 213 x)
                                         (ArrayConstant
                                             [(RealConstant
                                                 1.000000
@@ -172,7 +172,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 eps)
+                                        (Var 213 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -185,7 +185,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 211 x)
+                                                        (Var 213 x)
                                                         [(()
                                                         (IntegerConstant 0 (Integer 4))
                                                         ())]
@@ -206,7 +206,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 211 eps)
+                                            (Var 213 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -218,7 +218,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 211 x)
+                                                        (Var 213 x)
                                                         [(()
                                                         (IntegerConstant 1 (Integer 4))
                                                         ())]
@@ -239,7 +239,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 211 eps)
+                                            (Var 213 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -251,7 +251,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 211 x)
+                                                        (Var 213 x)
                                                         [(()
                                                         (IntegerConstant 2 (Integer 4))
                                                         ())]
@@ -272,7 +272,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 211 eps)
+                                            (Var 213 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -287,11 +287,11 @@
                             test_array_02:
                                 (Function
                                     (SymbolTable
-                                        212
+                                        214
                                         {
                                             eps:
                                                 (Variable
-                                                    212
+                                                    214
                                                     eps
                                                     []
                                                     Local
@@ -307,7 +307,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    212
+                                                    214
                                                     x
                                                     []
                                                     Local
@@ -345,7 +345,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 212 x)
+                                        (Var 214 x)
                                         (ArrayConstant
                                             [(IntegerConstant 1 (Integer 4))
                                             (IntegerConstant 2 (Integer 4))
@@ -361,7 +361,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 212 eps)
+                                        (Var 214 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -375,7 +375,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 212 x)
+                                                            (Var 214 x)
                                                             [(()
                                                             (IntegerConstant 0 (Integer 4))
                                                             ())]
@@ -397,7 +397,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 212 eps)
+                                            (Var 214 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -410,7 +410,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 212 x)
+                                                            (Var 214 x)
                                                             [(()
                                                             (IntegerConstant 1 (Integer 4))
                                                             ())]
@@ -432,7 +432,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 212 eps)
+                                            (Var 214 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -445,7 +445,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 212 x)
+                                                            (Var 214 x)
                                                             [(()
                                                             (IntegerConstant 2 (Integer 4))
                                                             ())]
@@ -467,7 +467,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 212 eps)
+                                            (Var 214 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -490,11 +490,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        215
+                        217
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    215
+                                    217
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -506,7 +506,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        215 __main__global_stmts
+                        217 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-vec_01-66ac423.json
+++ b/tests/reference/asr-vec_01-66ac423.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-vec_01-66ac423.stdout",
-    "stdout_hash": "2e2b41cdaa38cabb5b6dee642fdbade4259561a9ab1b06f21dce79f4",
+    "stdout_hash": "2c09e8d2e737d230a66aa6804cb871e71bcb54ea665e16b4cea1538c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-vec_01-66ac423.stdout
+++ b/tests/reference/asr-vec_01-66ac423.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        217
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             loop_vec:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             a:
                                                 (Variable
-                                                    211
+                                                    213
                                                     a
                                                     []
                                                     Local
@@ -71,7 +71,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    211
+                                                    213
                                                     b
                                                     []
                                                     Local
@@ -92,7 +92,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    211
+                                                    213
                                                     i
                                                     []
                                                     Local
@@ -125,7 +125,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 211 a)
+                                        (Var 213 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -139,7 +139,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 b)
+                                        (Var 213 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -154,7 +154,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 213 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -166,9 +166,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 211 b)
+                                                (Var 213 b)
                                                 [(()
-                                                (Var 211 i)
+                                                (Var 213 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -183,7 +183,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 213 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -195,18 +195,18 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 211 a)
+                                                (Var 213 a)
                                                 [(()
-                                                (Var 211 i)
+                                                (Var 213 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (ArrayItem
-                                                (Var 211 b)
+                                                (Var 213 b)
                                                 [(()
-                                                (Var 211 i)
+                                                (Var 213 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -217,7 +217,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 213 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -230,9 +230,9 @@
                                         [(Assert
                                             (RealCompare
                                                 (ArrayItem
-                                                    (Var 211 a)
+                                                    (Var 213 a)
                                                     [(()
-                                                    (Var 211 i)
+                                                    (Var 213 i)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -266,11 +266,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        216
+                        218
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    216
+                                    218
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -282,7 +282,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        216 __main__global_stmts
+                        218 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/pass_loop_vectorise-vec_01-be9985e.json
+++ b/tests/reference/pass_loop_vectorise-vec_01-be9985e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_loop_vectorise-vec_01-be9985e.stdout",
-    "stdout_hash": "20734037fd1fecf92e8421c6b558117fc0a2831ddbcbd1b2877485d4",
+    "stdout_hash": "87dc60df76e2bb9964f92e4c52c4104df2232195a75968724f9faf67",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_loop_vectorise-vec_01-be9985e.stdout
+++ b/tests/reference/pass_loop_vectorise-vec_01-be9985e.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        217
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             loop_vec:
                                 (Function
                                     (SymbolTable
-                                        211
+                                        213
                                         {
                                             a:
                                                 (Variable
-                                                    211
+                                                    213
                                                     a
                                                     []
                                                     Local
@@ -71,7 +71,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    211
+                                                    213
                                                     b
                                                     []
                                                     Local
@@ -92,7 +92,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    211
+                                                    213
                                                     i
                                                     []
                                                     Local
@@ -109,11 +109,11 @@
                                             vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization:
                                                 (Function
                                                     (SymbolTable
-                                                        217
+                                                        219
                                                         {
                                                             __1_k:
                                                                 (Variable
-                                                                    217
+                                                                    219
                                                                     __1_k
                                                                     []
                                                                     Local
@@ -129,7 +129,7 @@
                                                                 ),
                                                             arg0:
                                                                 (Variable
-                                                                    217
+                                                                    219
                                                                     arg0
                                                                     []
                                                                     In
@@ -150,7 +150,7 @@
                                                                 ),
                                                             arg1:
                                                                 (Variable
-                                                                    217
+                                                                    219
                                                                     arg1
                                                                     []
                                                                     In
@@ -171,7 +171,7 @@
                                                                 ),
                                                             arg2:
                                                                 (Variable
-                                                                    217
+                                                                    219
                                                                     arg2
                                                                     []
                                                                     In
@@ -187,7 +187,7 @@
                                                                 ),
                                                             arg3:
                                                                 (Variable
-                                                                    217
+                                                                    219
                                                                     arg3
                                                                     []
                                                                     In
@@ -203,7 +203,7 @@
                                                                 ),
                                                             arg4:
                                                                 (Variable
-                                                                    217
+                                                                    219
                                                                     arg4
                                                                     []
                                                                     In
@@ -219,7 +219,7 @@
                                                                 ),
                                                             arg5:
                                                                 (Variable
-                                                                    217
+                                                                    219
                                                                     arg5
                                                                     []
                                                                     In
@@ -265,18 +265,18 @@
                                                         .false.
                                                     )
                                                     []
-                                                    [(Var 217 arg0)
-                                                    (Var 217 arg1)
-                                                    (Var 217 arg2)
-                                                    (Var 217 arg3)
-                                                    (Var 217 arg4)
-                                                    (Var 217 arg5)]
+                                                    [(Var 219 arg0)
+                                                    (Var 219 arg1)
+                                                    (Var 219 arg2)
+                                                    (Var 219 arg3)
+                                                    (Var 219 arg4)
+                                                    (Var 219 arg5)]
                                                     [(=
-                                                        (Var 217 __1_k)
+                                                        (Var 219 __1_k)
                                                         (IntegerBinOp
-                                                            (Var 217 arg2)
+                                                            (Var 219 arg2)
                                                             Sub
-                                                            (Var 217 arg4)
+                                                            (Var 219 arg4)
                                                             (Integer 4)
                                                             ()
                                                         )
@@ -286,23 +286,23 @@
                                                         ()
                                                         (IntegerCompare
                                                             (IntegerBinOp
-                                                                (Var 217 __1_k)
+                                                                (Var 219 __1_k)
                                                                 Add
-                                                                (Var 217 arg4)
+                                                                (Var 219 arg4)
                                                                 (Integer 4)
                                                                 ()
                                                             )
                                                             Lt
-                                                            (Var 217 arg3)
+                                                            (Var 219 arg3)
                                                             (Logical 4)
                                                             ()
                                                         )
                                                         [(=
-                                                            (Var 217 __1_k)
+                                                            (Var 219 __1_k)
                                                             (IntegerBinOp
-                                                                (Var 217 __1_k)
+                                                                (Var 219 __1_k)
                                                                 Add
-                                                                (Var 217 arg4)
+                                                                (Var 219 arg4)
                                                                 (Integer 4)
                                                                 ()
                                                             )
@@ -310,18 +310,18 @@
                                                         )
                                                         (=
                                                             (ArrayItem
-                                                                (Var 217 arg0)
+                                                                (Var 219 arg0)
                                                                 [(()
-                                                                (Var 217 __1_k)
+                                                                (Var 219 __1_k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
                                                                 ()
                                                             )
                                                             (ArrayItem
-                                                                (Var 217 arg1)
+                                                                (Var 219 arg1)
                                                                 [(()
-                                                                (Var 217 __1_k)
+                                                                (Var 219 __1_k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
@@ -355,7 +355,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 211 a)
+                                        (Var 213 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -369,7 +369,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 211 b)
+                                        (Var 213 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -384,7 +384,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 213 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -396,9 +396,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 211 b)
+                                                (Var 213 b)
                                                 [(()
-                                                (Var 211 i)
+                                                (Var 213 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -413,17 +413,17 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 213 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerConstant 1151 (Integer 4))
                                         (IntegerConstant 1 (Integer 4)))
                                         [(SubroutineCall
-                                            211 vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization
+                                            213 vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization
                                             ()
-                                            [((Var 211 a))
-                                            ((Var 211 b))
+                                            [((Var 213 a))
+                                            ((Var 213 b))
                                             ((IntegerBinOp
-                                                (Var 211 i)
+                                                (Var 213 i)
                                                 Mul
                                                 (IntegerConstant 8 (Integer 4))
                                                 (Integer 4)
@@ -431,7 +431,7 @@
                                             ))
                                             ((IntegerBinOp
                                                 (IntegerBinOp
-                                                    (Var 211 i)
+                                                    (Var 213 i)
                                                     Add
                                                     (IntegerConstant 1 (Integer 4))
                                                     (Integer 4)
@@ -449,7 +449,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 211 i)
+                                        ((Var 213 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -462,9 +462,9 @@
                                         [(Assert
                                             (RealCompare
                                                 (ArrayItem
-                                                    (Var 211 a)
+                                                    (Var 213 a)
                                                     [(()
-                                                    (Var 211 i)
+                                                    (Var 213 i)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -498,11 +498,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        216
+                        218
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    216
+                                    218
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -514,7 +514,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        216 __main__global_stmts
+                        218 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()


### PR DESCRIPTION
- In this PR, I have added functionality for `hypot()` in numpy. 
- This can now be imported using: `from numpy import hypot`
- The function has been tested for both 1d and 2d arrays.