### PR TITLE
Added APIs isalnum() and isnumeric() in string object

### DIFF
--- a/integration_tests/test_str_attributes.py
+++ b/integration_tests/test_str_attributes.py
@@ -366,7 +366,69 @@ def is_space():
     s = ""
     assert s.isspace() == False
 
+def is_alnum():
+    a: str = "helloworld"
+    b: str = "hj kl"
+    c: str = "a12(){}A"
+    d: str = " "
+    e: str = ""
+    f: str = "ab23"
+    g: str = "ab2%3"
+    res: bool = a.isalnum()
+    res2: bool = b.isalnum()
+    res3: bool = c.isalnum()
+    res4: bool = d.isalnum()
+    res5: bool = e.isalnum()
+    res6: bool = f.isalnum()
+    res7: bool = g.isalnum()
 
+    assert res == True
+    assert res2 == False
+    assert res3 == False
+    assert res4 == False
+    assert res5 == False
+    assert res6 == True
+    assert res7 == False
+
+    assert "helloworld".isalnum() == True
+    assert "hj kl".isalnum() == False
+    assert "a12(){}A".isalnum() == False
+    assert " ".isalnum() == False
+    assert "".isalnum() == False
+    assert "ab23".isalnum() == True
+    assert "ab2%3".isalnum() == False
+
+def is_numeric():
+    a: str = "123"
+    b: str = "12 34"
+    c: str = "-123"
+    d: str = "12.3"
+    e: str = " "
+    f: str = ""
+    g: str = "ab2%3"
+    res: bool = a.isnumeric()
+    res2: bool = b.isnumeric()
+    res3: bool = c.isnumeric()
+    res4: bool = d.isnumeric()
+    res5: bool = e.isnumeric()
+    res6: bool = f.isnumeric()
+    res7: bool = g.isnumeric()
+
+    assert res == True
+    assert res2 == False
+    assert res3 == False
+    assert res4 == False
+    assert res5 == False
+    assert res6 == False
+    assert res7 == False
+
+    assert "123".isnumeric() == True
+    assert "12 34".isnumeric() == False
+    assert "-123".isnumeric() == False
+    assert "12.3".isnumeric() == False
+    assert " ".isnumeric() == False
+    assert "".isnumeric() == False
+    assert "ab2%3".isnumeric() == False
 
 def check():
     capitalize()
@@ -386,6 +448,8 @@ def check():
     is_alpha()
     is_title()
     is_space()
+    is_alnum()
+    is_numeric()
 
 
 check()

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6793,7 +6793,7 @@ public:
             /*
                 String Validation Methods i.e all "is" based functions are handled here
             */
