### PR TITLE
Implement `str` to `int` conversion

### DIFF
--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -1357,6 +1357,16 @@ ASR::asr_t* make_Cast_t_value(Allocator &al, const Location &a_loc,
             double real = value_complex->m_re;
             value = ASR::down_cast<ASR::expr_t>(
                     ASR::make_RealConstant_t(al, a_loc, real, a_type));
+        } else if (a_kind == ASR::cast_kindType::CharacterToInteger) {
+            int64_t value_integer;
+            int integer_type = ASRUtils::extract_kind_from_ttype_t(a_type);
+            std::string src_string = ASR::down_cast<ASR::StringConstant_t>(ASRUtils::expr_value(a_arg))->m_s;
+            if (integer_type <= 4) {
+                value_integer = std::stoi(src_string);
+            } else {
+                value_integer = std::stol(src_string);
+            }
+            value = ASR::down_cast<ASR::expr_t>(ASR::make_IntegerConstant_t(al, a_loc, value_integer, a_type));
         } else if (a_kind == ASR::cast_kindType::IntegerToSymbolicExpression) {
             Vec<ASR::expr_t*> args;
             args.reserve(al, 1);

--- a/src/libasr/casting_utils.cpp
+++ b/src/libasr/casting_utils.cpp
@@ -27,6 +27,7 @@ namespace LCompilers::CastingUtil {
         {std::make_pair(ASR::ttypeType::Integer, ASR::ttypeType::Complex), ASR::cast_kindType::IntegerToComplex},
         {std::make_pair(ASR::ttypeType::Integer, ASR::ttypeType::Real), ASR::cast_kindType::IntegerToReal},
         {std::make_pair(ASR::ttypeType::Integer, ASR::ttypeType::Logical), ASR::cast_kindType::IntegerToLogical},
+        {std::make_pair(ASR::ttypeType::Character, ASR::ttypeType::Integer), ASR::cast_kindType::CharacterToInteger},
         {std::make_pair(ASR::ttypeType::Integer, ASR::ttypeType::UnsignedInteger), ASR::cast_kindType::IntegerToUnsignedInteger},
         {std::make_pair(ASR::ttypeType::Logical, ASR::ttypeType::Real), ASR::cast_kindType::LogicalToReal},
         {std::make_pair(ASR::ttypeType::Logical, ASR::ttypeType::Integer), ASR::cast_kindType::LogicalToInteger},


### PR DESCRIPTION
Resolves #2554 

Implement basic string to integer conversion through a clean ASR using casting.

### Working
```python
from lpython import i8, i16, i32, i64

int8: i8 = i8("100")
int16: i16 = i16("100")
int32: i32 = i32("100")
int64: i64 = i64("100")

print("int8:", int8)
print("int16:", int16)
print("int32:", int32)
print("int64:", int64)
print()
print("int8 + i8(10)", int8 + i8(10))
print("int16 * i16(2):", int16 * i16(2))
print("int32 - 50:", int32 - 50)
print("int64 / i64(2):", int64 / i64(2))
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lpython$ ./src/bin/lpython ./examples/example.py
int8: 100
int16: 100
int32: 100
int64: 100

int8 + i8(10) 110
int16 * i16(2): 200
int32 - 50: 50
int64 / i64(2): 5.00000000000000000e+01
```

### ASR
```console
                            int32:
                                (Variable
                                    2
                                    int32
                                    []
                                    Local
                                    (Cast
                                        (StringConstant
                                            "100"
                                            (Character 1 3 ())
                                        )
                                        CharacterToInteger
                                        (Integer 4)
                                        (IntegerConstant 100 (Integer 4))
                                    )
                                    (IntegerConstant 100 (Integer 4))
                                    Default
                                    (Integer 4)
                                    ()
                                    Source
                                    Public
                                    Required
                                    .false.
                                ),
                            int64:
                                (Variable
                                    2
                                    int64
                                    []
                                    Local
                                    (Cast
                                        (StringConstant
                                            "100"
                                            (Character 1 3 ())
                                        )
                                        CharacterToInteger
                                        (Integer 8)
                                        (IntegerConstant 100 (Integer 8))
                                    )
                                    (IntegerConstant 100 (Integer 8))
                                    Default
                                    (Integer 8)
                                    ()
                                    Source
                                    Public
                                    Required
                                    .false.
                                ),
```

### Tasks
[ ] Throw a semantic error when an invalid literal is passed. While this can be handled while casting, it is not very clean to do it there. I request guidance on where the error should be thrown.
[ ] Throw an error when an integer larger or smaller than the upper and lower bounds is passed as a valid string. I request guidance on where it should be handled.
[ ] Handle integers with other bases. I doubt whether the types `i8`, `i16`, etc even take a 2nd argument. Even when several arguments are passed, only the 1st is dealt with and errors related to the same are thrown.