-            std::vector<std::string> validation_methods{"lower", "upper", "decimal", "ascii", "space", "alpha", "title"};  // Database of validation methods supported
+            std::vector<std::string> validation_methods{"lower", "upper", "decimal", "ascii", "space", "alpha", "title", "alnum", "numeric"};  // Database of validation methods supported
             std::string method_name = attr_name.substr(2);
 
             if(std::find(validation_methods.begin(),validation_methods.end(), method_name) == validation_methods.end()) {
@@ -7096,7 +7096,7 @@ public:
                 * islower() method is limited to English Alphabets currently
                 * TODO: We can support other characters from Unicode Library
             */
-            std::vector<std::string> validation_methods{"lower", "upper", "decimal", "ascii", "space", "alpha", "title"};  // Database of validation methods supported
+            std::vector<std::string> validation_methods{"lower", "upper", "decimal", "ascii", "space", "alpha", "title", "alnum", "numeric"};  // Database of validation methods supported
             std::string method_name = attr_name.substr(2);
             if(std::find(validation_methods.begin(),validation_methods.end(), method_name) == validation_methods.end()) {
                 throw SemanticError("String method not implemented: " + attr_name, loc);
@@ -7208,6 +7208,38 @@ we will have to use something else.
                     }
                 }
                 tmp = ASR::make_LogicalConstant_t(al, loc, is_alpha,
+                        ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)));
+                return;
+            } else if (attr_name == "isalnum") {
+                /*
+                    * Specification -
+                    Return True if all characters in the string are alphabets or numbers, 
+                    and there is at least one character in the string.
+                */
+                bool is_alnum = (s_var.size() != 0);
+                for (auto &i : s_var) {
+                    if (!((i >= 'A' && i <= 'Z') || (i >= 'a' && i <= 'z') || (i >= '0' && i <= '9'))) {
+                        is_alnum = false;
+                        break;
+                    }
+                }
+                tmp = ASR::make_LogicalConstant_t(al, loc, is_alnum,
+                        ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)));
+                return;
+            } else if (attr_name == "isnumeric") {
+                /*
+                    * Specification -
+                    Return True if all characters in the string are numbers, 
+                    and there is at least one character in the string.
+                */
+                bool is_numeric = (s_var.size() != 0);
+                for (auto &i : s_var) {
+                    if (!(i >= '0' && i <= '9')) {
+                        is_numeric = false;
+                        break;
+                    }
+                }
+                tmp = ASR::make_LogicalConstant_t(al, loc, is_numeric,
                         ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)));
                 return;
             } else if (attr_name == "istitle") {

--- a/src/lpython/semantics/python_comptime_eval.h
+++ b/src/lpython/semantics/python_comptime_eval.h
@@ -83,6 +83,8 @@ struct PythonIntrinsicProcedures {
             {"_lpython_str_join", {m_builtin, &not_implemented}},
             {"_lpython_str_find", {m_builtin, &not_implemented}},
             {"_lpython_str_isalpha", {m_builtin, &not_implemented}},
+            {"_lpython_str_isalnum", {m_builtin, &not_implemented}},
+            {"_lpython_str_isnumeric", {m_builtin, &not_implemented}},
             {"_lpython_str_title", {m_builtin, &not_implemented}},
             {"_lpython_str_istitle", {m_builtin, &not_implemented}},
             {"_lpython_str_rstrip", {m_builtin, &not_implemented}},

--- a/src/runtime/lpython_builtin.py
+++ b/src/runtime/lpython_builtin.py
@@ -730,6 +730,30 @@ def _lpython_str_isalpha(s: str) -> bool:
         return False
     return True
 
+def _lpython_str_isalnum(s: str) -> bool:
+    ch: str
+    if len(s) == 0: return False
+    for ch in s:
+        ch_ord: i32 = ord(ch)
+        if 65 <= ch_ord and ch_ord <= 90:
+            continue
+        if 97 <= ch_ord and ch_ord <= 122:
+            continue
+        if 48 <= ch_ord and ch_ord <= 57:
+            continue
+        return False
+    return True
+
+def _lpython_str_isnumeric(s: str) -> bool:
+    ch: str
+    if len(s) == 0: return False
+    for ch in s:
+        ch_ord: i32 = ord(ch)
+        if 48 <= ch_ord and ch_ord <= 57:
+            continue
+        return False
+    return True
+
 def _lpython_str_title(s: str) -> str:
     result: str = ""
     capitalize_next: bool = True

--- a/tests/reference/asr-array_01_decl-39cf894.json
+++ b/tests/reference/asr-array_01_decl-39cf894.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_01_decl-39cf894.stdout",
-    "stdout_hash": "d167f932ab4a4bb559ae3b4bb3b983cd6153a105cfb6180474e64ae2",
+    "stdout_hash": "7e3c68aa6acba27674e544f894bb141357db82f8840c756af448f5bb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_01_decl-39cf894.stdout
+++ b/tests/reference/asr-array_01_decl-39cf894.stdout
@@ -10,11 +10,11 @@
                             ArraySizes:
                                 (EnumType
                                     (SymbolTable
-                                        213
+                                        217
                                         {
                                             SIZE_10:
                                                 (Variable
-                                                    213
+                                                    217
                                                     SIZE_10
                                                     []
                                                     Local
@@ -30,7 +30,7 @@
                                                 ),
                                             SIZE_3:
                                                 (Variable
-                                                    213
+                                                    217
                                                     SIZE_3
                                                     []
                                                     Local
@@ -58,7 +58,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        220
+                                        224
                                         {
                                             
                                         })
@@ -94,11 +94,11 @@
                             accept_f32_array:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        221
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    217
+                                                    221
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -114,7 +114,7 @@
                                                 ),
                                             xf32:
                                                 (Variable
-                                                    217
+                                                    221
                                                     xf32
                                                     []
                                                     InOut
@@ -155,10 +155,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 217 xf32)]
+                                    [(Var 221 xf32)]
                                     [(=
                                         (ArrayItem
-                                            (Var 217 xf32)
+                                            (Var 221 xf32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -181,9 +181,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 _lpython_return_variable)
+                                        (Var 221 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 217 xf32)
+                                            (Var 221 xf32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -194,7 +194,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 217 _lpython_return_variable)
+                                    (Var 221 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -203,11 +203,11 @@
                             accept_f64_array:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        222
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    218
+                                                    222
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -223,7 +223,7 @@
                                                 ),
                                             xf64:
                                                 (Variable
-                                                    218
+                                                    222
                                                     xf64
                                                     []
                                                     InOut
@@ -264,10 +264,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 218 xf64)]
+                                    [(Var 222 xf64)]
                                     [(=
                                         (ArrayItem
-                                            (Var 218 xf64)
+                                            (Var 222 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -282,9 +282,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 _lpython_return_variable)
+                                        (Var 222 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 218 xf64)
+                                            (Var 222 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -295,7 +295,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 218 _lpython_return_variable)
+                                    (Var 222 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -304,11 +304,11 @@
                             accept_i16_array:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        218
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    214
+                                                    218
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -324,7 +324,7 @@
                                                 ),
                                             xi16:
                                                 (Variable
-                                                    214
+                                                    218
                                                     xi16
                                                     []
                                                     InOut
@@ -365,10 +365,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 xi16)]
+                                    [(Var 218 xi16)]
                                     [(=
                                         (ArrayItem
-                                            (Var 214 xi16)
+                                            (Var 218 xi16)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -385,9 +385,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 _lpython_return_variable)
+                                        (Var 218 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 214 xi16)
+                                            (Var 218 xi16)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -398,7 +398,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 214 _lpython_return_variable)
+                                    (Var 218 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -407,11 +407,11 @@
                             accept_i32_array:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        219
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    215
+                                                    219
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -427,7 +427,7 @@
                                                 ),
                                             xi32:
                                                 (Variable
-                                                    215
+                                                    219
                                                     xi32
                                                     []
                                                     InOut
@@ -468,10 +468,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 215 xi32)]
+                                    [(Var 219 xi32)]
                                     [(=
                                         (ArrayItem
-                                            (Var 215 xi32)
+                                            (Var 219 xi32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -483,9 +483,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 _lpython_return_variable)
+                                        (Var 219 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 215 xi32)
+                                            (Var 219 xi32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -496,7 +496,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 215 _lpython_return_variable)
+                                    (Var 219 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -505,11 +505,11 @@
                             accept_i64_array:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        220
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    216
+                                                    220
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -525,7 +525,7 @@
                                                 ),
                                             xi64:
                                                 (Variable
-                                                    216
+                                                    220
                                                     xi64
                                                     []
                                                     InOut
@@ -566,10 +566,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 216 xi64)]
+                                    [(Var 220 xi64)]
                                     [(=
                                         (ArrayItem
-                                            (Var 216 xi64)
+                                            (Var 220 xi64)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -586,9 +586,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 216 _lpython_return_variable)
+                                        (Var 220 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 216 xi64)
+                                            (Var 220 xi64)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -599,7 +599,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 216 _lpython_return_variable)
+                                    (Var 220 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -608,11 +608,11 @@
                             declare_arrays:
                                 (Function
                                     (SymbolTable
-                                        219
+                                        223
                                         {
                                             ac32:
                                                 (Variable
-                                                    219
+                                                    223
                                                     ac32
                                                     []
                                                     Local
@@ -633,7 +633,7 @@
                                                 ),
                                             ac64:
                                                 (Variable
-                                                    219
+                                                    223
                                                     ac64
                                                     []
                                                     Local
@@ -654,7 +654,7 @@
                                                 ),
                                             af32:
                                                 (Variable
-                                                    219
+                                                    223
                                                     af32
                                                     []
                                                     Local
@@ -675,7 +675,7 @@
                                                 ),
                                             af64:
                                                 (Variable
-                                                    219
+                                                    223
                                                     af64
                                                     []
                                                     Local
@@ -696,7 +696,7 @@
                                                 ),
                                             ai16:
                                                 (Variable
-                                                    219
+                                                    223
                                                     ai16
                                                     []
                                                     Local
@@ -717,7 +717,7 @@
                                                 ),
                                             ai32:
                                                 (Variable
-                                                    219
+                                                    223
                                                     ai32
                                                     []
                                                     Local
@@ -738,7 +738,7 @@
                                                 ),
                                             ai64:
                                                 (Variable
-                                                    219
+                                                    223
                                                     ai64
                                                     []
                                                     Local
@@ -780,7 +780,7 @@
                                     accept_f64_array]
                                     []
                                     [(=
-                                        (Var 219 ai16)
+                                        (Var 223 ai16)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -794,7 +794,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 219 ai32)
+                                        (Var 223 ai32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -808,7 +808,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 219 ai64)
+                                        (Var 223 ai64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -822,7 +822,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 219 af32)
+                                        (Var 223 af32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -836,7 +836,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 219 af64)
+                                        (Var 223 af64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -850,7 +850,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 219 ac32)
+                                        (Var 223 ac32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -864,7 +864,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 219 ac64)
+                                        (Var 223 ac64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -882,7 +882,7 @@
                                             2 accept_i16_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 219 ai16)
+                                                (Var 223 ai16)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -905,7 +905,7 @@
                                             2 accept_i32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 219 ai32)
+                                                (Var 223 ai32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -928,7 +928,7 @@
                                             2 accept_i64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 219 ai64)
+                                                (Var 223 ai64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -951,7 +951,7 @@
                                             2 accept_f32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 219 af32)
+                                                (Var 223 af32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -974,7 +974,7 @@
                                             2 accept_f64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 219 af64)
+                                                (Var 223 af64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -1009,11 +1009,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        221
+                        225
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    221
+                                    225
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1025,7 +1025,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        221 __main__global_stmts
+                        225 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-array_02_decl-e8f6874.json
+++ b/tests/reference/asr-array_02_decl-e8f6874.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_02_decl-e8f6874.stdout",
-    "stdout_hash": "a85bf9e005195a013607a8f2b7492215183cbae4b1e52882d47b8b02",
+    "stdout_hash": "438ea76f5f3d93052f2d8fdd138cc3fb05400a21ff8379f346473bd1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_02_decl-e8f6874.stdout
+++ b/tests/reference/asr-array_02_decl-e8f6874.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        222
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             accept_multidim_f32_array:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        219
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    215
+                                                    219
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -66,7 +66,7 @@
                                                 ),
                                             xf32:
                                                 (Variable
-                                                    215
+                                                    219
                                                     xf32
                                                     []
                                                     InOut
@@ -107,11 +107,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 215 xf32)]
+                                    [(Var 219 xf32)]
                                     [(=
-                                        (Var 215 _lpython_return_variable)
+                                        (Var 219 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 215 xf32)
+                                            (Var 219 xf32)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -122,7 +122,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 215 _lpython_return_variable)
+                                    (Var 219 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -131,11 +131,11 @@
                             accept_multidim_f64_array:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        220
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    216
+                                                    220
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -151,7 +151,7 @@
                                                 ),
                                             xf64:
                                                 (Variable
-                                                    216
+                                                    220
                                                     xf64
                                                     []
                                                     InOut
@@ -196,11 +196,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 216 xf64)]
+                                    [(Var 220 xf64)]
                                     [(=
-                                        (Var 216 _lpython_return_variable)
+                                        (Var 220 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 216 xf64)
+                                            (Var 220 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -214,7 +214,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 216 _lpython_return_variable)
+                                    (Var 220 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -223,11 +223,11 @@
                             accept_multidim_i32_array:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        217
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    217
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -243,7 +243,7 @@
                                                 ),
                                             xi32:
                                                 (Variable
-                                                    213
+                                                    217
                                                     xi32
                                                     []
                                                     InOut
@@ -288,11 +288,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 xi32)]
+                                    [(Var 217 xi32)]
                                     [(=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 217 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 213 xi32)
+                                            (Var 217 xi32)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -306,7 +306,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 217 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -315,11 +315,11 @@
                             accept_multidim_i64_array:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        218
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    214
+                                                    218
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -335,7 +335,7 @@
                                                 ),
                                             xi64:
                                                 (Variable
-                                                    214
+                                                    218
                                                     xi64
                                                     []
                                                     InOut
@@ -384,11 +384,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 xi64)]
+                                    [(Var 218 xi64)]
                                     [(=
-                                        (Var 214 _lpython_return_variable)
+                                        (Var 218 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 214 xi64)
+                                            (Var 218 xi64)
                                             [(()
                                             (IntegerConstant 9 (Integer 4))
                                             ())
@@ -405,7 +405,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 214 _lpython_return_variable)
+                                    (Var 218 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -414,11 +414,11 @@
                             declare_arrays:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        221
                                         {
                                             ac32:
                                                 (Variable
-                                                    217
+                                                    221
                                                     ac32
                                                     []
                                                     Local
@@ -443,7 +443,7 @@
                                                 ),
                                             ac64:
                                                 (Variable
-                                                    217
+                                                    221
                                                     ac64
                                                     []
                                                     Local
@@ -470,7 +470,7 @@
                                                 ),
                                             af32:
                                                 (Variable
-                                                    217
+                                                    221
                                                     af32
                                                     []
                                                     Local
@@ -491,7 +491,7 @@
                                                 ),
                                             af64:
                                                 (Variable
-                                                    217
+                                                    221
                                                     af64
                                                     []
                                                     Local
@@ -514,7 +514,7 @@
                                                 ),
                                             ai32:
                                                 (Variable
-                                                    217
+                                                    221
                                                     ai32
                                                     []
                                                     Local
@@ -537,7 +537,7 @@
                                                 ),
                                             ai64:
                                                 (Variable
-                                                    217
+                                                    221
                                                     ai64
                                                     []
                                                     Local
@@ -582,7 +582,7 @@
                                     accept_multidim_f64_array]
                                     []
                                     [(=
-                                        (Var 217 ai32)
+                                        (Var 221 ai32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -598,7 +598,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 ai64)
+                                        (Var 221 ai64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -616,7 +616,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 af32)
+                                        (Var 221 af32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -630,7 +630,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 af64)
+                                        (Var 221 af64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -646,7 +646,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 ac32)
+                                        (Var 221 ac32)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -664,7 +664,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 ac64)
+                                        (Var 221 ac64)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -688,7 +688,7 @@
                                             2 accept_multidim_i32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 ai32)
+                                                (Var 221 ai32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -713,7 +713,7 @@
                                             2 accept_multidim_i64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 ai64)
+                                                (Var 221 ai64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -740,7 +740,7 @@
                                             2 accept_multidim_f32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 af32)
+                                                (Var 221 af32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -763,7 +763,7 @@
                                             2 accept_multidim_f64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 217 af64)
+                                                (Var 221 af64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -800,11 +800,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        219
+                        223
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    219
+                                    223
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -816,7 +816,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        219 __main__global_stmts
+                        223 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-bindc_02-bc1a7ea.json
+++ b/tests/reference/asr-bindc_02-bc1a7ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-bindc_02-bc1a7ea.stdout",
-    "stdout_hash": "dcbadfda0430682f5e14ae9eb1ddccb91f68b3def7cb8218c2fc9c06",
+    "stdout_hash": "d5ffa96b3a5833d2e0c9cc6d5c13086223bfba3bb53de623b1c4058a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-bindc_02-bc1a7ea.stdout
+++ b/tests/reference/asr-bindc_02-bc1a7ea.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        218
                                         {
                                             
                                         })
@@ -76,11 +76,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        217
                                         {
                                             y:
                                                 (Variable
-                                                    213
+                                                    217
                                                     y
                                                     []
                                                     Local
@@ -101,7 +101,7 @@
                                                 ),
                                             yptr1:
                                                 (Variable
-                                                    213
+                                                    217
                                                     yptr1
                                                     []
                                                     Local
@@ -124,7 +124,7 @@
                                                 ),
                                             yq:
                                                 (Variable
-                                                    213
+                                                    217
                                                     yq
                                                     []
                                                     Local
@@ -157,14 +157,14 @@
                                     []
                                     []
                                     [(=
-                                        (Var 213 yq)
+                                        (Var 217 yq)
                                         (PointerNullConstant
                                             (CPtr)
                                         )
                                         ()
                                     )
                                     (=
-                                        (Var 213 y)
+                                        (Var 217 y)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -179,7 +179,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 y)
+                                            (Var 217 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -197,7 +197,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 y)
+                                            (Var 217 y)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -214,9 +214,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 yptr1)
+                                        (Var 217 yptr1)
                                         (GetPointer
-                                            (Var 213 y)
+                                            (Var 217 y)
                                             (Pointer
                                                 (Array
                                                     (Integer 2)
@@ -231,7 +231,7 @@
                                     )
                                     (Print
                                         [(GetPointer
-                                            (Var 213 y)
+                                            (Var 217 y)
                                             (Pointer
                                                 (Array
                                                     (Integer 2)
@@ -242,13 +242,13 @@
                                             )
                                             ()
                                         )
-                                        (Var 213 yptr1)]
+                                        (Var 217 yptr1)]
                                         ()
                                         ()
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 213 yptr1)
+                                            (Var 217 yptr1)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -257,7 +257,7 @@
                                             ()
                                         )
                                         (ArrayItem
-                                            (Var 213 yptr1)
+                                            (Var 217 yptr1)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -271,7 +271,7 @@
                                     (Assert
                                         (IntegerCompare
                                             (ArrayItem
-                                                (Var 213 yptr1)
+                                                (Var 217 yptr1)
                                                 [(()
                                                 (IntegerConstant 0 (Integer 4))
                                                 ())]
@@ -294,7 +294,7 @@
                                     (Assert
                                         (IntegerCompare
                                             (ArrayItem
-                                                (Var 213 yptr1)
+                                                (Var 217 yptr1)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -315,8 +315,8 @@
                                         ()
                                     )
                                     (CPtrToPointer
-                                        (Var 213 yq)
-                                        (Var 213 yptr1)
+                                        (Var 217 yq)
+                                        (Var 217 yptr1)
                                         (ArrayConstant
                                             [(IntegerConstant 2 (Integer 4))]
                                             (Array
@@ -339,8 +339,8 @@
                                         )
                                     )
                                     (Print
-                                        [(Var 213 yq)
-                                        (Var 213 yptr1)]
+                                        [(Var 217 yq)
+                                        (Var 217 yptr1)]
                                         ()
                                         ()
                                     )]
@@ -404,11 +404,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        215
+                        219
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    215
+                                    219
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -420,7 +420,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        215 __main__global_stmts
+                        219 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-cast-435c233.json
+++ b/tests/reference/asr-cast-435c233.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-cast-435c233.stdout",
-    "stdout_hash": "da51ce5078b2a34b978ae26fc76fb325b261a218555466a38aeeec6a",
+    "stdout_hash": "e568a4235ef2ea5a21a03f280baf6e18a4a83f2a9b1d804d695a185d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-cast-435c233.stdout
+++ b/tests/reference/asr-cast-435c233.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        133
                                         {
                                             
                                         })
@@ -285,11 +285,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        134
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    134
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -301,7 +301,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        134 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-complex1-f26c460.json
+++ b/tests/reference/asr-complex1-f26c460.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-complex1-f26c460.stdout",
-    "stdout_hash": "7c3f0d1d66094c100e19a8b2b83c3589ece73fc7224de1e618a4f4c2",
+    "stdout_hash": "22dc4c9b17e4d9a3d251c7b52d71603358cb8003e3d1b5bf520965cb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-complex1-f26c460.stdout
+++ b/tests/reference/asr-complex1-f26c460.stdout
@@ -776,7 +776,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        134
                         {
                             
                         })

--- a/tests/reference/asr-constants1-5828e8a.json
+++ b/tests/reference/asr-constants1-5828e8a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-constants1-5828e8a.stdout",
-    "stdout_hash": "417211efafb2f2d5bb5defcc9f4de14b6e4c0945c52c0a5f53c75d49",
+    "stdout_hash": "52b5b013e314db6e9bfdc763cfc5d57b06dc3cdadcf143d7de20cb96",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-constants1-5828e8a.stdout
+++ b/tests/reference/asr-constants1-5828e8a.stdout
@@ -1778,7 +1778,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        138
+                        142
                         {
                             
                         })

--- a/tests/reference/asr-elemental_01-b58df26.json
+++ b/tests/reference/asr-elemental_01-b58df26.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-elemental_01-b58df26.stdout",
-    "stdout_hash": "3d90c8b22b8857e98ea441b7224d8e5104cefd038cbd72353a82babf",
+    "stdout_hash": "60bd6f26f1332d2a618ddb3f459ce1a31ce710db3f2ec4fba1d1c751",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-elemental_01-b58df26.stdout
+++ b/tests/reference/asr-elemental_01-b58df26.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        246
+                                        250
                                         {
                                             
                                         })
@@ -84,11 +84,11 @@
                             elemental_cos:
                                 (Function
                                     (SymbolTable
-                                        221
+                                        225
                                         {
                                             array2d:
                                                 (Variable
-                                                    221
+                                                    225
                                                     array2d
                                                     []
                                                     Local
@@ -111,7 +111,7 @@
                                                 ),
                                             cos2d:
                                                 (Variable
-                                                    221
+                                                    225
                                                     cos2d
                                                     []
                                                     Local
@@ -134,7 +134,7 @@
                                                 ),
                                             cos@__lpython_overloaded_0__cos:
                                                 (ExternalSymbol
-                                                    221
+                                                    225
                                                     cos@__lpython_overloaded_0__cos
                                                     3 __lpython_overloaded_0__cos
                                                     numpy
@@ -144,7 +144,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    221
+                                                    225
                                                     i
                                                     []
                                                     Local
@@ -160,7 +160,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    221
+                                                    225
                                                     j
                                                     []
                                                     Local
@@ -193,7 +193,7 @@
                                     [verify2d]
                                     []
                                     [(=
-                                        (Var 221 array2d)
+                                        (Var 225 array2d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -209,7 +209,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 221 cos2d)
+                                        (Var 225 cos2d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -226,7 +226,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 221 i)
+                                        ((Var 225 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -238,7 +238,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 221 j)
+                                            ((Var 225 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 64 (Integer 4))
@@ -250,12 +250,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 221 array2d)
+                                                    (Var 225 array2d)
                                                     [(()
-                                                    (Var 221 i)
+                                                    (Var 225 i)
                                                     ())
                                                     (()
-                                                    (Var 221 j)
+                                                    (Var 225 j)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -263,9 +263,9 @@
                                                 )
                                                 (Cast
                                                     (IntegerBinOp
-                                                        (Var 221 i)
+                                                        (Var 225 i)
                                                         Add
-                                                        (Var 221 j)
+                                                        (Var 225 j)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -278,12 +278,12 @@
                                         )]
                                     )
                                     (=
-                                        (Var 221 cos2d)
+                                        (Var 225 cos2d)
                                         (RealBinOp
                                             (FunctionCall
-                                                221 cos@__lpython_overloaded_0__cos
+                                                225 cos@__lpython_overloaded_0__cos
                                                 2 cos
-                                                [((Var 221 array2d))]
+                                                [((Var 225 array2d))]
                                                 (Array
                                                     (Real 8)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -316,7 +316,7 @@
                                         2 verify2d
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 221 array2d)
+                                            (Var 225 array2d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -330,7 +330,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 221 cos2d)
+                                            (Var 225 cos2d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -356,11 +356,11 @@
                             elemental_mul:
                                 (Function
                                     (SymbolTable
-                                        219
+                                        223
                                         {
                                             array_a:
                                                 (Variable
-                                                    219
+                                                    223
                                                     array_a
                                                     []
                                                     Local
@@ -381,7 +381,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    219
+                                                    223
                                                     array_b
                                                     []
                                                     Local
@@ -402,7 +402,7 @@
                                                 ),
                                             array_c:
                                                 (Variable
-                                                    219
+                                                    223
                                                     array_c
                                                     []
                                                     Local
@@ -423,7 +423,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    219
+                                                    223
                                                     i
                                                     []
                                                     Local
@@ -439,7 +439,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    219
+                                                    223
                                                     j
                                                     []
                                                     Local
@@ -455,7 +455,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    219
+                                                    223
                                                     k
                                                     []
                                                     Local
@@ -488,7 +488,7 @@
                                     [verify1d_mul]
                                     []
                                     [(=
-                                        (Var 219 array_a)
+                                        (Var 223 array_a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -502,7 +502,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 219 array_b)
+                                        (Var 223 array_b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -516,7 +516,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 219 array_c)
+                                        (Var 223 array_c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -531,7 +531,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 219 i)
+                                        ((Var 223 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -543,16 +543,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 219 array_a)
+                                                (Var 223 array_a)
                                                 [(()
-                                                (Var 219 i)
+                                                (Var 223 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 219 i)
+                                                (Var 223 i)
                                                 IntegerToReal
                                                 (Real 8)
                                                 ()
@@ -562,7 +562,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 219 j)
+                                        ((Var 223 j)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -574,9 +574,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 219 array_b)
+                                                (Var 223 array_b)
                                                 [(()
-                                                (Var 219 j)
+                                                (Var 223 j)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -584,7 +584,7 @@
                                             )
                                             (Cast
                                                 (IntegerBinOp
-                                                    (Var 219 j)
+                                                    (Var 223 j)
                                                     Add
                                                     (IntegerConstant 5 (Integer 4))
                                                     (Integer 4)
@@ -598,11 +598,11 @@
                                         )]
                                     )
                                     (=
-                                        (Var 219 array_c)
+                                        (Var 223 array_c)
                                         (RealBinOp
                                             (RealBinOp
                                                 (RealBinOp
-                                                    (Var 219 array_a)
+                                                    (Var 223 array_a)
                                                     Pow
                                                     (RealConstant
                                                         2.000000
@@ -631,7 +631,7 @@
                                             )
                                             Mul
                                             (RealBinOp
-                                                (Var 219 array_b)
+                                                (Var 223 array_b)
                                                 Pow
                                                 (RealConstant
                                                     3.000000
@@ -659,7 +659,7 @@
                                         2 verify1d_mul
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 219 array_a)
+                                            (Var 223 array_a)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -671,7 +671,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 219 array_b)
+                                            (Var 223 array_b)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -683,7 +683,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 219 array_c)
+                                            (Var 223 array_c)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -706,11 +706,11 @@
                             elemental_sin:
                                 (Function
                                     (SymbolTable
-                                        220
+                                        224
                                         {
                                             array1d:
                                                 (Variable
-                                                    220
+                                                    224
                                                     array1d
                                                     []
                                                     Local
@@ -731,7 +731,7 @@
                                                 ),
                                             arraynd:
                                                 (Variable
-                                                    220
+                                                    224
                                                     arraynd
                                                     []
                                                     Local
@@ -756,7 +756,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    220
+                                                    224
                                                     i
                                                     []
                                                     Local
@@ -772,7 +772,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    220
+                                                    224
                                                     j
                                                     []
                                                     Local
@@ -788,7 +788,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    220
+                                                    224
                                                     k
                                                     []
                                                     Local
@@ -804,7 +804,7 @@
                                                 ),
                                             sin1d:
                                                 (Variable
-                                                    220
+                                                    224
                                                     sin1d
                                                     []
                                                     Local
@@ -825,7 +825,7 @@
                                                 ),
                                             sin@__lpython_overloaded_0__sin:
                                                 (ExternalSymbol
-                                                    220
+                                                    224
                                                     sin@__lpython_overloaded_0__sin
                                                     3 __lpython_overloaded_0__sin
                                                     numpy
@@ -835,7 +835,7 @@
                                                 ),
                                             sin@__lpython_overloaded_1__sin:
                                                 (ExternalSymbol
-                                                    220
+                                                    224
                                                     sin@__lpython_overloaded_1__sin
                                                     3 __lpython_overloaded_1__sin
                                                     numpy
@@ -845,7 +845,7 @@
                                                 ),
                                             sinnd:
                                                 (Variable
-                                                    220
+                                                    224
                                                     sinnd
                                                     []
                                                     Local
@@ -888,7 +888,7 @@
                                     verifynd]
                                     []
                                     [(=
-                                        (Var 220 array1d)
+                                        (Var 224 array1d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -902,7 +902,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 sin1d)
+                                        (Var 224 sin1d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -917,7 +917,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 220 i)
+                                        ((Var 224 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -929,16 +929,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 220 array1d)
+                                                (Var 224 array1d)
                                                 [(()
-                                                (Var 220 i)
+                                                (Var 224 i)
                                                 ())]
                                                 (Real 4)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 220 i)
+                                                (Var 224 i)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -947,14 +947,14 @@
                                         )]
                                     )
                                     (=
-                                        (Var 220 sin1d)
+                                        (Var 224 sin1d)
                                         (FunctionCall
-                                            220 sin@__lpython_overloaded_1__sin
+                                            224 sin@__lpython_overloaded_1__sin
                                             2 sin
                                             [((FunctionCall
-                                                220 sin@__lpython_overloaded_1__sin
+                                                224 sin@__lpython_overloaded_1__sin
                                                 2 sin
-                                                [((Var 220 array1d))]
+                                                [((Var 224 array1d))]
                                                 (Array
                                                     (Real 4)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -979,7 +979,7 @@
                                         2 verify1d
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 220 array1d)
+                                            (Var 224 array1d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -991,7 +991,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 220 sin1d)
+                                            (Var 224 sin1d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1006,7 +1006,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 arraynd)
+                                        (Var 224 arraynd)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1024,7 +1024,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 220 sinnd)
+                                        (Var 224 sinnd)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1043,7 +1043,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 220 i)
+                                        ((Var 224 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 200 (Integer 4))
@@ -1055,7 +1055,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 220 j)
+                                            ((Var 224 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 64 (Integer 4))
@@ -1067,7 +1067,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 220 k)
+                                                ((Var 224 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 16 (Integer 4))
@@ -1079,15 +1079,15 @@
                                                 (IntegerConstant 1 (Integer 4)))
                                                 [(=
                                                     (ArrayItem
-                                                        (Var 220 arraynd)
+                                                        (Var 224 arraynd)
                                                         [(()
-                                                        (Var 220 i)
+                                                        (Var 224 i)
                                                         ())
                                                         (()
-                                                        (Var 220 j)
+                                                        (Var 224 j)
                                                         ())
                                                         (()
-                                                        (Var 220 k)
+                                                        (Var 224 k)
                                                         ())]
                                                         (Real 8)
                                                         RowMajor
@@ -1096,14 +1096,14 @@
                                                     (Cast
                                                         (IntegerBinOp
                                                             (IntegerBinOp
-                                                                (Var 220 i)
+                                                                (Var 224 i)
                                                                 Add
-                                                                (Var 220 j)
+                                                                (Var 224 j)
                                                                 (Integer 4)
                                                                 ()
                                                             )
                                                             Add
-                                                            (Var 220 k)
+                                                            (Var 224 k)
                                                             (Integer 4)
                                                             ()
                                                         )
@@ -1117,12 +1117,12 @@
                                         )]
                                     )
                                     (=
-                                        (Var 220 sinnd)
+                                        (Var 224 sinnd)
                                         (RealBinOp
                                             (FunctionCall
-                                                220 sin@__lpython_overloaded_0__sin
+                                                224 sin@__lpython_overloaded_0__sin
                                                 2 sin
-                                                [((Var 220 arraynd))]
+                                                [((Var 224 arraynd))]
                                                 (Array
                                                     (Real 8)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -1159,7 +1159,7 @@
                                         2 verifynd
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 220 arraynd)
+                                            (Var 224 arraynd)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1175,7 +1175,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 220 sinnd)
+                                            (Var 224 sinnd)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1204,11 +1204,11 @@
                             elemental_sum:
                                 (Function
                                     (SymbolTable
-                                        218
+                                        222
                                         {
                                             array_a:
                                                 (Variable
-                                                    218
+                                                    222
                                                     array_a
                                                     []
                                                     Local
@@ -1229,7 +1229,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    218
+                                                    222
                                                     array_b
                                                     []
                                                     Local
@@ -1250,7 +1250,7 @@
                                                 ),
                                             array_c:
                                                 (Variable
-                                                    218
+                                                    222
                                                     array_c
                                                     []
                                                     Local
@@ -1271,7 +1271,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    218
+                                                    222
                                                     i
                                                     []
                                                     Local
@@ -1287,7 +1287,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    218
+                                                    222
                                                     j
                                                     []
                                                     Local
@@ -1303,7 +1303,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    218
+                                                    222
                                                     k
                                                     []
                                                     Local
@@ -1336,7 +1336,7 @@
                                     [verify1d_sum]
                                     []
                                     [(=
-                                        (Var 218 array_a)
+                                        (Var 222 array_a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1350,7 +1350,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 array_b)
+                                        (Var 222 array_b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1364,7 +1364,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 218 array_c)
+                                        (Var 222 array_c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1379,7 +1379,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 218 i)
+                                        ((Var 222 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -1391,16 +1391,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 218 array_a)
+                                                (Var 222 array_a)
                                                 [(()
-                                                (Var 218 i)
+                                                (Var 222 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 218 i)
+                                                (Var 222 i)
                                                 IntegerToReal
                                                 (Real 8)
                                                 ()
@@ -1410,7 +1410,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 218 j)
+                                        ((Var 222 j)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -1422,9 +1422,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 218 array_b)
+                                                (Var 222 array_b)
                                                 [(()
-                                                (Var 218 j)
+                                                (Var 222 j)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -1432,7 +1432,7 @@
                                             )
                                             (Cast
                                                 (IntegerBinOp
-                                                    (Var 218 j)
+                                                    (Var 222 j)
                                                     Add
                                                     (IntegerConstant 5 (Integer 4))
                                                     (Integer 4)
@@ -1446,10 +1446,10 @@
                                         )]
                                     )
                                     (=
-                                        (Var 218 array_c)
+                                        (Var 222 array_c)
                                         (RealBinOp
                                             (RealBinOp
-                                                (Var 218 array_a)
+                                                (Var 222 array_a)
                                                 Pow
                                                 (RealConstant
                                                     2.000000
@@ -1471,7 +1471,7 @@
                                                 )
                                                 Mul
                                                 (RealBinOp
-                                                    (Var 218 array_b)
+                                                    (Var 222 array_b)
                                                     Pow
                                                     (RealConstant
                                                         3.000000
@@ -1507,7 +1507,7 @@
                                         2 verify1d_sum
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 218 array_a)
+                                            (Var 222 array_a)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1519,7 +1519,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 218 array_b)
+                                            (Var 222 array_b)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1531,7 +1531,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 218 array_c)
+                                            (Var 222 array_c)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1554,11 +1554,11 @@
                             elemental_trig_identity:
                                 (Function
                                     (SymbolTable
-                                        222
+                                        226
                                         {
                                             arraynd:
                                                 (Variable
-                                                    222
+                                                    226
                                                     arraynd
                                                     []
                                                     Local
@@ -1585,7 +1585,7 @@
                                                 ),
                                             cos@__lpython_overloaded_1__cos:
                                                 (ExternalSymbol
-                                                    222
+                                                    226
                                                     cos@__lpython_overloaded_1__cos
                                                     3 __lpython_overloaded_1__cos
                                                     numpy
@@ -1595,7 +1595,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    222
+                                                    226
                                                     eps
                                                     []
                                                     Local
@@ -1611,7 +1611,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    222
+                                                    226
                                                     i
                                                     []
                                                     Local
@@ -1627,7 +1627,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    222
+                                                    226
                                                     j
                                                     []
                                                     Local
@@ -1643,7 +1643,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    222
+                                                    226
                                                     k
                                                     []
                                                     Local
@@ -1659,7 +1659,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    222
+                                                    226
                                                     l
                                                     []
                                                     Local
@@ -1675,7 +1675,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    222
+                                                    226
                                                     newshape
                                                     []
                                                     Local
@@ -1696,7 +1696,7 @@
                                                 ),
                                             observed:
                                                 (Variable
-                                                    222
+                                                    226
                                                     observed
                                                     []
                                                     Local
@@ -1723,7 +1723,7 @@
                                                 ),
                                             observed1d:
                                                 (Variable
-                                                    222
+                                                    226
                                                     observed1d
                                                     []
                                                     Local
@@ -1744,7 +1744,7 @@
                                                 ),
                                             sin@__lpython_overloaded_1__sin:
                                                 (ExternalSymbol
-                                                    222
+                                                    226
                                                     sin@__lpython_overloaded_1__sin
                                                     3 __lpython_overloaded_1__sin
                                                     numpy
@@ -1771,7 +1771,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 222 eps)
+                                        (Var 226 eps)
                                         (Cast
                                             (RealConstant
                                                 0.000001
@@ -1787,7 +1787,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 222 arraynd)
+                                        (Var 226 arraynd)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1807,7 +1807,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 222 observed)
+                                        (Var 226 observed)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1827,7 +1827,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 222 observed1d)
+                                        (Var 226 observed1d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1842,7 +1842,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 222 i)
+                                        ((Var 226 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 64 (Integer 4))
@@ -1854,7 +1854,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 222 j)
+                                            ((Var 226 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 32 (Integer 4))
@@ -1866,7 +1866,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 222 k)
+                                                ((Var 226 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 8 (Integer 4))
@@ -1878,7 +1878,7 @@
                                                 (IntegerConstant 1 (Integer 4)))
                                                 [(DoLoop
                                                     ()
-                                                    ((Var 222 l)
+                                                    ((Var 226 l)
                                                     (IntegerConstant 0 (Integer 4))
                                                     (IntegerBinOp
                                                         (IntegerConstant 4 (Integer 4))
@@ -1890,18 +1890,18 @@
                                                     (IntegerConstant 1 (Integer 4)))
                                                     [(=
                                                         (ArrayItem
-                                                            (Var 222 arraynd)
+                                                            (Var 226 arraynd)
                                                             [(()
-                                                            (Var 222 i)
+                                                            (Var 226 i)
                                                             ())
                                                             (()
-                                                            (Var 222 j)
+                                                            (Var 226 j)
                                                             ())
                                                             (()
-                                                            (Var 222 k)
+                                                            (Var 226 k)
                                                             ())
                                                             (()
-                                                            (Var 222 l)
+                                                            (Var 226 l)
                                                             ())]
                                                             (Real 4)
                                                             RowMajor
@@ -1911,19 +1911,19 @@
                                                             (IntegerBinOp
                                                                 (IntegerBinOp
                                                                     (IntegerBinOp
-                                                                        (Var 222 i)
+                                                                        (Var 226 i)
                                                                         Add
-                                                                        (Var 222 j)
+                                                                        (Var 226 j)
                                                                         (Integer 4)
                                                                         ()
                                                                     )
                                                                     Add
-                                                                    (Var 222 k)
+                                                                    (Var 226 k)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
                                                                 Add
-                                                                (Var 222 l)
+                                                                (Var 226 l)
                                                                 (Integer 4)
                                                                 ()
                                                             )
@@ -1938,13 +1938,13 @@
                                         )]
                                     )
                                     (=
-                                        (Var 222 observed)
+                                        (Var 226 observed)
                                         (RealBinOp
                                             (RealBinOp
                                                 (FunctionCall
-                                                    222 sin@__lpython_overloaded_1__sin
+                                                    226 sin@__lpython_overloaded_1__sin
                                                     2 sin
-                                                    [((Var 222 arraynd))]
+                                                    [((Var 226 arraynd))]
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
@@ -1987,9 +1987,9 @@
                                             Add
                                             (RealBinOp
                                                 (FunctionCall
-                                                    222 cos@__lpython_overloaded_1__cos
+                                                    226 cos@__lpython_overloaded_1__cos
                                                     2 cos
-                                                    [((Var 222 arraynd))]
+                                                    [((Var 226 arraynd))]
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
@@ -2046,7 +2046,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 222 newshape)
+                                        (Var 226 newshape)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -2061,7 +2061,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 222 newshape)
+                                            (Var 226 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -2073,11 +2073,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 222 observed1d)
+                                        (Var 226 observed1d)
                                         (ArrayReshape
-                                            (Var 222 observed)
+                                            (Var 226 observed)
                                             (ArrayPhysicalCast
-                                                (Var 222 newshape)
+                                                (Var 226 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -2100,7 +2100,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 222 i)
+                                        ((Var 226 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 65536 (Integer 4))
@@ -2116,9 +2116,9 @@
                                                     Abs
                                                     [(RealBinOp
                                                         (ArrayItem
-                                                            (Var 222 observed1d)
+                                                            (Var 226 observed1d)
                                                             [(()
-                                                            (Var 222 i)
+                                                            (Var 226 i)
                                                             ())]
                                                             (Real 4)
                                                             RowMajor
@@ -2145,7 +2145,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 222 eps)
+                                                (Var 226 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2171,11 +2171,11 @@
                             verify1d:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        217
                                         {
                                             array:
                                                 (Variable
-                                                    213
+                                                    217
                                                     array
                                                     []
                                                     InOut
@@ -2197,11 +2197,11 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        223
+                                                        227
                                                         {
                                                             sin@__lpython_overloaded_1__sin:
                                                                 (ExternalSymbol
-                                                                    223
+                                                                    227
                                                                     sin@__lpython_overloaded_1__sin
                                                                     3 __lpython_overloaded_1__sin
                                                                     numpy
@@ -2217,15 +2217,15 @@
                                                                 Abs
                                                                 [(RealBinOp
                                                                     (FunctionCall
-                                                                        223 sin@__lpython_overloaded_1__sin
+                                                                        227 sin@__lpython_overloaded_1__sin
                                                                         2 sin
                                                                         [((FunctionCall
-                                                                            223 sin@__lpython_overloaded_1__sin
+                                                                            227 sin@__lpython_overloaded_1__sin
                                                                             2 sin
                                                                             [((ArrayItem
-                                                                                (Var 213 array)
+                                                                                (Var 217 array)
                                                                                 [(()
-                                                                                (Var 213 i)
+                                                                                (Var 217 i)
                                                                                 ())]
                                                                                 (Real 4)
                                                                                 RowMajor
@@ -2241,9 +2241,9 @@
                                                                     )
                                                                     Sub
                                                                     (ArrayItem
-                                                                        (Var 213 result)
+                                                                        (Var 217 result)
                                                                         [(()
-                                                                        (Var 213 i)
+                                                                        (Var 217 i)
                                                                         ())]
                                                                         (Real 4)
                                                                         RowMajor
@@ -2257,7 +2257,7 @@
                                                                 ()
                                                             )
                                                             LtE
-                                                            (Var 213 eps)
+                                                            (Var 217 eps)
                                                             (Logical 4)
                                                             ()
                                                         )
@@ -2266,7 +2266,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    213
+                                                    217
                                                     eps
                                                     []
                                                     Local
@@ -2282,7 +2282,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    213
+                                                    217
                                                     i
                                                     []
                                                     Local
@@ -2298,7 +2298,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    213
+                                                    217
                                                     result
                                                     []
                                                     InOut
@@ -2319,7 +2319,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    213
+                                                    217
                                                     size
                                                     []
                                                     In
@@ -2362,11 +2362,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 array)
-                                    (Var 213 result)
-                                    (Var 213 size)]
+                                    [(Var 217 array)
+                                    (Var 217 result)
+                                    (Var 217 size)]
                                     [(=
-                                        (Var 213 eps)
+                                        (Var 217 eps)
                                         (Cast
                                             (RealConstant
                                                 0.000001
@@ -2383,10 +2383,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 213 size)
+                                            (Var 217 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2395,7 +2395,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            213 block
+                                            217 block
                                         )]
                                     )]
                                     ()
@@ -2407,11 +2407,11 @@
                             verify1d_mul:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        221
                                         {
                                             array_a:
                                                 (Variable
-                                                    217
+                                                    221
                                                     array_a
                                                     []
                                                     InOut
@@ -2432,7 +2432,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    217
+                                                    221
                                                     array_b
                                                     []
                                                     InOut
@@ -2453,7 +2453,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    217
+                                                    221
                                                     eps
                                                     []
                                                     Local
@@ -2469,7 +2469,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    217
+                                                    221
                                                     i
                                                     []
                                                     Local
@@ -2485,7 +2485,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    217
+                                                    221
                                                     result
                                                     []
                                                     InOut
@@ -2506,7 +2506,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    217
+                                                    221
                                                     size
                                                     []
                                                     In
@@ -2555,12 +2555,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 217 array_a)
-                                    (Var 217 array_b)
-                                    (Var 217 result)
-                                    (Var 217 size)]
+                                    [(Var 221 array_a)
+                                    (Var 221 array_b)
+                                    (Var 221 result)
+                                    (Var 221 size)]
                                     [(=
-                                        (Var 217 eps)
+                                        (Var 221 eps)
                                         (RealConstant
                                             0.000010
                                             (Real 8)
@@ -2569,10 +2569,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 217 i)
+                                        ((Var 221 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 217 size)
+                                            (Var 221 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2588,9 +2588,9 @@
                                                             (RealBinOp
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 217 array_a)
+                                                                        (Var 221 array_a)
                                                                         [(()
-                                                                        (Var 217 i)
+                                                                        (Var 221 i)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -2615,9 +2615,9 @@
                                                             Mul
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 217 array_b)
+                                                                    (Var 221 array_b)
                                                                     [(()
-                                                                    (Var 217 i)
+                                                                    (Var 221 i)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -2636,9 +2636,9 @@
                                                         )
                                                         Sub
                                                         (ArrayItem
-                                                            (Var 217 result)
+                                                            (Var 221 result)
                                                             [(()
-                                                            (Var 217 i)
+                                                            (Var 221 i)
                                                             ())]
                                                             (Real 8)
                                                             RowMajor
@@ -2652,7 +2652,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 217 eps)
+                                                (Var 221 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2668,11 +2668,11 @@
                             verify1d_sum:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        220
                                         {
                                             array_a:
                                                 (Variable
-                                                    216
+                                                    220
                                                     array_a
                                                     []
                                                     InOut
@@ -2693,7 +2693,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    216
+                                                    220
                                                     array_b
                                                     []
                                                     InOut
@@ -2714,7 +2714,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    216
+                                                    220
                                                     eps
                                                     []
                                                     Local
@@ -2730,7 +2730,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    216
+                                                    220
                                                     i
                                                     []
                                                     Local
@@ -2746,7 +2746,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    216
+                                                    220
                                                     result
                                                     []
                                                     InOut
@@ -2767,7 +2767,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    216
+                                                    220
                                                     size
                                                     []
                                                     In
@@ -2816,12 +2816,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 216 array_a)
-                                    (Var 216 array_b)
-                                    (Var 216 result)
-                                    (Var 216 size)]
+                                    [(Var 220 array_a)
+                                    (Var 220 array_b)
+                                    (Var 220 result)
+                                    (Var 220 size)]
                                     [(=
-                                        (Var 216 eps)
+                                        (Var 220 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -2830,10 +2830,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 216 i)
+                                        ((Var 220 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 216 size)
+                                            (Var 220 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2848,9 +2848,9 @@
                                                         (RealBinOp
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 216 array_a)
+                                                                    (Var 220 array_a)
                                                                     [(()
-                                                                    (Var 216 i)
+                                                                    (Var 220 i)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -2873,9 +2873,9 @@
                                                                 Mul
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 216 array_b)
+                                                                        (Var 220 array_b)
                                                                         [(()
-                                                                        (Var 216 i)
+                                                                        (Var 220 i)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -2897,9 +2897,9 @@
                                                         )
                                                         Sub
                                                         (ArrayItem
-                                                            (Var 216 result)
+                                                            (Var 220 result)
                                                             [(()
-                                                            (Var 216 i)
+                                                            (Var 220 i)
                                                             ())]
                                                             (Real 8)
                                                             RowMajor
@@ -2913,7 +2913,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 216 eps)
+                                                (Var 220 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2929,11 +2929,11 @@
                             verify2d:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        219
                                         {
                                             array:
                                                 (Variable
-                                                    215
+                                                    219
                                                     array
                                                     []
                                                     InOut
@@ -2957,16 +2957,16 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        227
+                                                        231
                                                         {
                                                             block:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        228
+                                                                        232
                                                                         {
                                                                             cos@__lpython_overloaded_0__cos:
                                                                                 (ExternalSymbol
-                                                                                    228
+                                                                                    232
                                                                                     cos@__lpython_overloaded_0__cos
                                                                                     3 __lpython_overloaded_0__cos
                                                                                     numpy
@@ -2983,15 +2983,15 @@
                                                                                 [(RealBinOp
                                                                                     (RealBinOp
                                                                                         (FunctionCall
-                                                                                            228 cos@__lpython_overloaded_0__cos
+                                                                                            232 cos@__lpython_overloaded_0__cos
                                                                                             2 cos
                                                                                             [((ArrayItem
-                                                                                                (Var 215 array)
+                                                                                                (Var 219 array)
                                                                                                 [(()
-                                                                                                (Var 215 i)
+                                                                                                (Var 219 i)
                                                                                                 ())
                                                                                                 (()
-                                                                                                (Var 215 j)
+                                                                                                (Var 219 j)
                                                                                                 ())]
                                                                                                 (Real 8)
                                                                                                 RowMajor
@@ -3011,12 +3011,12 @@
                                                                                     )
                                                                                     Sub
                                                                                     (ArrayItem
-                                                                                        (Var 215 result)
+                                                                                        (Var 219 result)
                                                                                         [(()
-                                                                                        (Var 215 i)
+                                                                                        (Var 219 i)
                                                                                         ())
                                                                                         (()
-                                                                                        (Var 215 j)
+                                                                                        (Var 219 j)
                                                                                         ())]
                                                                                         (Real 8)
                                                                                         RowMajor
@@ -3030,7 +3030,7 @@
                                                                                 ()
                                                                             )
                                                                             LtE
-                                                                            (Var 215 eps)
+                                                                            (Var 219 eps)
                                                                             (Logical 4)
                                                                             ()
                                                                         )
@@ -3041,10 +3041,10 @@
                                                     block
                                                     [(DoLoop
                                                         ()
-                                                        ((Var 215 j)
+                                                        ((Var 219 j)
                                                         (IntegerConstant 0 (Integer 4))
                                                         (IntegerBinOp
-                                                            (Var 215 size2)
+                                                            (Var 219 size2)
                                                             Sub
                                                             (IntegerConstant 1 (Integer 4))
                                                             (Integer 4)
@@ -3053,13 +3053,13 @@
                                                         (IntegerConstant 1 (Integer 4)))
                                                         [(BlockCall
                                                             -1
-                                                            227 block
+                                                            231 block
                                                         )]
                                                     )]
                                                 ),
                                             eps:
                                                 (Variable
-                                                    215
+                                                    219
                                                     eps
                                                     []
                                                     Local
@@ -3075,7 +3075,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    215
+                                                    219
                                                     i
                                                     []
                                                     Local
@@ -3091,7 +3091,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    215
+                                                    219
                                                     j
                                                     []
                                                     Local
@@ -3107,7 +3107,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    215
+                                                    219
                                                     result
                                                     []
                                                     InOut
@@ -3130,7 +3130,7 @@
                                                 ),
                                             size1:
                                                 (Variable
-                                                    215
+                                                    219
                                                     size1
                                                     []
                                                     In
@@ -3146,7 +3146,7 @@
                                                 ),
                                             size2:
                                                 (Variable
-                                                    215
+                                                    219
                                                     size2
                                                     []
                                                     In
@@ -3194,12 +3194,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 215 array)
-                                    (Var 215 result)
-                                    (Var 215 size1)
-                                    (Var 215 size2)]
+                                    [(Var 219 array)
+                                    (Var 219 result)
+                                    (Var 219 size1)
+                                    (Var 219 size2)]
                                     [(=
-                                        (Var 215 eps)
+                                        (Var 219 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -3208,10 +3208,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 215 i)
+                                        ((Var 219 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 215 size1)
+                                            (Var 219 size1)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -3220,7 +3220,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            215 block
+                                            219 block
                                         )]
                                     )]
                                     ()
@@ -3232,11 +3232,11 @@
                             verifynd:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        218
                                         {
                                             array:
                                                 (Variable
-                                                    214
+                                                    218
                                                     array
                                                     []
                                                     InOut
@@ -3262,21 +3262,21 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        224
+                                                        228
                                                         {
                                                             block:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        225
+                                                                        229
                                                                         {
                                                                             block:
                                                                                 (Block
                                                                                     (SymbolTable
-                                                                                        226
+                                                                                        230
                                                                                         {
                                                                                             sin@__lpython_overloaded_0__sin:
                                                                                                 (ExternalSymbol
-                                                                                                    226
+                                                                                                    230
                                                                                                     sin@__lpython_overloaded_0__sin
                                                                                                     3 __lpython_overloaded_0__sin
                                                                                                     numpy
@@ -3293,18 +3293,18 @@
                                                                                                 [(RealBinOp
                                                                                                     (RealBinOp
                                                                                                         (FunctionCall
-                                                                                                            226 sin@__lpython_overloaded_0__sin
+                                                                                                            230 sin@__lpython_overloaded_0__sin
                                                                                                             2 sin
                                                                                                             [((ArrayItem
-                                                                                                                (Var 214 array)
+                                                                                                                (Var 218 array)
                                                                                                                 [(()
-                                                                                                                (Var 214 i)
+                                                                                                                (Var 218 i)
                                                                                                                 ())
                                                                                                                 (()
-                                                                                                                (Var 214 j)
+                                                                                                                (Var 218 j)
                                                                                                                 ())
                                                                                                                 (()
-                                                                                                                (Var 214 k)
+                                                                                                                (Var 218 k)
                                                                                                                 ())]
                                                                                                                 (Real 8)
                                                                                                                 RowMajor
@@ -3324,15 +3324,15 @@
                                                                                                     )
                                                                                                     Sub
                                                                                                     (ArrayItem
-                                                                                                        (Var 214 result)
+                                                                                                        (Var 218 result)
                                                                                                         [(()
-                                                                                                        (Var 214 i)
+                                                                                                        (Var 218 i)
                                                                                                         ())
                                                                                                         (()
-                                                                                                        (Var 214 j)
+                                                                                                        (Var 218 j)
                                                                                                         ())
                                                                                                         (()
-                                                                                                        (Var 214 k)
+                                                                                                        (Var 218 k)
                                                                                                         ())]
                                                                                                         (Real 8)
                                                                                                         RowMajor
@@ -3346,7 +3346,7 @@
                                                                                                 ()
                                                                                             )
                                                                                             LtE
-                                                                                            (Var 214 eps)
+                                                                                            (Var 218 eps)
                                                                                             (Logical 4)
                                                                                             ()
                                                                                         )
@@ -3357,10 +3357,10 @@
                                                                     block
                                                                     [(DoLoop
                                                                         ()
-                                                                        ((Var 214 k)
+                                                                        ((Var 218 k)
                                                                         (IntegerConstant 0 (Integer 4))
                                                                         (IntegerBinOp
-                                                                            (Var 214 size3)
+                                                                            (Var 218 size3)
                                                                             Sub
                                                                             (IntegerConstant 1 (Integer 4))
                                                                             (Integer 4)
@@ -3369,7 +3369,7 @@
                                                                         (IntegerConstant 1 (Integer 4)))
                                                                         [(BlockCall
                                                                             -1
-                                                                            225 block
+                                                                            229 block
                                                                         )]
                                                                     )]
                                                                 )
@@ -3377,10 +3377,10 @@
                                                     block
                                                     [(DoLoop
                                                         ()
-                                                        ((Var 214 j)
+                                                        ((Var 218 j)
                                                         (IntegerConstant 0 (Integer 4))
                                                         (IntegerBinOp
-                                                            (Var 214 size2)
+                                                            (Var 218 size2)
                                                             Sub
                                                             (IntegerConstant 1 (Integer 4))
                                                             (Integer 4)
@@ -3389,13 +3389,13 @@
                                                         (IntegerConstant 1 (Integer 4)))
                                                         [(BlockCall
                                                             -1
-                                                            224 block
+                                                            228 block
                                                         )]
                                                     )]
                                                 ),
                                             eps:
                                                 (Variable
-                                                    214
+                                                    218
                                                     eps
                                                     []
                                                     Local
@@ -3411,7 +3411,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    214
+                                                    218
                                                     i
                                                     []
                                                     Local
@@ -3427,7 +3427,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    214
+                                                    218
                                                     j
                                                     []
                                                     Local
@@ -3443,7 +3443,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    214
+                                                    218
                                                     k
                                                     []
                                                     Local
@@ -3459,7 +3459,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    214
+                                                    218
                                                     result
                                                     []
                                                     InOut
@@ -3484,7 +3484,7 @@
                                                 ),
                                             size1:
                                                 (Variable
-                                                    214
+                                                    218
                                                     size1
                                                     []
                                                     In
@@ -3500,7 +3500,7 @@
                                                 ),
                                             size2:
                                                 (Variable
-                                                    214
+                                                    218
                                                     size2
                                                     []
                                                     In
@@ -3516,7 +3516,7 @@
                                                 ),
                                             size3:
                                                 (Variable
-                                                    214
+                                                    218
                                                     size3
                                                     []
                                                     In
@@ -3569,13 +3569,13 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 array)
-                                    (Var 214 result)
-                                    (Var 214 size1)
-                                    (Var 214 size2)
-                                    (Var 214 size3)]
+                                    [(Var 218 array)
+                                    (Var 218 result)
+                                    (Var 218 size1)
+                                    (Var 218 size2)
+                                    (Var 218 size3)]
                                     [(=
-                                        (Var 214 eps)
+                                        (Var 218 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -3584,10 +3584,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 214 i)
+                                        ((Var 218 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 214 size1)
+                                            (Var 218 size1)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -3596,7 +3596,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            214 block
+                                            218 block
                                         )]
                                     )]
                                     ()
@@ -3616,11 +3616,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        247
+                        251
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    247
+                                    251
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -3632,7 +3632,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        247 __main__global_stmts
+                        251 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-expr10-efcbb1b.json
+++ b/tests/reference/asr-expr10-efcbb1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr10-efcbb1b.stdout",
-    "stdout_hash": "e5af4d07e688e5d3f0fa40058fe7d249ce5675929b44d2858d9ac6fa",
+    "stdout_hash": "49e11c3fdd9598777fbcede05d2201334a2312adacb1aaf11b3b6494",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr10-efcbb1b.stdout
+++ b/tests/reference/asr-expr10-efcbb1b.stdout
@@ -440,7 +440,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        129
+                        133
                         {
                             
                         })

--- a/tests/reference/asr-expr13-81bdb5a.json
+++ b/tests/reference/asr-expr13-81bdb5a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr13-81bdb5a.stdout",
-    "stdout_hash": "3faa0920151f2cb40d38e75757bf51817410141b1d74fb55da4215e6",
+    "stdout_hash": "2809b128c6ef1ec6a287a8583c17f3129c467d1de7f83158d8686dd0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr13-81bdb5a.stdout
+++ b/tests/reference/asr-expr13-81bdb5a.stdout
@@ -459,7 +459,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        129
+                        133
                         {
                             
                         })

--- a/tests/reference/asr-expr7-480ba2f.json
+++ b/tests/reference/asr-expr7-480ba2f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr7-480ba2f.stdout",
-    "stdout_hash": "eadbba4703440765da070a31d868859432c562349c5c2552222b70fc",
+    "stdout_hash": "4834c05f67c941d7c9abd01a25e78ea0cf59dd855c9d635d21247cc4",
     "stderr": "asr-expr7-480ba2f.stderr",
     "stderr_hash": "6e9790ac88db1a9ead8f64a91ba8a6605de67167037908a74b77be0c",
     "returncode": 0

--- a/tests/reference/asr-expr7-480ba2f.stdout
+++ b/tests/reference/asr-expr7-480ba2f.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        131
+                                        135
                                         {
                                             
                                         })
@@ -344,11 +344,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        132
+                        136
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    132
+                                    136
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -360,7 +360,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        132 __main__global_stmts
+                        136 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-expr_05-3a37324.json
+++ b/tests/reference/asr-expr_05-3a37324.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr_05-3a37324.stdout",
-    "stdout_hash": "a83c0f670181262a752f1ed741cb5d1f075b8bca5d6d4d7ae4c9c15c",
+    "stdout_hash": "e4c7e4ed4ed65f39d751f00be6544b4f378762ffa1c72cab5f852dec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr_05-3a37324.stdout
+++ b/tests/reference/asr-expr_05-3a37324.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        131
+                                        135
                                         {
                                             
                                         })
@@ -1612,11 +1612,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        132
+                        136
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    132
+                                    136
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1628,7 +1628,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        132 __main__global_stmts
+                        136 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_01-682b1b2.json
+++ b/tests/reference/asr-generics_array_01-682b1b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_01-682b1b2.stdout",
-    "stdout_hash": "084f48e82e0e32123a6da2aa362f36f0b19de8db5b8d2d9682cfa481",
+    "stdout_hash": "421aec154b394d5a7e1947fabfb10c5b73d44fcb9d6d646157975ba3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_01-682b1b2.stdout
+++ b/tests/reference/asr-generics_array_01-682b1b2.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_f_0:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        219
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    215
+                                                    219
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -48,7 +48,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    215
+                                                    219
                                                     i
                                                     []
                                                     In
@@ -64,7 +64,7 @@
                                                 ),
                                             lst:
                                                 (Variable
-                                                    215
+                                                    219
                                                     lst
                                                     []
                                                     InOut
@@ -106,11 +106,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 215 lst)
-                                    (Var 215 i)]
+                                    [(Var 219 lst)
+                                    (Var 219 i)]
                                     [(=
                                         (ArrayItem
-                                            (Var 215 lst)
+                                            (Var 219 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -118,13 +118,13 @@
                                             RowMajor
                                             ()
                                         )
-                                        (Var 215 i)
+                                        (Var 219 i)
                                         ()
                                     )
                                     (=
-                                        (Var 215 _lpython_return_variable)
+                                        (Var 219 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 215 lst)
+                                            (Var 219 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -135,7 +135,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 215 _lpython_return_variable)
+                                    (Var 219 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -144,7 +144,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        220
                                         {
                                             
                                         })
@@ -180,11 +180,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        217
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    217
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -202,7 +202,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    213
+                                                    217
                                                     i
                                                     []
                                                     In
@@ -220,7 +220,7 @@
                                                 ),
                                             lst:
                                                 (Variable
-                                                    213
+                                                    217
                                                     lst
                                                     []
                                                     InOut
@@ -270,11 +270,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 lst)
-                                    (Var 213 i)]
+                                    [(Var 217 lst)
+                                    (Var 217 i)]
                                     [(=
                                         (ArrayItem
-                                            (Var 213 lst)
+                                            (Var 217 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -284,13 +284,13 @@
                                             RowMajor
                                             ()
                                         )
-                                        (Var 213 i)
+                                        (Var 217 i)
                                         ()
                                     )
                                     (=
-                                        (Var 213 _lpython_return_variable)
+                                        (Var 217 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 213 lst)
+                                            (Var 217 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -303,7 +303,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 217 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -312,11 +312,11 @@
                             use_array:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        218
                                         {
                                             array:
                                                 (Variable
-                                                    214
+                                                    218
                                                     array
                                                     []
                                                     Local
@@ -337,7 +337,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    214
+                                                    218
                                                     x
                                                     []
                                                     Local
@@ -370,7 +370,7 @@
                                     [__asr_generic_f_0]
                                     []
                                     [(=
-                                        (Var 214 array)
+                                        (Var 218 array)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -384,7 +384,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 x)
+                                        (Var 218 x)
                                         (IntegerConstant 69 (Integer 4))
                                         ()
                                     )
@@ -393,7 +393,7 @@
                                             2 __asr_generic_f_0
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 214 array)
+                                                (Var 218 array)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -404,7 +404,7 @@
                                                 )
                                                 ()
                                             ))
-                                            ((Var 214 x))]
+                                            ((Var 218 x))]
                                             (Integer 4)
                                             ()
                                             ()
@@ -429,11 +429,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        217
+                        221
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    217
+                                    221
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -445,7 +445,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        217 __main__global_stmts
+                        221 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_02-22c8dc1.json
+++ b/tests/reference/asr-generics_array_02-22c8dc1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_02-22c8dc1.stdout",
-    "stdout_hash": "d6bb6357752ee916c8a45c47c759770f8a8f7f068ec588d28058b208",
+    "stdout_hash": "e5f7a7dfcbe77d17d83d54dee4bf42ae4908be2ddfeefe0dd7b4d041",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_02-22c8dc1.stdout
+++ b/tests/reference/asr-generics_array_02-22c8dc1.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_g_0:
                                 (Function
                                     (SymbolTable
-                                        219
+                                        223
                                         {
                                             a:
                                                 (Variable
-                                                    219
+                                                    223
                                                     a
                                                     [n]
                                                     InOut
@@ -42,7 +42,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 n))]
+                                                        (Var 223 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -53,7 +53,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    219
+                                                    223
                                                     b
                                                     [n]
                                                     InOut
@@ -63,7 +63,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 n))]
+                                                        (Var 223 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -74,7 +74,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    219
+                                                    223
                                                     i
                                                     []
                                                     Local
@@ -90,7 +90,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    219
+                                                    223
                                                     n
                                                     []
                                                     In
@@ -106,7 +106,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    219
+                                                    223
                                                     r
                                                     [n]
                                                     Local
@@ -116,7 +116,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 219 n))]
+                                                        (Var 223 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -162,17 +162,17 @@
                                         .false.
                                     )
                                     [add_integer]
-                                    [(Var 219 n)
-                                    (Var 219 a)
-                                    (Var 219 b)]
+                                    [(Var 223 n)
+                                    (Var 223 a)
+                                    (Var 223 b)]
                                     [(=
-                                        (Var 219 r)
+                                        (Var 223 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Integer 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 219 n))]
+                                                (Var 223 n))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -181,10 +181,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 219 i)
+                                        ((Var 223 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 219 n)
+                                            (Var 223 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -193,9 +193,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 219 r)
+                                                (Var 223 r)
                                                 [(()
-                                                (Var 219 i)
+                                                (Var 223 i)
                                                 ())]
                                                 (Integer 4)
                                                 RowMajor
@@ -205,18 +205,18 @@
                                                 2 add_integer
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 219 a)
+                                                    (Var 223 a)
                                                     [(()
-                                                    (Var 219 i)
+                                                    (Var 223 i)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 219 b)
+                                                    (Var 223 b)
                                                     [(()
-                                                    (Var 219 i)
+                                                    (Var 223 i)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
@@ -231,7 +231,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 219 r)
+                                            (Var 223 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -251,11 +251,11 @@
                             __asr_generic_g_1:
                                 (Function
                                     (SymbolTable
-                                        220
+                                        224
                                         {
                                             a:
                                                 (Variable
-                                                    220
+                                                    224
                                                     a
                                                     [n]
                                                     InOut
@@ -265,7 +265,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 220 n))]
+                                                        (Var 224 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -276,7 +276,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    220
+                                                    224
                                                     b
                                                     [n]
                                                     InOut
@@ -286,7 +286,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 220 n))]
+                                                        (Var 224 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -297,7 +297,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    220
+                                                    224
                                                     i
                                                     []
                                                     Local
@@ -313,7 +313,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    220
+                                                    224
                                                     n
                                                     []
                                                     In
@@ -329,7 +329,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    220
+                                                    224
                                                     r
                                                     [n]
                                                     Local
@@ -339,7 +339,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 220 n))]
+                                                        (Var 224 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -385,17 +385,17 @@
                                         .false.
                                     )
                                     [add_float]
-                                    [(Var 220 n)
-                                    (Var 220 a)
-                                    (Var 220 b)]
+                                    [(Var 224 n)
+                                    (Var 224 a)
+                                    (Var 224 b)]
                                     [(=
-                                        (Var 220 r)
+                                        (Var 224 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Real 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 220 n))]
+                                                (Var 224 n))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -404,10 +404,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 220 i)
+                                        ((Var 224 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 220 n)
+                                            (Var 224 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -416,9 +416,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 220 r)
+                                                (Var 224 r)
                                                 [(()
-                                                (Var 220 i)
+                                                (Var 224 i)
                                                 ())]
                                                 (Real 4)
                                                 RowMajor
@@ -428,18 +428,18 @@
                                                 2 add_float
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 220 a)
+                                                    (Var 224 a)
                                                     [(()
-                                                    (Var 220 i)
+                                                    (Var 224 i)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 220 b)
+                                                    (Var 224 b)
                                                     [(()
-                                                    (Var 220 i)
+                                                    (Var 224 i)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
@@ -454,7 +454,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 220 r)
+                                            (Var 224 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -474,7 +474,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        221
+                                        225
                                         {
                                             
                                         })
@@ -510,11 +510,11 @@
                             add:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        217
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    217
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -532,7 +532,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    213
+                                                    217
                                                     x
                                                     []
                                                     In
@@ -550,7 +550,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    213
+                                                    217
                                                     y
                                                     []
                                                     In
@@ -590,10 +590,10 @@
                                         .true.
                                     )
                                     []
-                                    [(Var 213 x)
-                                    (Var 213 y)]
+                                    [(Var 217 x)
+                                    (Var 217 y)]
                                     []
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 217 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -602,11 +602,11 @@
                             add_float:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        219
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    215
+                                                    219
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -622,7 +622,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    215
+                                                    219
                                                     x
                                                     []
                                                     In
@@ -638,7 +638,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    215
+                                                    219
                                                     y
                                                     []
                                                     In
@@ -670,21 +670,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 215 x)
-                                    (Var 215 y)]
+                                    [(Var 219 x)
+                                    (Var 219 y)]
                                     [(=
-                                        (Var 215 _lpython_return_variable)
+                                        (Var 219 _lpython_return_variable)
                                         (RealBinOp
-                                            (Var 215 x)
+                                            (Var 219 x)
                                             Add
-                                            (Var 215 y)
+                                            (Var 219 y)
                                             (Real 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 215 _lpython_return_variable)
+                                    (Var 219 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -693,11 +693,11 @@
                             add_integer:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        218
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    214
+                                                    218
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -713,7 +713,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    214
+                                                    218
                                                     x
                                                     []
                                                     In
@@ -729,7 +729,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    214
+                                                    218
                                                     y
                                                     []
                                                     In
@@ -761,21 +761,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 x)
-                                    (Var 214 y)]
+                                    [(Var 218 x)
+                                    (Var 218 y)]
                                     [(=
-                                        (Var 214 _lpython_return_variable)
+                                        (Var 218 _lpython_return_variable)
                                         (IntegerBinOp
-                                            (Var 214 x)
+                                            (Var 218 x)
                                             Add
-                                            (Var 214 y)
+                                            (Var 218 y)
                                             (Integer 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 214 _lpython_return_variable)
+                                    (Var 218 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -784,11 +784,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        220
                                         {
                                             a:
                                                 (Variable
-                                                    216
+                                                    220
                                                     a
                                                     [n]
                                                     InOut
@@ -800,7 +800,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))]
+                                                        (Var 220 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -811,7 +811,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    216
+                                                    220
                                                     b
                                                     [n]
                                                     InOut
@@ -823,7 +823,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))]
+                                                        (Var 220 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -834,7 +834,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    216
+                                                    220
                                                     i
                                                     []
                                                     Local
@@ -850,7 +850,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    216
+                                                    220
                                                     n
                                                     []
                                                     In
@@ -866,7 +866,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    216
+                                                    220
                                                     r
                                                     [n]
                                                     Local
@@ -878,7 +878,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))]
+                                                        (Var 220 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -928,11 +928,11 @@
                                         .false.
                                     )
                                     [add]
-                                    [(Var 216 n)
-                                    (Var 216 a)
-                                    (Var 216 b)]
+                                    [(Var 220 n)
+                                    (Var 220 a)
+                                    (Var 220 b)]
                                     [(=
-                                        (Var 216 r)
+                                        (Var 220 r)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -940,7 +940,7 @@
                                                     T
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 216 n))]
+                                                (Var 220 n))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -949,10 +949,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 216 i)
+                                        ((Var 220 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 216 n)
+                                            (Var 220 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -961,9 +961,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 216 r)
+                                                (Var 220 r)
                                                 [(()
-                                                (Var 216 i)
+                                                (Var 220 i)
                                                 ())]
                                                 (TypeParameter
                                                     T
@@ -975,9 +975,9 @@
                                                 2 add
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 216 a)
+                                                    (Var 220 a)
                                                     [(()
-                                                    (Var 216 i)
+                                                    (Var 220 i)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -986,9 +986,9 @@
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 216 b)
+                                                    (Var 220 b)
                                                     [(()
-                                                    (Var 216 i)
+                                                    (Var 220 i)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -1007,7 +1007,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 216 r)
+                                            (Var 220 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1029,11 +1029,11 @@
                             main:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        221
                                         {
                                             a_float:
                                                 (Variable
-                                                    217
+                                                    221
                                                     a_float
                                                     []
                                                     Local
@@ -1054,7 +1054,7 @@
                                                 ),
                                             a_int:
                                                 (Variable
-                                                    217
+                                                    221
                                                     a_int
                                                     []
                                                     Local
@@ -1075,7 +1075,7 @@
                                                 ),
                                             b_float:
                                                 (Variable
-                                                    217
+                                                    221
                                                     b_float
                                                     []
                                                     Local
@@ -1096,7 +1096,7 @@
                                                 ),
                                             b_int:
                                                 (Variable
-                                                    217
+                                                    221
                                                     b_int
                                                     []
                                                     Local
@@ -1135,7 +1135,7 @@
                                     __asr_generic_g_1]
                                     []
                                     [(=
-                                        (Var 217 a_int)
+                                        (Var 221 a_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1150,7 +1150,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 217 a_int)
+                                            (Var 221 a_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1162,7 +1162,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 b_int)
+                                        (Var 221 b_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1177,7 +1177,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 217 b_int)
+                                            (Var 221 b_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1193,7 +1193,7 @@
                                         ()
                                         [((IntegerConstant 1 (Integer 4)))
                                         ((ArrayPhysicalCast
-                                            (Var 217 a_int)
+                                            (Var 221 a_int)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1205,7 +1205,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 217 b_int)
+                                            (Var 221 b_int)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1219,7 +1219,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 a_float)
+                                        (Var 221 a_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1234,7 +1234,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 217 a_float)
+                                            (Var 221 a_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1257,7 +1257,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 b_float)
+                                        (Var 221 b_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1272,7 +1272,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 217 b_float)
+                                            (Var 221 b_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1299,7 +1299,7 @@
                                         ()
                                         [((IntegerConstant 1 (Integer 4)))
                                         ((ArrayPhysicalCast
-                                            (Var 217 a_float)
+                                            (Var 221 a_float)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1311,7 +1311,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 217 b_float)
+                                            (Var 221 b_float)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1359,11 +1359,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        222
+                        226
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    222
+                                    226
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1375,7 +1375,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        222 __main__global_stmts
+                        226 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_03-fb3706c.json
+++ b/tests/reference/asr-generics_array_03-fb3706c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_03-fb3706c.stdout",
-    "stdout_hash": "23993ae97006859db7166e0fc85bfb998136623d6fbbe48ca89fb450",
+    "stdout_hash": "b3e1fcb7505a3aee6a0ec84d86a9c37ef05a83e528234fd49cbddb5a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_03-fb3706c.stdout
+++ b/tests/reference/asr-generics_array_03-fb3706c.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_g_0:
                                 (Function
                                     (SymbolTable
-                                        220
+                                        224
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    220
+                                                    224
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -43,9 +43,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 220 n))
+                                                        (Var 224 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 220 m))]
+                                                        (Var 224 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -56,7 +56,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    220
+                                                    224
                                                     a
                                                     [n
                                                     m]
@@ -67,9 +67,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 220 n))
+                                                        (Var 224 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 220 m))]
+                                                        (Var 224 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -80,7 +80,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    220
+                                                    224
                                                     b
                                                     [n
                                                     m]
@@ -91,9 +91,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 220 n))
+                                                        (Var 224 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 220 m))]
+                                                        (Var 224 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -104,7 +104,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    220
+                                                    224
                                                     i
                                                     []
                                                     Local
@@ -120,7 +120,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    220
+                                                    224
                                                     j
                                                     []
                                                     Local
@@ -136,7 +136,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    220
+                                                    224
                                                     m
                                                     []
                                                     In
@@ -152,7 +152,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    220
+                                                    224
                                                     n
                                                     []
                                                     In
@@ -168,7 +168,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    220
+                                                    224
                                                     r
                                                     [n
                                                     m]
@@ -179,9 +179,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 220 n))
+                                                        (Var 224 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 220 m))]
+                                                        (Var 224 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -255,20 +255,20 @@
                                         .false.
                                     )
                                     [add_integer]
-                                    [(Var 220 n)
-                                    (Var 220 m)
-                                    (Var 220 a)
-                                    (Var 220 b)]
+                                    [(Var 224 n)
+                                    (Var 224 m)
+                                    (Var 224 a)
+                                    (Var 224 b)]
                                     [(=
-                                        (Var 220 r)
+                                        (Var 224 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Integer 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 220 n))
+                                                (Var 224 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 220 m))]
+                                                (Var 224 m))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -277,10 +277,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 220 i)
+                                        ((Var 224 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 220 n)
+                                            (Var 224 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -289,10 +289,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 220 j)
+                                            ((Var 224 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 220 m)
+                                                (Var 224 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -301,12 +301,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 220 r)
+                                                    (Var 224 r)
                                                     [(()
-                                                    (Var 220 i)
+                                                    (Var 224 i)
                                                     ())
                                                     (()
-                                                    (Var 220 j)
+                                                    (Var 224 j)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
@@ -316,24 +316,24 @@
                                                     2 add_integer
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 220 a)
+                                                        (Var 224 a)
                                                         [(()
-                                                        (Var 220 i)
+                                                        (Var 224 i)
                                                         ())
                                                         (()
-                                                        (Var 220 j)
+                                                        (Var 224 j)
                                                         ())]
                                                         (Integer 4)
                                                         RowMajor
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 220 b)
+                                                        (Var 224 b)
                                                         [(()
-                                                        (Var 220 i)
+                                                        (Var 224 i)
                                                         ())
                                                         (()
-                                                        (Var 220 j)
+                                                        (Var 224 j)
                                                         ())]
                                                         (Integer 4)
                                                         RowMajor
@@ -349,7 +349,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 220 r)
+                                            (Var 224 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -363,7 +363,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 220 _lpython_return_variable)
+                                    (Var 224 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -372,11 +372,11 @@
                             __asr_generic_g_1:
                                 (Function
                                     (SymbolTable
-                                        221
+                                        225
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    221
+                                                    225
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -387,9 +387,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 221 n))
+                                                        (Var 225 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 221 m))]
+                                                        (Var 225 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -400,7 +400,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    221
+                                                    225
                                                     a
                                                     [n
                                                     m]
@@ -411,9 +411,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 221 n))
+                                                        (Var 225 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 221 m))]
+                                                        (Var 225 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -424,7 +424,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    221
+                                                    225
                                                     b
                                                     [n
                                                     m]
@@ -435,9 +435,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 221 n))
+                                                        (Var 225 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 221 m))]
+                                                        (Var 225 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -448,7 +448,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    221
+                                                    225
                                                     i
                                                     []
                                                     Local
@@ -464,7 +464,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    221
+                                                    225
                                                     j
                                                     []
                                                     Local
@@ -480,7 +480,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    221
+                                                    225
                                                     m
                                                     []
                                                     In
@@ -496,7 +496,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    221
+                                                    225
                                                     n
                                                     []
                                                     In
@@ -512,7 +512,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    221
+                                                    225
                                                     r
                                                     [n
                                                     m]
@@ -523,9 +523,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 221 n))
+                                                        (Var 225 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 221 m))]
+                                                        (Var 225 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -599,20 +599,20 @@
                                         .false.
                                     )
                                     [add_float]
-                                    [(Var 221 n)
-                                    (Var 221 m)
-                                    (Var 221 a)
-                                    (Var 221 b)]
+                                    [(Var 225 n)
+                                    (Var 225 m)
+                                    (Var 225 a)
+                                    (Var 225 b)]
                                     [(=
-                                        (Var 221 r)
+                                        (Var 225 r)
                                         (ArrayConstant
                                             []
                                             (Array
                                                 (Real 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 221 n))
+                                                (Var 225 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 221 m))]
+                                                (Var 225 m))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -621,10 +621,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 221 i)
+                                        ((Var 225 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 221 n)
+                                            (Var 225 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -633,10 +633,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 221 j)
+                                            ((Var 225 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 221 m)
+                                                (Var 225 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -645,12 +645,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 221 r)
+                                                    (Var 225 r)
                                                     [(()
-                                                    (Var 221 i)
+                                                    (Var 225 i)
                                                     ())
                                                     (()
-                                                    (Var 221 j)
+                                                    (Var 225 j)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
@@ -660,24 +660,24 @@
                                                     2 add_float
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 221 a)
+                                                        (Var 225 a)
                                                         [(()
-                                                        (Var 221 i)
+                                                        (Var 225 i)
                                                         ())
                                                         (()
-                                                        (Var 221 j)
+                                                        (Var 225 j)
                                                         ())]
                                                         (Real 4)
                                                         RowMajor
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 221 b)
+                                                        (Var 225 b)
                                                         [(()
-                                                        (Var 221 i)
+                                                        (Var 225 i)
                                                         ())
                                                         (()
-                                                        (Var 221 j)
+                                                        (Var 225 j)
                                                         ())]
                                                         (Real 4)
                                                         RowMajor
@@ -693,7 +693,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 221 r)
+                                            (Var 225 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -707,7 +707,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 221 _lpython_return_variable)
+                                    (Var 225 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -716,7 +716,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        222
+                                        226
                                         {
                                             
                                         })
@@ -752,11 +752,11 @@
                             add:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        217
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    213
+                                                    217
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -774,7 +774,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    213
+                                                    217
                                                     x
                                                     []
                                                     In
@@ -792,7 +792,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    213
+                                                    217
                                                     y
                                                     []
                                                     In
@@ -832,10 +832,10 @@
                                         .true.
                                     )
                                     []
-                                    [(Var 213 x)
-                                    (Var 213 y)]
+                                    [(Var 217 x)
+                                    (Var 217 y)]
                                     []
-                                    (Var 213 _lpython_return_variable)
+                                    (Var 217 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -844,11 +844,11 @@
                             add_float:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        219
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    215
+                                                    219
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -864,7 +864,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    215
+                                                    219
                                                     x
                                                     []
                                                     In
@@ -880,7 +880,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    215
+                                                    219
                                                     y
                                                     []
                                                     In
@@ -912,21 +912,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 215 x)
-                                    (Var 215 y)]
+                                    [(Var 219 x)
+                                    (Var 219 y)]
                                     [(=
-                                        (Var 215 _lpython_return_variable)
+                                        (Var 219 _lpython_return_variable)
                                         (RealBinOp
-                                            (Var 215 x)
+                                            (Var 219 x)
                                             Add
-                                            (Var 215 y)
+                                            (Var 219 y)
                                             (Real 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 215 _lpython_return_variable)
+                                    (Var 219 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -935,11 +935,11 @@
                             add_integer:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        218
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    214
+                                                    218
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -955,7 +955,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    214
+                                                    218
                                                     x
                                                     []
                                                     In
@@ -971,7 +971,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    214
+                                                    218
                                                     y
                                                     []
                                                     In
@@ -1003,21 +1003,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 x)
-                                    (Var 214 y)]
+                                    [(Var 218 x)
+                                    (Var 218 y)]
                                     [(=
-                                        (Var 214 _lpython_return_variable)
+                                        (Var 218 _lpython_return_variable)
                                         (IntegerBinOp
-                                            (Var 214 x)
+                                            (Var 218 x)
                                             Add
-                                            (Var 214 y)
+                                            (Var 218 y)
                                             (Integer 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 214 _lpython_return_variable)
+                                    (Var 218 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -1026,11 +1026,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        220
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    216
+                                                    220
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -1043,9 +1043,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))
+                                                        (Var 220 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 m))]
+                                                        (Var 220 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1056,7 +1056,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    216
+                                                    220
                                                     a
                                                     [n
                                                     m]
@@ -1069,9 +1069,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))
+                                                        (Var 220 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 m))]
+                                                        (Var 220 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1082,7 +1082,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    216
+                                                    220
                                                     b
                                                     [n
                                                     m]
@@ -1095,9 +1095,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))
+                                                        (Var 220 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 m))]
+                                                        (Var 220 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1108,7 +1108,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    216
+                                                    220
                                                     i
                                                     []
                                                     Local
@@ -1124,7 +1124,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    216
+                                                    220
                                                     j
                                                     []
                                                     Local
@@ -1140,7 +1140,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    216
+                                                    220
                                                     m
                                                     []
                                                     In
@@ -1156,7 +1156,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    216
+                                                    220
                                                     n
                                                     []
                                                     In
@@ -1172,7 +1172,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    216
+                                                    220
                                                     r
                                                     [n
                                                     m]
@@ -1185,9 +1185,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 n))
+                                                        (Var 220 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 216 m))]
+                                                        (Var 220 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1267,12 +1267,12 @@
                                         .false.
                                     )
                                     [add]
-                                    [(Var 216 n)
-                                    (Var 216 m)
-                                    (Var 216 a)
-                                    (Var 216 b)]
+                                    [(Var 220 n)
+                                    (Var 220 m)
+                                    (Var 220 a)
+                                    (Var 220 b)]
                                     [(=
-                                        (Var 216 r)
+                                        (Var 220 r)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1280,9 +1280,9 @@
                                                     T
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 216 n))
+                                                (Var 220 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 216 m))]
+                                                (Var 220 m))]
                                                 PointerToDataArray
                                             )
                                             RowMajor
@@ -1291,10 +1291,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 216 i)
+                                        ((Var 220 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 216 n)
+                                            (Var 220 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -1303,10 +1303,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 216 j)
+                                            ((Var 220 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 216 m)
+                                                (Var 220 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -1315,12 +1315,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 216 r)
+                                                    (Var 220 r)
                                                     [(()
-                                                    (Var 216 i)
+                                                    (Var 220 i)
                                                     ())
                                                     (()
-                                                    (Var 216 j)
+                                                    (Var 220 j)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -1332,12 +1332,12 @@
                                                     2 add
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 216 a)
+                                                        (Var 220 a)
                                                         [(()
-                                                        (Var 216 i)
+                                                        (Var 220 i)
                                                         ())
                                                         (()
-                                                        (Var 216 j)
+                                                        (Var 220 j)
                                                         ())]
                                                         (TypeParameter
                                                             T
@@ -1346,12 +1346,12 @@
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 216 b)
+                                                        (Var 220 b)
                                                         [(()
-                                                        (Var 216 i)
+                                                        (Var 220 i)
                                                         ())
                                                         (()
-                                                        (Var 216 j)
+                                                        (Var 220 j)
                                                         ())]
                                                         (TypeParameter
                                                             T
@@ -1371,7 +1371,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 216 r)
+                                            (Var 220 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1387,7 +1387,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 216 _lpython_return_variable)
+                                    (Var 220 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -1414,11 +1414,11 @@
                             main:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        221
                                         {
                                             __lcompilers_dummy:
                                                 (Variable
-                                                    217
+                                                    221
                                                     __lcompilers_dummy
                                                     []
                                                     Local
@@ -1441,7 +1441,7 @@
                                                 ),
                                             __lcompilers_dummy1:
                                                 (Variable
-                                                    217
+                                                    221
                                                     __lcompilers_dummy1
                                                     []
                                                     Local
@@ -1464,7 +1464,7 @@
                                                 ),
                                             a_float:
                                                 (Variable
-                                                    217
+                                                    221
                                                     a_float
                                                     []
                                                     Local
@@ -1487,7 +1487,7 @@
                                                 ),
                                             a_int:
                                                 (Variable
-                                                    217
+                                                    221
                                                     a_int
                                                     []
                                                     Local
@@ -1510,7 +1510,7 @@
                                                 ),
                                             b_float:
                                                 (Variable
-                                                    217
+                                                    221
                                                     b_float
                                                     []
                                                     Local
@@ -1533,7 +1533,7 @@
                                                 ),
                                             b_int:
                                                 (Variable
-                                                    217
+                                                    221
                                                     b_int
                                                     []
                                                     Local
@@ -1574,7 +1574,7 @@
                                     __asr_generic_g_1]
                                     []
                                     [(=
-                                        (Var 217 a_int)
+                                        (Var 221 a_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1591,7 +1591,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 217 a_int)
+                                            (Var 221 a_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1606,7 +1606,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 b_int)
+                                        (Var 221 b_int)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1623,7 +1623,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 217 b_int)
+                                            (Var 221 b_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1638,14 +1638,14 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 __lcompilers_dummy)
+                                        (Var 221 __lcompilers_dummy)
                                         (FunctionCall
                                             2 __asr_generic_g_0
                                             ()
                                             [((IntegerConstant 1 (Integer 4)))
                                             ((IntegerConstant 1 (Integer 4)))
                                             ((ArrayPhysicalCast
-                                                (Var 217 a_int)
+                                                (Var 221 a_int)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1659,7 +1659,7 @@
                                                 ()
                                             ))
                                             ((ArrayPhysicalCast
-                                                (Var 217 b_int)
+                                                (Var 221 b_int)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1686,7 +1686,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 a_float)
+                                        (Var 221 a_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1703,7 +1703,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 217 a_float)
+                                            (Var 221 a_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1726,7 +1726,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 b_float)
+                                        (Var 221 b_float)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1743,7 +1743,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 217 b_float)
+                                            (Var 221 b_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1766,14 +1766,14 @@
                                         ()
                                     )
                                     (=
-                                        (Var 217 __lcompilers_dummy1)
+                                        (Var 221 __lcompilers_dummy1)
                                         (FunctionCall
                                             2 __asr_generic_g_1
                                             ()
                                             [((IntegerConstant 1 (Integer 4)))
                                             ((IntegerConstant 1 (Integer 4)))
                                             ((ArrayPhysicalCast
-                                                (Var 217 a_float)
+                                                (Var 221 a_float)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1787,7 +1787,7 @@
                                                 ()
                                             ))
                                             ((ArrayPhysicalCast
-                                                (Var 217 b_float)
+                                                (Var 221 b_float)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1848,11 +1848,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        223
+                        227
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    223
+                                    227
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1864,7 +1864,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        223 __main__global_stmts
+                        227 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-structs_05-fa98307.json
+++ b/tests/reference/asr-structs_05-fa98307.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_05-fa98307.stdout",
-    "stdout_hash": "a45fe6fa95d8afe6d018d68f32834ab3b1d6a56bb3d35b96300d95b2",
+    "stdout_hash": "7a24526654352572337d0e4311d8c696aed85c054e698a5238ef0eb3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_05-fa98307.stdout
+++ b/tests/reference/asr-structs_05-fa98307.stdout
@@ -10,11 +10,11 @@
                             A:
                                 (StructType
                                     (SymbolTable
-                                        213
+                                        217
                                         {
                                             a:
                                                 (Variable
-                                                    213
+                                                    217
                                                     a
                                                     []
                                                     Local
@@ -30,7 +30,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    213
+                                                    217
                                                     b
                                                     []
                                                     Local
@@ -46,7 +46,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    213
+                                                    217
                                                     c
                                                     []
                                                     Local
@@ -62,7 +62,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    213
+                                                    217
                                                     d
                                                     []
                                                     Local
@@ -78,7 +78,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    213
+                                                    217
                                                     x
                                                     []
                                                     Local
@@ -94,7 +94,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    213
+                                                    217
                                                     y
                                                     []
                                                     Local
@@ -110,7 +110,7 @@
                                                 ),
                                             z:
                                                 (Variable
-                                                    213
+                                                    217
                                                     z
                                                     []
                                                     Local
@@ -151,7 +151,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        219
+                                        223
                                         {
                                             
                                         })
@@ -187,11 +187,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        221
                                         {
                                             y:
                                                 (Variable
-                                                    217
+                                                    221
                                                     y
                                                     []
                                                     Local
@@ -233,7 +233,7 @@
                                     update_2]
                                     []
                                     [(=
-                                        (Var 217 y)
+                                        (Var 221 y)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -250,7 +250,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 217 y)
+                                            (Var 221 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -310,7 +310,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 217 y)
+                                            (Var 221 y)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -372,7 +372,7 @@
                                         2 verify
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 217 y)
+                                            (Var 221 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -401,7 +401,7 @@
                                         2 update_1
                                         ()
                                         [((ArrayItem
-                                            (Var 217 y)
+                                            (Var 221 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -417,7 +417,7 @@
                                         2 update_2
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 217 y)
+                                            (Var 221 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -436,7 +436,7 @@
                                         2 verify
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 217 y)
+                                            (Var 221 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -470,11 +470,11 @@
                             update_1:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        219
                                         {
                                             s:
                                                 (Variable
-                                                    215
+                                                    219
                                                     s
                                                     []
                                                     InOut
@@ -509,11 +509,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 215 s)]
+                                    [(Var 219 s)]
                                     [(=
                                         (StructInstanceMember
-                                            (Var 215 s)
-                                            213 x
+                                            (Var 219 s)
+                                            217 x
                                             (Integer 4)
                                             ()
                                         )
@@ -522,8 +522,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 215 s)
-                                            213 y
+                                            (Var 219 s)
+                                            217 y
                                             (Real 8)
                                             ()
                                         )
@@ -535,8 +535,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 215 s)
-                                            213 z
+                                            (Var 219 s)
+                                            217 z
                                             (Integer 8)
                                             ()
                                         )
@@ -550,8 +550,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 215 s)
-                                            213 a
+                                            (Var 219 s)
+                                            217 a
                                             (Real 4)
                                             ()
                                         )
@@ -571,8 +571,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 215 s)
-                                            213 b
+                                            (Var 219 s)
+                                            217 b
                                             (Integer 2)
                                             ()
                                         )
@@ -586,8 +586,8 @@
                                     )
                                     (=
                                         (StructInstanceMember
-                                            (Var 215 s)
-                                            213 c
+                                            (Var 219 s)
+                                            217 c
                                             (Integer 1)
                                             ()
                                         )
@@ -608,11 +608,11 @@
                             update_2:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        220
                                         {
                                             s:
                                                 (Variable
-                                                    216
+                                                    220
                                                     s
                                                     []
                                                     InOut
@@ -657,11 +657,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 216 s)]
+                                    [(Var 220 s)]
                                     [(=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 216 s)
+                                                (Var 220 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -671,7 +671,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            213 x
+                                            217 x
                                             (Integer 4)
                                             ()
                                         )
@@ -681,7 +681,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 216 s)
+                                                (Var 220 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -691,7 +691,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            213 y
+                                            217 y
                                             (Real 8)
                                             ()
                                         )
@@ -704,7 +704,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 216 s)
+                                                (Var 220 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -714,7 +714,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            213 z
+                                            217 z
                                             (Integer 8)
                                             ()
                                         )
@@ -729,7 +729,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 216 s)
+                                                (Var 220 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -739,7 +739,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            213 a
+                                            217 a
                                             (Real 4)
                                             ()
                                         )
@@ -760,7 +760,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 216 s)
+                                                (Var 220 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -770,7 +770,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            213 b
+                                            217 b
                                             (Integer 2)
                                             ()
                                         )
@@ -785,7 +785,7 @@
                                     (=
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 216 s)
+                                                (Var 220 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -795,7 +795,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            213 c
+                                            217 c
                                             (Integer 1)
                                             ()
                                         )
@@ -816,11 +816,11 @@
                             verify:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        218
                                         {
                                             eps:
                                                 (Variable
-                                                    214
+                                                    218
                                                     eps
                                                     []
                                                     Local
@@ -836,7 +836,7 @@
                                                 ),
                                             s:
                                                 (Variable
-                                                    214
+                                                    218
                                                     s
                                                     []
                                                     InOut
@@ -859,7 +859,7 @@
                                                 ),
                                             s0:
                                                 (Variable
-                                                    214
+                                                    218
                                                     s0
                                                     []
                                                     Local
@@ -877,7 +877,7 @@
                                                 ),
                                             s1:
                                                 (Variable
-                                                    214
+                                                    218
                                                     s1
                                                     []
                                                     Local
@@ -895,7 +895,7 @@
                                                 ),
                                             x1:
                                                 (Variable
-                                                    214
+                                                    218
                                                     x1
                                                     []
                                                     In
@@ -911,7 +911,7 @@
                                                 ),
                                             x2:
                                                 (Variable
-                                                    214
+                                                    218
                                                     x2
                                                     []
                                                     In
@@ -927,7 +927,7 @@
                                                 ),
                                             y1:
                                                 (Variable
-                                                    214
+                                                    218
                                                     y1
                                                     []
                                                     In
@@ -943,7 +943,7 @@
                                                 ),
                                             y2:
                                                 (Variable
-                                                    214
+                                                    218
                                                     y2
                                                     []
                                                     In
@@ -985,13 +985,13 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 s)
-                                    (Var 214 x1)
-                                    (Var 214 y1)
-                                    (Var 214 x2)
-                                    (Var 214 y2)]
+                                    [(Var 218 s)
+                                    (Var 218 x1)
+                                    (Var 218 y1)
+                                    (Var 218 x2)
+                                    (Var 218 y2)]
                                     [(=
-                                        (Var 214 eps)
+                                        (Var 218 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -999,9 +999,9 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 s0)
+                                        (Var 218 s0)
                                         (ArrayItem
-                                            (Var 214 s)
+                                            (Var 218 s)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1015,44 +1015,44 @@
                                     )
                                     (Print
                                         [(StructInstanceMember
-                                            (Var 214 s0)
-                                            213 x
+                                            (Var 218 s0)
+                                            217 x
                                             (Integer 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 214 s0)
-                                            213 y
+                                            (Var 218 s0)
+                                            217 y
                                             (Real 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 214 s0)
-                                            213 z
+                                            (Var 218 s0)
+                                            217 z
                                             (Integer 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 214 s0)
-                                            213 a
+                                            (Var 218 s0)
+                                            217 a
                                             (Real 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 214 s0)
-                                            213 b
+                                            (Var 218 s0)
+                                            217 b
                                             (Integer 2)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 214 s0)
-                                            213 c
+                                            (Var 218 s0)
+                                            217 c
                                             (Integer 1)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 214 s0)
-                                            213 d
+                                            (Var 218 s0)
+                                            217 d
                                             (Logical 4)
                                             ()
                                         )]
@@ -1062,13 +1062,13 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 214 s0)
-                                                213 x
+                                                (Var 218 s0)
+                                                217 x
                                                 (Integer 4)
                                                 ()
                                             )
                                             Eq
-                                            (Var 214 x1)
+                                            (Var 218 x1)
                                             (Logical 4)
                                             ()
                                         )
@@ -1080,13 +1080,13 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 214 s0)
-                                                        213 y
+                                                        (Var 218 s0)
+                                                        217 y
                                                         (Real 8)
                                                         ()
                                                     )
                                                     Sub
-                                                    (Var 214 y1)
+                                                    (Var 218 y1)
                                                     (Real 8)
                                                     ()
                                                 )]
@@ -1095,7 +1095,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 214 eps)
+                                            (Var 218 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -1104,14 +1104,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 214 s0)
-                                                213 z
+                                                (Var 218 s0)
+                                                217 z
                                                 (Integer 8)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 214 x1)
+                                                (Var 218 x1)
                                                 IntegerToInteger
                                                 (Integer 8)
                                                 ()
@@ -1127,14 +1127,14 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 214 s0)
-                                                        213 a
+                                                        (Var 218 s0)
+                                                        217 a
                                                         (Real 4)
                                                         ()
                                                     )
                                                     Sub
                                                     (Cast
-                                                        (Var 214 y1)
+                                                        (Var 218 y1)
                                                         RealToReal
                                                         (Real 4)
                                                         ()
@@ -1167,14 +1167,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 214 s0)
-                                                213 b
+                                                (Var 218 s0)
+                                                217 b
                                                 (Integer 2)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 214 x1)
+                                                (Var 218 x1)
                                                 IntegerToInteger
                                                 (Integer 2)
                                                 ()
@@ -1187,14 +1187,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 214 s0)
-                                                213 c
+                                                (Var 218 s0)
+                                                217 c
                                                 (Integer 1)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 214 x1)
+                                                (Var 218 x1)
                                                 IntegerToInteger
                                                 (Integer 1)
                                                 ()
@@ -1206,17 +1206,17 @@
                                     )
                                     (Assert
                                         (StructInstanceMember
-                                            (Var 214 s0)
-                                            213 d
+                                            (Var 218 s0)
+                                            217 d
                                             (Logical 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (=
-                                        (Var 214 s1)
+                                        (Var 218 s1)
                                         (ArrayItem
-                                            (Var 214 s)
+                                            (Var 218 s)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -1230,44 +1230,44 @@
                                     )
                                     (Print
                                         [(StructInstanceMember
-                                            (Var 214 s1)
-                                            213 x
+                                            (Var 218 s1)
+                                            217 x
                                             (Integer 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 214 s1)
-                                            213 y
+                                            (Var 218 s1)
+                                            217 y
                                             (Real 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 214 s1)
-                                            213 z
+                                            (Var 218 s1)
+                                            217 z
                                             (Integer 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 214 s1)
-                                            213 a
+                                            (Var 218 s1)
+                                            217 a
                                             (Real 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 214 s1)
-                                            213 b
+                                            (Var 218 s1)
+                                            217 b
                                             (Integer 2)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 214 s1)
-                                            213 c
+                                            (Var 218 s1)
+                                            217 c
                                             (Integer 1)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 214 s1)
-                                            213 d
+                                            (Var 218 s1)
+                                            217 d
                                             (Logical 4)
                                             ()
                                         )]
@@ -1277,13 +1277,13 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 214 s1)
-                                                213 x
+                                                (Var 218 s1)
+                                                217 x
                                                 (Integer 4)
                                                 ()
                                             )
                                             Eq
-                                            (Var 214 x2)
+                                            (Var 218 x2)
                                             (Logical 4)
                                             ()
                                         )
@@ -1295,13 +1295,13 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 214 s1)
-                                                        213 y
+                                                        (Var 218 s1)
+                                                        217 y
                                                         (Real 8)
                                                         ()
                                                     )
                                                     Sub
-                                                    (Var 214 y2)
+                                                    (Var 218 y2)
                                                     (Real 8)
                                                     ()
                                                 )]
@@ -1310,7 +1310,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 214 eps)
+                                            (Var 218 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -1319,14 +1319,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 214 s1)
-                                                213 z
+                                                (Var 218 s1)
+                                                217 z
                                                 (Integer 8)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 214 x2)
+                                                (Var 218 x2)
                                                 IntegerToInteger
                                                 (Integer 8)
                                                 ()
@@ -1342,14 +1342,14 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 214 s1)
-                                                        213 a
+                                                        (Var 218 s1)
+                                                        217 a
                                                         (Real 4)
                                                         ()
                                                     )
                                                     Sub
                                                     (Cast
-                                                        (Var 214 y2)
+                                                        (Var 218 y2)
                                                         RealToReal
                                                         (Real 4)
                                                         ()
@@ -1382,14 +1382,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 214 s1)
-                                                213 b
+                                                (Var 218 s1)
+                                                217 b
                                                 (Integer 2)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 214 x2)
+                                                (Var 218 x2)
                                                 IntegerToInteger
                                                 (Integer 2)
                                                 ()
@@ -1402,14 +1402,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 214 s1)
-                                                213 c
+                                                (Var 218 s1)
+                                                217 c
                                                 (Integer 1)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 214 x2)
+                                                (Var 218 x2)
                                                 IntegerToInteger
                                                 (Integer 1)
                                                 ()
@@ -1421,8 +1421,8 @@
                                     )
                                     (Assert
                                         (StructInstanceMember
-                                            (Var 214 s1)
-                                            213 d
+                                            (Var 218 s1)
+                                            217 d
                                             (Logical 4)
                                             ()
                                         )
@@ -1445,11 +1445,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        220
+                        224
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    220
+                                    224
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1461,7 +1461,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        220 __main__global_stmts
+                        224 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_bin-52ba9fa.json
+++ b/tests/reference/asr-test_builtin_bin-52ba9fa.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_bin-52ba9fa.stdout",
-    "stdout_hash": "8fd060dd84db4f7c18de2d216cefcccc5515af6e6f5a770f65c1b71a",
+    "stdout_hash": "e1179ec1b473fe251e4106bcd4d151dc604f9569819412a7d910a2d5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_bin-52ba9fa.stdout
+++ b/tests/reference/asr-test_builtin_bin-52ba9fa.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        133
                                         {
                                             
                                         })
@@ -244,11 +244,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        134
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    134
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -260,7 +260,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        134 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_bool-330223a.json
+++ b/tests/reference/asr-test_builtin_bool-330223a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_bool-330223a.stdout",
-    "stdout_hash": "e98ced1a47246ef02452991e9ceaa2d49b9120834fe8092966fe015e",
+    "stdout_hash": "633eb259d3d1676e39979eff8d343c71be980225ce4a7cc31d641ddc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_bool-330223a.stdout
+++ b/tests/reference/asr-test_builtin_bool-330223a.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        133
                                         {
                                             
                                         })
@@ -868,11 +868,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        134
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    134
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -884,7 +884,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        134 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_hex-64bd268.json
+++ b/tests/reference/asr-test_builtin_hex-64bd268.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_hex-64bd268.stdout",
-    "stdout_hash": "6e6192771598830edbd7d8a833184396f040b182b9004af5ffb3c599",
+    "stdout_hash": "88506e54ca99d4f65e8abaeb044fa053b0a6332bad51fafba77c1849",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_hex-64bd268.stdout
+++ b/tests/reference/asr-test_builtin_hex-64bd268.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        133
                                         {
                                             
                                         })
@@ -219,11 +219,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        134
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    134
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -235,7 +235,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        134 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_oct-20b9066.json
+++ b/tests/reference/asr-test_builtin_oct-20b9066.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_oct-20b9066.stdout",
-    "stdout_hash": "a3b3f11d9cbcb6f57d5b23e364c26ced7b915e8c72eded358f01d9cd",
+    "stdout_hash": "d06d119d9d7c082fa9b5e50ca36382b1dd2eda3d02199c361219ac82",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_oct-20b9066.stdout
+++ b/tests/reference/asr-test_builtin_oct-20b9066.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        133
                                         {
                                             
                                         })
@@ -219,11 +219,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        134
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    134
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -235,7 +235,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        134 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_pow-f02fcda.json
+++ b/tests/reference/asr-test_builtin_pow-f02fcda.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_pow-f02fcda.stdout",
-    "stdout_hash": "b0aa9ff1f31769b515e2aedd650656b6a53676d5bf276e6b9a4b12b9",
+    "stdout_hash": "d7db3665c9c7ca8791dfa3594c82d61b2402e2580b0970751abb31a5",
     "stderr": "asr-test_builtin_pow-f02fcda.stderr",
     "stderr_hash": "859ce76c74748f2d32c7eab92cfbba789a78d4cbf5818646b99806ea",
     "returncode": 0

--- a/tests/reference/asr-test_builtin_pow-f02fcda.stdout
+++ b/tests/reference/asr-test_builtin_pow-f02fcda.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        133
                                         {
                                             
                                         })
@@ -1880,11 +1880,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        134
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    134
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1896,7 +1896,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        134 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_round-7417a21.json
+++ b/tests/reference/asr-test_builtin_round-7417a21.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_round-7417a21.stdout",
-    "stdout_hash": "9fcfa25b2101c8a11d06e0ae473edee98c3c76beeb20fceb1e5f528d",
+    "stdout_hash": "215f5e7f9107ae70bb13c7e3e0462c2f3a272a73da7eec57894cb6ad",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_round-7417a21.stdout
+++ b/tests/reference/asr-test_builtin_round-7417a21.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        133
                                         {
                                             
                                         })
@@ -886,11 +886,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        134
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    134
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -902,7 +902,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        134 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_complex_01-a6def58.json
+++ b/tests/reference/asr-test_complex_01-a6def58.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_complex_01-a6def58.stdout",
-    "stdout_hash": "f0bab05549d2ee9805936995e3f111a308efc78a61ce593d2c765339",
+    "stdout_hash": "0edbd82d16370eadb471e7fe3c91fb8332c704f82e694c430e5872cb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_complex_01-a6def58.stdout
+++ b/tests/reference/asr-test_complex_01-a6def58.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        133
+                                        137
                                         {
                                             
                                         })
@@ -1975,11 +1975,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        134
+                        138
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    134
+                                    138
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1991,7 +1991,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        134 __main__global_stmts
+                        138 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_complex_02-782ba2d.json
+++ b/tests/reference/asr-test_complex_02-782ba2d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_complex_02-782ba2d.stdout",
-    "stdout_hash": "8855f80a3c24a954dd0d003ef093368456a95c20b7d723ddd8a01c81",
+    "stdout_hash": "c885b7488369d53c7617d0d51897e192bf97eb337c77b60c24303588",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_complex_02-782ba2d.stdout
+++ b/tests/reference/asr-test_complex_02-782ba2d.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        132
+                                        136
                                         {
                                             
                                         })
@@ -691,11 +691,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        133
+                        137
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    133
+                                    137
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -707,7 +707,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        133 __main__global_stmts
+                        137 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_max_min-3c2fc51.json
+++ b/tests/reference/asr-test_max_min-3c2fc51.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_max_min-3c2fc51.stdout",
-    "stdout_hash": "e67150b066db479e51b74178342475bc51b3e56bc715d5c4b4495693",
+    "stdout_hash": "cbd5fd7c0b04f5a2109d3c122a3853f6b5a46e67cfa928e244cd5bec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_max_min-3c2fc51.stdout
+++ b/tests/reference/asr-test_max_min-3c2fc51.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        133
+                                        137
                                         {
                                             
                                         })
@@ -785,11 +785,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        134
+                        138
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    134
+                                    138
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -801,7 +801,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        134 __main__global_stmts
+                        138 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_numpy_03-e600a49.json
+++ b/tests/reference/asr-test_numpy_03-e600a49.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_03-e600a49.stdout",
-    "stdout_hash": "114211056524f1f918fbf9d494aafeae75c1a95278fc3b38bae57916",
+    "stdout_hash": "2f7d13adae2c2b96b7cb3ae2dc24a5fcdef85b410ed3ea9841aba678",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_03-e600a49.stdout
+++ b/tests/reference/asr-test_numpy_03-e600a49.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        230
+                                        234
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             test_1d_to_nd:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        218
                                         {
                                             a:
                                                 (Variable
-                                                    214
+                                                    218
                                                     a
                                                     []
                                                     Local
@@ -73,7 +73,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    214
+                                                    218
                                                     b
                                                     []
                                                     Local
@@ -94,7 +94,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    214
+                                                    218
                                                     c
                                                     []
                                                     Local
@@ -119,7 +119,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    214
+                                                    218
                                                     d
                                                     []
                                                     InOut
@@ -140,7 +140,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    214
+                                                    218
                                                     eps
                                                     []
                                                     Local
@@ -156,7 +156,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    214
+                                                    218
                                                     i
                                                     []
                                                     Local
@@ -172,7 +172,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    214
+                                                    218
                                                     j
                                                     []
                                                     Local
@@ -188,7 +188,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    214
+                                                    218
                                                     k
                                                     []
                                                     Local
@@ -204,7 +204,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    214
+                                                    218
                                                     l
                                                     []
                                                     Local
@@ -220,7 +220,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    214
+                                                    218
                                                     newshape
                                                     []
                                                     Local
@@ -241,7 +241,7 @@
                                                 ),
                                             newshape1:
                                                 (Variable
-                                                    214
+                                                    218
                                                     newshape1
                                                     []
                                                     Local
@@ -282,9 +282,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 214 d)]
+                                    [(Var 218 d)]
                                     [(=
-                                        (Var 214 eps)
+                                        (Var 218 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -292,7 +292,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 b)
+                                        (Var 218 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -307,7 +307,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 214 k)
+                                        ((Var 218 k)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -318,10 +318,10 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
-                                            (Var 214 i)
+                                            (Var 218 i)
                                             (IntrinsicScalarFunction
                                                 FloorDiv
-                                                [(Var 214 k)
+                                                [(Var 218 k)
                                                 (IntegerConstant 16 (Integer 4))]
                                                 0
                                                 (Integer 4)
@@ -330,12 +330,12 @@
                                             ()
                                         )
                                         (=
-                                            (Var 214 j)
+                                            (Var 218 j)
                                             (IntegerBinOp
-                                                (Var 214 k)
+                                                (Var 218 k)
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 214 i)
+                                                    (Var 218 i)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -348,9 +348,9 @@
                                         )
                                         (=
                                             (ArrayItem
-                                                (Var 214 b)
+                                                (Var 218 b)
                                                 [(()
-                                                (Var 214 k)
+                                                (Var 218 k)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -359,9 +359,9 @@
                                             (RealBinOp
                                                 (Cast
                                                     (IntegerBinOp
-                                                        (Var 214 i)
+                                                        (Var 218 i)
                                                         Add
-                                                        (Var 214 j)
+                                                        (Var 218 j)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -381,7 +381,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 214 a)
+                                        (Var 218 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -397,7 +397,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 newshape)
+                                        (Var 218 newshape)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -412,7 +412,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 214 newshape)
+                                            (Var 218 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -425,7 +425,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 214 newshape)
+                                            (Var 218 newshape)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -437,11 +437,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 a)
+                                        (Var 218 a)
                                         (ArrayReshape
-                                            (Var 214 b)
+                                            (Var 218 b)
                                             (ArrayPhysicalCast
-                                                (Var 214 newshape)
+                                                (Var 218 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -464,7 +464,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 214 i)
+                                        ((Var 218 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -476,7 +476,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 214 j)
+                                            ((Var 218 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -493,12 +493,12 @@
                                                         [(RealBinOp
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 214 a)
+                                                                    (Var 218 a)
                                                                     [(()
-                                                                    (Var 214 i)
+                                                                    (Var 218 i)
                                                                     ())
                                                                     (()
-                                                                    (Var 214 j)
+                                                                    (Var 218 j)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -507,9 +507,9 @@
                                                                 Sub
                                                                 (Cast
                                                                     (IntegerBinOp
-                                                                        (Var 214 i)
+                                                                        (Var 218 i)
                                                                         Add
-                                                                        (Var 214 j)
+                                                                        (Var 218 j)
                                                                         (Integer 4)
                                                                         ()
                                                                     )
@@ -533,7 +533,7 @@
                                                         ()
                                                     )
                                                     LtE
-                                                    (Var 214 eps)
+                                                    (Var 218 eps)
                                                     (Logical 4)
                                                     ()
                                                 )
@@ -542,7 +542,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 214 c)
+                                        (Var 218 c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -560,7 +560,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 newshape1)
+                                        (Var 218 newshape1)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -575,7 +575,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 214 newshape1)
+                                            (Var 218 newshape1)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -588,7 +588,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 214 newshape1)
+                                            (Var 218 newshape1)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -601,7 +601,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 214 newshape1)
+                                            (Var 218 newshape1)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -613,11 +613,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 c)
+                                        (Var 218 c)
                                         (ArrayReshape
-                                            (Var 214 d)
+                                            (Var 218 d)
                                             (ArrayPhysicalCast
-                                                (Var 214 newshape1)
+                                                (Var 218 newshape1)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -640,7 +640,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 214 i)
+                                        ((Var 218 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -652,7 +652,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 214 j)
+                                            ((Var 218 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -664,7 +664,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 214 k)
+                                                ((Var 218 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 16 (Integer 4))
@@ -681,15 +681,15 @@
                                                             [(RealBinOp
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 214 c)
+                                                                        (Var 218 c)
                                                                         [(()
-                                                                        (Var 214 i)
+                                                                        (Var 218 i)
                                                                         ())
                                                                         (()
-                                                                        (Var 214 j)
+                                                                        (Var 218 j)
                                                                         ())
                                                                         (()
-                                                                        (Var 214 k)
+                                                                        (Var 218 k)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -699,14 +699,14 @@
                                                                     (Cast
                                                                         (IntegerBinOp
                                                                             (IntegerBinOp
-                                                                                (Var 214 i)
+                                                                                (Var 218 i)
                                                                                 Add
-                                                                                (Var 214 j)
+                                                                                (Var 218 j)
                                                                                 (Integer 4)
                                                                                 ()
                                                                             )
                                                                             Add
-                                                                            (Var 214 k)
+                                                                            (Var 218 k)
                                                                             (Integer 4)
                                                                             ()
                                                                         )
@@ -730,7 +730,7 @@
                                                             ()
                                                         )
                                                         LtE
-                                                        (Var 214 eps)
+                                                        (Var 218 eps)
                                                         (Logical 4)
                                                         ()
                                                     )
@@ -748,11 +748,11 @@
                             test_nd_to_1d:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        217
                                         {
                                             a:
                                                 (Variable
-                                                    213
+                                                    217
                                                     a
                                                     []
                                                     InOut
@@ -775,7 +775,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    213
+                                                    217
                                                     b
                                                     []
                                                     Local
@@ -796,7 +796,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    213
+                                                    217
                                                     c
                                                     []
                                                     Local
@@ -821,7 +821,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    213
+                                                    217
                                                     d
                                                     []
                                                     Local
@@ -842,7 +842,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    213
+                                                    217
                                                     eps
                                                     []
                                                     Local
@@ -858,7 +858,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    213
+                                                    217
                                                     i
                                                     []
                                                     Local
@@ -874,7 +874,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    213
+                                                    217
                                                     j
                                                     []
                                                     Local
@@ -890,7 +890,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    213
+                                                    217
                                                     k
                                                     []
                                                     Local
@@ -906,7 +906,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    213
+                                                    217
                                                     l
                                                     []
                                                     Local
@@ -922,7 +922,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    213
+                                                    217
                                                     newshape
                                                     []
                                                     Local
@@ -943,7 +943,7 @@
                                                 ),
                                             newshape1:
                                                 (Variable
-                                                    213
+                                                    217
                                                     newshape1
                                                     []
                                                     Local
@@ -986,9 +986,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 213 a)]
+                                    [(Var 217 a)]
                                     [(=
-                                        (Var 213 eps)
+                                        (Var 217 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -996,7 +996,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 b)
+                                        (Var 217 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1010,7 +1010,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 newshape)
+                                        (Var 217 newshape)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1025,7 +1025,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 newshape)
+                                            (Var 217 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1037,11 +1037,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 b)
+                                        (Var 217 b)
                                         (ArrayReshape
-                                            (Var 213 a)
+                                            (Var 217 a)
                                             (ArrayPhysicalCast
-                                                (Var 213 newshape)
+                                                (Var 217 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -1064,7 +1064,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 k)
+                                        ((Var 217 k)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -1075,10 +1075,10 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
-                                            (Var 213 i)
+                                            (Var 217 i)
                                             (IntrinsicScalarFunction
                                                 FloorDiv
-                                                [(Var 213 k)
+                                                [(Var 217 k)
                                                 (IntegerConstant 16 (Integer 4))]
                                                 0
                                                 (Integer 4)
@@ -1087,12 +1087,12 @@
                                             ()
                                         )
                                         (=
-                                            (Var 213 j)
+                                            (Var 217 j)
                                             (IntegerBinOp
-                                                (Var 213 k)
+                                                (Var 217 k)
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 213 i)
+                                                    (Var 217 i)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -1110,9 +1110,9 @@
                                                     [(RealBinOp
                                                         (RealBinOp
                                                             (ArrayItem
-                                                                (Var 213 b)
+                                                                (Var 217 b)
                                                                 [(()
-                                                                (Var 213 k)
+                                                                (Var 217 k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
@@ -1121,9 +1121,9 @@
                                                             Sub
                                                             (Cast
                                                                 (IntegerBinOp
-                                                                    (Var 213 i)
+                                                                    (Var 217 i)
                                                                     Add
-                                                                    (Var 213 j)
+                                                                    (Var 217 j)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
@@ -1147,7 +1147,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 213 eps)
+                                                (Var 217 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -1155,7 +1155,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 213 c)
+                                        (Var 217 c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1173,7 +1173,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 c)
+                                        (Var 217 c)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1192,7 +1192,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -1204,7 +1204,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 213 j)
+                                            ((Var 217 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -1216,7 +1216,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 213 k)
+                                                ((Var 217 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 16 (Integer 4))
@@ -1228,15 +1228,15 @@
                                                 (IntegerConstant 1 (Integer 4)))
                                                 [(=
                                                     (ArrayItem
-                                                        (Var 213 c)
+                                                        (Var 217 c)
                                                         [(()
-                                                        (Var 213 i)
+                                                        (Var 217 i)
                                                         ())
                                                         (()
-                                                        (Var 213 j)
+                                                        (Var 217 j)
                                                         ())
                                                         (()
-                                                        (Var 213 k)
+                                                        (Var 217 k)
                                                         ())]
                                                         (Real 8)
                                                         RowMajor
@@ -1246,14 +1246,14 @@
                                                         (Cast
                                                             (IntegerBinOp
                                                                 (IntegerBinOp
-                                                                    (Var 213 i)
+                                                                    (Var 217 i)
                                                                     Add
-                                                                    (Var 213 j)
+                                                                    (Var 217 j)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
                                                                 Add
-                                                                (Var 213 k)
+                                                                (Var 217 k)
                                                                 (Integer 4)
                                                                 ()
                                                             )
@@ -1275,7 +1275,7 @@
                                         )]
                                     )
                                     (=
-                                        (Var 213 d)
+                                        (Var 217 d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1289,7 +1289,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 newshape1)
+                                        (Var 217 newshape1)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1304,7 +1304,7 @@
                                     )
                                     (=
                                         (ArrayItem
-                                            (Var 213 newshape1)
+                                            (Var 217 newshape1)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1316,11 +1316,11 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 d)
+                                        (Var 217 d)
                                         (ArrayReshape
-                                            (Var 213 c)
+                                            (Var 217 c)
                                             (ArrayPhysicalCast
-                                                (Var 213 newshape1)
+                                                (Var 217 newshape1)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -1343,7 +1343,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 l)
+                                        ((Var 217 l)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 4096 (Integer 4))
@@ -1354,11 +1354,11 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
-                                            (Var 213 i)
+                                            (Var 217 i)
                                             (Cast
                                                 (RealBinOp
                                                     (Cast
-                                                        (Var 213 l)
+                                                        (Var 217 l)
                                                         IntegerToReal
                                                         (Real 8)
                                                         ()
@@ -1383,14 +1383,14 @@
                                             ()
                                         )
                                         (=
-                                            (Var 213 j)
+                                            (Var 217 j)
                                             (IntrinsicScalarFunction
                                                 FloorDiv
                                                 [(IntegerBinOp
-                                                    (Var 213 l)
+                                                    (Var 217 l)
                                                     Sub
                                                     (IntegerBinOp
-                                                        (Var 213 i)
+                                                        (Var 217 i)
                                                         Mul
                                                         (IntegerConstant 256 (Integer 4))
                                                         (Integer 4)
@@ -1407,13 +1407,13 @@
                                             ()
                                         )
                                         (=
-                                            (Var 213 k)
+                                            (Var 217 k)
                                             (IntegerBinOp
                                                 (IntegerBinOp
-                                                    (Var 213 l)
+                                                    (Var 217 l)
                                                     Sub
                                                     (IntegerBinOp
-                                                        (Var 213 i)
+                                                        (Var 217 i)
                                                         Mul
                                                         (IntegerConstant 256 (Integer 4))
                                                         (Integer 4)
@@ -1424,7 +1424,7 @@
                                                 )
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 213 j)
+                                                    (Var 217 j)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -1442,9 +1442,9 @@
                                                     [(RealBinOp
                                                         (RealBinOp
                                                             (ArrayItem
-                                                                (Var 213 d)
+                                                                (Var 217 d)
                                                                 [(()
-                                                                (Var 213 l)
+                                                                (Var 217 l)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
@@ -1454,14 +1454,14 @@
                                                             (Cast
                                                                 (IntegerBinOp
                                                                     (IntegerBinOp
-                                                                        (Var 213 i)
+                                                                        (Var 217 i)
                                                                         Add
-                                                                        (Var 213 j)
+                                                                        (Var 217 j)
                                                                         (Integer 4)
                                                                         ()
                                                                     )
                                                                     Add
-                                                                    (Var 213 k)
+                                                                    (Var 217 k)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
@@ -1485,7 +1485,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 213 eps)
+                                                (Var 217 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -1501,11 +1501,11 @@
                             test_reshape_with_argument:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        219
                                         {
                                             a:
                                                 (Variable
-                                                    215
+                                                    219
                                                     a
                                                     []
                                                     Local
@@ -1528,7 +1528,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    215
+                                                    219
                                                     d
                                                     []
                                                     Local
@@ -1549,7 +1549,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    215
+                                                    219
                                                     i
                                                     []
                                                     Local
@@ -1565,7 +1565,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    215
+                                                    219
                                                     j
                                                     []
                                                     Local
@@ -1581,7 +1581,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    215
+                                                    219
                                                     k
                                                     []
                                                     Local
@@ -1597,7 +1597,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    215
+                                                    219
                                                     l
                                                     []
                                                     Local
@@ -1631,7 +1631,7 @@
                                     test_1d_to_nd]
                                     []
                                     [(=
-                                        (Var 215 a)
+                                        (Var 219 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1648,7 +1648,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 215 i)
+                                        ((Var 219 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -1660,7 +1660,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 215 j)
+                                            ((Var 219 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -1672,12 +1672,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(=
                                                 (ArrayItem
-                                                    (Var 215 a)
+                                                    (Var 219 a)
                                                     [(()
-                                                    (Var 215 i)
+                                                    (Var 219 i)
                                                     ())
                                                     (()
-                                                    (Var 215 j)
+                                                    (Var 219 j)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -1686,9 +1686,9 @@
                                                 (RealBinOp
                                                     (Cast
                                                         (IntegerBinOp
-                                                            (Var 215 i)
+                                                            (Var 219 i)
                                                             Add
-                                                            (Var 215 j)
+                                                            (Var 219 j)
                                                             (Integer 4)
                                                             ()
                                                         )
@@ -1712,7 +1712,7 @@
                                         2 test_nd_to_1d
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 215 a)
+                                            (Var 219 a)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1728,7 +1728,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 215 d)
+                                        (Var 219 d)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -1743,7 +1743,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 215 l)
+                                        ((Var 219 l)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 4096 (Integer 4))
@@ -1754,11 +1754,11 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
-                                            (Var 215 i)
+                                            (Var 219 i)
                                             (Cast
                                                 (RealBinOp
                                                     (Cast
-                                                        (Var 215 l)
+                                                        (Var 219 l)
                                                         IntegerToReal
                                                         (Real 8)
                                                         ()
@@ -1783,14 +1783,14 @@
                                             ()
                                         )
                                         (=
-                                            (Var 215 j)
+                                            (Var 219 j)
                                             (IntrinsicScalarFunction
                                                 FloorDiv
                                                 [(IntegerBinOp
-                                                    (Var 215 l)
+                                                    (Var 219 l)
                                                     Sub
                                                     (IntegerBinOp
-                                                        (Var 215 i)
+                                                        (Var 219 i)
                                                         Mul
                                                         (IntegerConstant 256 (Integer 4))
                                                         (Integer 4)
@@ -1807,13 +1807,13 @@
                                             ()
                                         )
                                         (=
-                                            (Var 215 k)
+                                            (Var 219 k)
                                             (IntegerBinOp
                                                 (IntegerBinOp
-                                                    (Var 215 l)
+                                                    (Var 219 l)
                                                     Sub
                                                     (IntegerBinOp
-                                                        (Var 215 i)
+                                                        (Var 219 i)
                                                         Mul
                                                         (IntegerConstant 256 (Integer 4))
                                                         (Integer 4)
@@ -1824,7 +1824,7 @@
                                                 )
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 215 j)
+                                                    (Var 219 j)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -1837,9 +1837,9 @@
                                         )
                                         (=
                                             (ArrayItem
-                                                (Var 215 d)
+                                                (Var 219 d)
                                                 [(()
-                                                (Var 215 l)
+                                                (Var 219 l)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -1849,14 +1849,14 @@
                                                 (Cast
                                                     (IntegerBinOp
                                                         (IntegerBinOp
-                                                            (Var 215 i)
+                                                            (Var 219 i)
                                                             Add
-                                                            (Var 215 j)
+                                                            (Var 219 j)
                                                             (Integer 4)
                                                             ()
                                                         )
                                                         Add
-                                                        (Var 215 k)
+                                                        (Var 219 k)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -1879,7 +1879,7 @@
                                         2 test_1d_to_nd
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 215 d)
+                                            (Var 219 d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1909,11 +1909,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        231
+                        235
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    231
+                                    235
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1925,7 +1925,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        231 __main__global_stmts
+                        235 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_numpy_04-ecbb614.json
+++ b/tests/reference/asr-test_numpy_04-ecbb614.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_04-ecbb614.stdout",
-    "stdout_hash": "24066681e1eb081bc9287e3065e2938a40ce102e83756f71c7464b60",
+    "stdout_hash": "f7aafa916ad6585ff83a53877c0682997e1a49618d42deaa626fc866",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_04-ecbb614.stdout
+++ b/tests/reference/asr-test_numpy_04-ecbb614.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        216
+                                        220
                                         {
                                             
                                         })
@@ -46,7 +46,7 @@
                             check:
                                 (Function
                                     (SymbolTable
-                                        215
+                                        219
                                         {
                                             
                                         })
@@ -89,11 +89,11 @@
                             test_array_01:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        217
                                         {
                                             eps:
                                                 (Variable
-                                                    213
+                                                    217
                                                     eps
                                                     []
                                                     Local
@@ -109,7 +109,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    213
+                                                    217
                                                     x
                                                     []
                                                     Local
@@ -147,7 +147,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 213 x)
+                                        (Var 217 x)
                                         (ArrayConstant
                                             [(RealConstant
                                                 1.000000
@@ -172,7 +172,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 eps)
+                                        (Var 217 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -185,7 +185,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 213 x)
+                                                        (Var 217 x)
                                                         [(()
                                                         (IntegerConstant 0 (Integer 4))
                                                         ())]
@@ -206,7 +206,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 213 eps)
+                                            (Var 217 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -218,7 +218,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 213 x)
+                                                        (Var 217 x)
                                                         [(()
                                                         (IntegerConstant 1 (Integer 4))
                                                         ())]
@@ -239,7 +239,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 213 eps)
+                                            (Var 217 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -251,7 +251,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 213 x)
+                                                        (Var 217 x)
                                                         [(()
                                                         (IntegerConstant 2 (Integer 4))
                                                         ())]
@@ -272,7 +272,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 213 eps)
+                                            (Var 217 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -287,11 +287,11 @@
                             test_array_02:
                                 (Function
                                     (SymbolTable
-                                        214
+                                        218
                                         {
                                             eps:
                                                 (Variable
-                                                    214
+                                                    218
                                                     eps
                                                     []
                                                     Local
@@ -307,7 +307,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    214
+                                                    218
                                                     x
                                                     []
                                                     Local
@@ -345,7 +345,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 214 x)
+                                        (Var 218 x)
                                         (ArrayConstant
                                             [(IntegerConstant 1 (Integer 4))
                                             (IntegerConstant 2 (Integer 4))
@@ -361,7 +361,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 214 eps)
+                                        (Var 218 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -375,7 +375,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 214 x)
+                                                            (Var 218 x)
                                                             [(()
                                                             (IntegerConstant 0 (Integer 4))
                                                             ())]
@@ -397,7 +397,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 214 eps)
+                                            (Var 218 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -410,7 +410,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 214 x)
+                                                            (Var 218 x)
                                                             [(()
                                                             (IntegerConstant 1 (Integer 4))
                                                             ())]
@@ -432,7 +432,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 214 eps)
+                                            (Var 218 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -445,7 +445,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 214 x)
+                                                            (Var 218 x)
                                                             [(()
                                                             (IntegerConstant 2 (Integer 4))
                                                             ())]
@@ -467,7 +467,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 214 eps)
+                                            (Var 218 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -490,11 +490,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        217
+                        221
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    217
+                                    221
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -506,7 +506,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        217 __main__global_stmts
+                        221 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_pow-3f5d550.json
+++ b/tests/reference/asr-test_pow-3f5d550.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_pow-3f5d550.stdout",
-    "stdout_hash": "2e9aa5421687f0dc2a5b8aba48d887cef6c04c3d8e28569637396212",
+    "stdout_hash": "f99fae8fa893e9c136dc484ae505e45e656d00e836d569069b740de0",
     "stderr": "asr-test_pow-3f5d550.stderr",
     "stderr_hash": "3d950301563cce75654f28bf41f6f53428ed1f5ae997774345f374a3",
     "returncode": 0

--- a/tests/reference/asr-test_pow-3f5d550.stdout
+++ b/tests/reference/asr-test_pow-3f5d550.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        129
+                                        133
                                         {
                                             
                                         })
@@ -130,11 +130,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        130
+                        134
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    130
+                                    134
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -146,7 +146,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        130 __main__global_stmts
+                        134 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-vec_01-66ac423.json
+++ b/tests/reference/asr-vec_01-66ac423.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-vec_01-66ac423.stdout",
-    "stdout_hash": "2c09e8d2e737d230a66aa6804cb871e71bcb54ea665e16b4cea1538c",
+    "stdout_hash": "1e7aa6b0ddf132fdcba7bee154ce4f2182e35d5e262ba5c6d04d9ad9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-vec_01-66ac423.stdout
+++ b/tests/reference/asr-vec_01-66ac423.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        221
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             loop_vec:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        217
                                         {
                                             a:
                                                 (Variable
-                                                    213
+                                                    217
                                                     a
                                                     []
                                                     Local
@@ -71,7 +71,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    213
+                                                    217
                                                     b
                                                     []
                                                     Local
@@ -92,7 +92,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    213
+                                                    217
                                                     i
                                                     []
                                                     Local
@@ -125,7 +125,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 213 a)
+                                        (Var 217 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -139,7 +139,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 b)
+                                        (Var 217 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -154,7 +154,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -166,9 +166,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 213 b)
+                                                (Var 217 b)
                                                 [(()
-                                                (Var 213 i)
+                                                (Var 217 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -183,7 +183,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -195,18 +195,18 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 213 a)
+                                                (Var 217 a)
                                                 [(()
-                                                (Var 213 i)
+                                                (Var 217 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (ArrayItem
-                                                (Var 213 b)
+                                                (Var 217 b)
                                                 [(()
-                                                (Var 213 i)
+                                                (Var 217 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -217,7 +217,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -230,9 +230,9 @@
                                         [(Assert
                                             (RealCompare
                                                 (ArrayItem
-                                                    (Var 213 a)
+                                                    (Var 217 a)
                                                     [(()
-                                                    (Var 213 i)
+                                                    (Var 217 i)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -266,11 +266,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        218
+                        222
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    218
+                                    222
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -282,7 +282,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        218 __main__global_stmts
+                        222 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/pass_loop_vectorise-vec_01-be9985e.json
+++ b/tests/reference/pass_loop_vectorise-vec_01-be9985e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_loop_vectorise-vec_01-be9985e.stdout",
-    "stdout_hash": "87dc60df76e2bb9964f92e4c52c4104df2232195a75968724f9faf67",
+    "stdout_hash": "5e00c84dbfa994e8cfda471d186672fdc2bb519cce4261e5b16d3d4b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_loop_vectorise-vec_01-be9985e.stdout
+++ b/tests/reference/pass_loop_vectorise-vec_01-be9985e.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        217
+                                        221
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             loop_vec:
                                 (Function
                                     (SymbolTable
-                                        213
+                                        217
                                         {
                                             a:
                                                 (Variable
-                                                    213
+                                                    217
                                                     a
                                                     []
                                                     Local
@@ -71,7 +71,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    213
+                                                    217
                                                     b
                                                     []
                                                     Local
@@ -92,7 +92,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    213
+                                                    217
                                                     i
                                                     []
                                                     Local
@@ -109,11 +109,11 @@
                                             vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization:
                                                 (Function
                                                     (SymbolTable
-                                                        219
+                                                        223
                                                         {
                                                             __1_k:
                                                                 (Variable
-                                                                    219
+                                                                    223
                                                                     __1_k
                                                                     []
                                                                     Local
@@ -129,7 +129,7 @@
                                                                 ),
                                                             arg0:
                                                                 (Variable
-                                                                    219
+                                                                    223
                                                                     arg0
                                                                     []
                                                                     In
@@ -150,7 +150,7 @@
                                                                 ),
                                                             arg1:
                                                                 (Variable
-                                                                    219
+                                                                    223
                                                                     arg1
                                                                     []
                                                                     In
@@ -171,7 +171,7 @@
                                                                 ),
                                                             arg2:
                                                                 (Variable
-                                                                    219
+                                                                    223
                                                                     arg2
                                                                     []
                                                                     In
@@ -187,7 +187,7 @@
                                                                 ),
                                                             arg3:
                                                                 (Variable
-                                                                    219
+                                                                    223
                                                                     arg3
                                                                     []
                                                                     In
@@ -203,7 +203,7 @@
                                                                 ),
                                                             arg4:
                                                                 (Variable
-                                                                    219
+                                                                    223
                                                                     arg4
                                                                     []
                                                                     In
@@ -219,7 +219,7 @@
                                                                 ),
                                                             arg5:
                                                                 (Variable
-                                                                    219
+                                                                    223
                                                                     arg5
                                                                     []
                                                                     In
@@ -265,18 +265,18 @@
                                                         .false.
                                                     )
                                                     []
-                                                    [(Var 219 arg0)
-                                                    (Var 219 arg1)
-                                                    (Var 219 arg2)
-                                                    (Var 219 arg3)
-                                                    (Var 219 arg4)
-                                                    (Var 219 arg5)]
+                                                    [(Var 223 arg0)
+                                                    (Var 223 arg1)
+                                                    (Var 223 arg2)
+                                                    (Var 223 arg3)
+                                                    (Var 223 arg4)
+                                                    (Var 223 arg5)]
                                                     [(=
-                                                        (Var 219 __1_k)
+                                                        (Var 223 __1_k)
                                                         (IntegerBinOp
-                                                            (Var 219 arg2)
+                                                            (Var 223 arg2)
                                                             Sub
-                                                            (Var 219 arg4)
+                                                            (Var 223 arg4)
                                                             (Integer 4)
                                                             ()
                                                         )
@@ -286,23 +286,23 @@
                                                         ()
                                                         (IntegerCompare
                                                             (IntegerBinOp
-                                                                (Var 219 __1_k)
+                                                                (Var 223 __1_k)
                                                                 Add
-                                                                (Var 219 arg4)
+                                                                (Var 223 arg4)
                                                                 (Integer 4)
                                                                 ()
                                                             )
                                                             Lt
-                                                            (Var 219 arg3)
+                                                            (Var 223 arg3)
                                                             (Logical 4)
                                                             ()
                                                         )
                                                         [(=
-                                                            (Var 219 __1_k)
+                                                            (Var 223 __1_k)
                                                             (IntegerBinOp
-                                                                (Var 219 __1_k)
+                                                                (Var 223 __1_k)
                                                                 Add
-                                                                (Var 219 arg4)
+                                                                (Var 223 arg4)
                                                                 (Integer 4)
                                                                 ()
                                                             )
@@ -310,18 +310,18 @@
                                                         )
                                                         (=
                                                             (ArrayItem
-                                                                (Var 219 arg0)
+                                                                (Var 223 arg0)
                                                                 [(()
-                                                                (Var 219 __1_k)
+                                                                (Var 223 __1_k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
                                                                 ()
                                                             )
                                                             (ArrayItem
-                                                                (Var 219 arg1)
+                                                                (Var 223 arg1)
                                                                 [(()
-                                                                (Var 219 __1_k)
+                                                                (Var 223 __1_k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
@@ -355,7 +355,7 @@
                                     []
                                     []
                                     [(=
-                                        (Var 213 a)
+                                        (Var 217 a)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -369,7 +369,7 @@
                                         ()
                                     )
                                     (=
-                                        (Var 213 b)
+                                        (Var 217 b)
                                         (ArrayConstant
                                             []
                                             (Array
@@ -384,7 +384,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -396,9 +396,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(=
                                             (ArrayItem
-                                                (Var 213 b)
+                                                (Var 217 b)
                                                 [(()
-                                                (Var 213 i)
+                                                (Var 217 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -413,17 +413,17 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerConstant 1151 (Integer 4))
                                         (IntegerConstant 1 (Integer 4)))
                                         [(SubroutineCall
-                                            213 vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization
+                                            217 vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization
                                             ()
-                                            [((Var 213 a))
-                                            ((Var 213 b))
+                                            [((Var 217 a))
+                                            ((Var 217 b))
                                             ((IntegerBinOp
-                                                (Var 213 i)
+                                                (Var 217 i)
                                                 Mul
                                                 (IntegerConstant 8 (Integer 4))
                                                 (Integer 4)
@@ -431,7 +431,7 @@
                                             ))
                                             ((IntegerBinOp
                                                 (IntegerBinOp
-                                                    (Var 213 i)
+                                                    (Var 217 i)
                                                     Add
                                                     (IntegerConstant 1 (Integer 4))
                                                     (Integer 4)
@@ -449,7 +449,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 213 i)
+                                        ((Var 217 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -462,9 +462,9 @@
                                         [(Assert
                                             (RealCompare
                                                 (ArrayItem
-                                                    (Var 213 a)
+                                                    (Var 217 a)
                                                     [(()
-                                                    (Var 213 i)
+                                                    (Var 217 i)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -498,11 +498,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        218
+                        222
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    218
+                                    222
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -514,7 +514,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        218 __main__global_stmts
+                        222 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()


### PR DESCRIPTION
Towards: https://github.com/lcompilers/lpython/issues/2356

APIs added:

- isalnum()
- isnumeric()

These have been tested extensively, for both compile time and run time tests.