### PR TITLE
Function Default Arguments

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -792,7 +792,6 @@ RUN(NAME test_str_attributes LABELS cpython llvm llvm_jit c)
 RUN(NAME kwargs_01           LABELS cpython llvm llvm_jit c NOFAST)
 RUN(NAME def_func_01         LABELS cpython llvm c)
 
-
 RUN(NAME func_inline_01 LABELS llvm llvm_jit c wasm)
 RUN(NAME func_inline_02 LABELS cpython llvm llvm_jit c)
 RUN(NAME func_static_01 LABELS cpython llvm llvm_jit c wasm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -790,6 +790,8 @@ RUN(NAME test_statistics_01  LABELS cpython llvm llvm_jit NOFAST)
 RUN(NAME test_statistics_02  LABELS cpython llvm llvm_jit NOFAST REQ_PY_VER 3.10)
 RUN(NAME test_str_attributes LABELS cpython llvm llvm_jit c)
 RUN(NAME kwargs_01           LABELS cpython llvm llvm_jit c NOFAST)
+RUN(NAME def_func_01         LABELS cpython llvm c)
+
 
 RUN(NAME func_inline_01 LABELS llvm llvm_jit c wasm)
 RUN(NAME func_inline_02 LABELS cpython llvm llvm_jit c)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -790,7 +790,7 @@ RUN(NAME test_statistics_01  LABELS cpython llvm llvm_jit NOFAST)
 RUN(NAME test_statistics_02  LABELS cpython llvm llvm_jit NOFAST REQ_PY_VER 3.10)
 RUN(NAME test_str_attributes LABELS cpython llvm llvm_jit c)
 RUN(NAME kwargs_01           LABELS cpython llvm llvm_jit c NOFAST)
-RUN(NAME def_func_01         LABELS cpython llvm c)
+RUN(NAME def_func_01         LABELS cpython llvm llvm_jit c)
 
 RUN(NAME func_inline_01 LABELS llvm llvm_jit c wasm)
 RUN(NAME func_inline_02 LABELS cpython llvm llvm_jit c)

--- a/integration_tests/def_func_01.py
+++ b/integration_tests/def_func_01.py
@@ -1,0 +1,68 @@
+from lpython import i32,i64
+
+def factorial_1(x: i32, y:i32 =1) ->i32 :
+    if x <= 1:
+         return y
+    return x * factorial_1(x-1)
+
+def factorial_2(x: i32, y:i32=3 ,z:i32 =2) ->i32:
+    if x ==4:
+        return x * y * z
+    return x * factorial_2(x-1)
+
+def default_func(x : str ="Hello" ,y : str = " ", z : str = "World") ->str:
+    return x + y + z
+
+
+def even_positons(iterator : i32 , to_add : str = "?")-> str:
+    if (iterator == 10): return ""
+
+    if iterator%2 == 0 :
+        return to_add + even_positons(iterator+1,"X")
+
+    return to_add +even_positons(iterator+1)
+
+
+
+def test_all():
+
+    test_01 : i32  = factorial_1(5,0)
+    print("test_01 is =>",test_01)
+    assert test_01 == 120
+
+    test_02 : i32  = factorial_1(1,5555)
+    print("test_02 is =>",test_02)
+    assert test_02 == 5555
+
+    test_03 : i32 =factorial_2(5,99999,99999)
+    print("test_03 is =>",test_03)
+    assert test_03 == 120
+
+    test_04 : i32  = factorial_2(4,-1,100)
+    print("test_04 is =>",test_04)
+    assert test_04 == -400
+
+    test_05 :str = default_func()
+    print("test_05 is =>",test_05)
+    assert test_05 == "Hello World"
+
+    test_06 :str = default_func(y = "|||",x="Hi")
+    print("test_06 is =>",test_06)
+    assert test_06 == "Hi|||World"
+
+    test_07 : str = even_positons(0)
+    print("test_07 is =>",test_07)
+    assert test_07 == "?X?X?X?X?X"
+
+    test_08 : str = even_positons(0,"W")
+    print("test_08 is =>",test_08)
+    assert test_08 == "WX?X?X?X?X"
+
+test_all()
+
+
+
+
+
+
+    

--- a/integration_tests/def_func_01.py
+++ b/integration_tests/def_func_01.py
@@ -22,7 +22,7 @@ def even_positions(iterator : i32, to_add : str = "?")-> str:
 
 
 
-def test_all():
+def test_factorial_1():
     test_00 : i32  = factorial_1(1)
     print("test_00 is =>", test_00)
     assert test_00 == 1
@@ -35,6 +35,7 @@ def test_all():
     print("test_02 is =>", test_02)
     assert test_02 == 5555
 
+def test_factorial_2():
     test_03 : i32 =factorial_2(5,99999,99999)
     print("test_03 is =>", test_03)
     assert test_03 == 120
@@ -43,6 +44,7 @@ def test_all():
     print("test_04 is =>", test_04)
     assert test_04 == -400
 
+def test_default_func():
     test_05 :str = default_func()
     print("test_05 is =>", test_05)
     assert test_05 == "Hello World"
@@ -51,19 +53,24 @@ def test_all():
     print("test_06 is =>", test_06)
     assert test_06 == "Hi|||World"
 
-    test_07 : str = even_positions(0)
+    test_07 :str = default_func(y = "++",z = "LPython")
     print("test_07 is =>", test_07)
-    assert test_07 == "?X?X?X?X?X"
+    assert test_07 == "Hello++LPython"
 
-    test_08 : str = even_positions(0,"W")
-    print("test_08 is =>", test_08)
-    assert test_08 == "WX?X?X?X?X"
+    test_8 :str = default_func("Welcome",z = "LPython")
+    print("test_8 is =>", test_8)
+    assert test_8 == "Welcome LPython"
 
-    test_09 :str = default_func(y = "++",z = "LPython")
+def test_even_positions():
+    test_09 : str = even_positions(0)
     print("test_09 is =>", test_09)
-    assert test_09 == "Hello++LPython"
+    assert test_09 == "?X?X?X?X?X"
 
-    test_10 :str = default_func("Welcome",z = "LPython")
+    test_10 : str = even_positions(0,"W")
     print("test_10 is =>", test_10)
-    assert test_10 == "Welcome LPython"
-test_all() 
+    assert test_10 == "WX?X?X?X?X"
+
+test_factorial_1()
+test_factorial_2()
+test_default_func()
+test_even_positions() 

--- a/integration_tests/def_func_01.py
+++ b/integration_tests/def_func_01.py
@@ -10,71 +10,60 @@ def factorial_2(x: i32, y:i32=3 ,z:i32 =2) ->i32:
         return x * y * z
     return x * factorial_2(x-1)
 
-def default_func(x : str ="Hello" ,y : str = " ", z : str = "World") ->str:
+def default_func(x : str ="Hello", y : str = " ", z : str = "World") ->str:
     return x + y + z
 
 
-def even_positions(iterator : i32 , to_add : str = "?")-> str:
+def even_positions(iterator : i32, to_add : str = "?")-> str:
     if (iterator == 10): return ""
-
     if iterator%2 == 0 :
         return to_add + even_positions(iterator+1,"X")
-
     return to_add +even_positions(iterator+1)
 
 
 
 def test_all():
-
     test_00 : i32  = factorial_1(1)
-    print("test_00 is =>",test_00)
+    print("test_00 is =>", test_00)
     assert test_00 == 1
 
     test_01 : i32  = factorial_1(5,0)
-    print("test_01 is =>",test_01)
+    print("test_01 is =>", test_01)
     assert test_01 == 120
 
     test_02 : i32  = factorial_1(1,5555)
-    print("test_02 is =>",test_02)
+    print("test_02 is =>", test_02)
     assert test_02 == 5555
 
     test_03 : i32 =factorial_2(5,99999,99999)
-    print("test_03 is =>",test_03)
+    print("test_03 is =>", test_03)
     assert test_03 == 120
 
     test_04 : i32  = factorial_2(4,-1,100)
-    print("test_04 is =>",test_04)
+    print("test_04 is =>", test_04)
     assert test_04 == -400
 
     test_05 :str = default_func()
-    print("test_05 is =>",test_05)
+    print("test_05 is =>", test_05)
     assert test_05 == "Hello World"
 
     test_06 :str = default_func(y = "|||",x="Hi")
-    print("test_06 is =>",test_06)
+    print("test_06 is =>", test_06)
     assert test_06 == "Hi|||World"
 
-
     test_07 : str = even_positions(0)
-    print("test_07 is =>",test_07)
+    print("test_07 is =>", test_07)
     assert test_07 == "?X?X?X?X?X"
 
     test_08 : str = even_positions(0,"W")
-    print("test_08 is =>",test_08)
+    print("test_08 is =>", test_08)
     assert test_08 == "WX?X?X?X?X"
 
     test_09 :str = default_func(y = "++",z = "LPython")
-    print("test_09 is =>",test_09)
+    print("test_09 is =>", test_09)
     assert test_09 == "Hello++LPython"
 
     test_10 :str = default_func("Welcome",z = "LPython")
-    print("test_10 is =>",test_10)
+    print("test_10 is =>", test_10)
     assert test_10 == "Welcome LPython"
-test_all()
-
-
-
-
-
-
-    
+test_all() 

--- a/integration_tests/def_func_01.py
+++ b/integration_tests/def_func_01.py
@@ -14,17 +14,21 @@ def default_func(x : str ="Hello" ,y : str = " ", z : str = "World") ->str:
     return x + y + z
 
 
-def even_positons(iterator : i32 , to_add : str = "?")-> str:
+def even_positions(iterator : i32 , to_add : str = "?")-> str:
     if (iterator == 10): return ""
 
     if iterator%2 == 0 :
-        return to_add + even_positons(iterator+1,"X")
+        return to_add + even_positions(iterator+1,"X")
 
-    return to_add +even_positons(iterator+1)
+    return to_add +even_positions(iterator+1)
 
 
 
 def test_all():
+
+    test_00 : i32  = factorial_1(1)
+    print("test_00 is =>",test_00)
+    assert test_00 == 1
 
     test_01 : i32  = factorial_1(5,0)
     print("test_01 is =>",test_01)
@@ -51,11 +55,11 @@ def test_all():
     assert test_06 == "Hi|||World"
 
 
-    test_07 : str = even_positons(0)
+    test_07 : str = even_positions(0)
     print("test_07 is =>",test_07)
     assert test_07 == "?X?X?X?X?X"
 
-    test_08 : str = even_positons(0,"W")
+    test_08 : str = even_positions(0,"W")
     print("test_08 is =>",test_08)
     assert test_08 == "WX?X?X?X?X"
 

--- a/integration_tests/def_func_01.py
+++ b/integration_tests/def_func_01.py
@@ -50,6 +50,7 @@ def test_all():
     print("test_06 is =>",test_06)
     assert test_06 == "Hi|||World"
 
+
     test_07 : str = even_positons(0)
     print("test_07 is =>",test_07)
     assert test_07 == "?X?X?X?X?X"
@@ -58,6 +59,13 @@ def test_all():
     print("test_08 is =>",test_08)
     assert test_08 == "WX?X?X?X?X"
 
+    test_09 :str = default_func(y = "++",z = "LPython")
+    print("test_09 is =>",test_09)
+    assert test_09 == "Hello++LPython"
+
+    test_10 :str = default_func("Welcome",z = "LPython")
+    print("test_10 is =>",test_10)
+    assert test_10 == "Welcome LPython"
 test_all()
 
 

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -565,6 +565,7 @@ R"(#include <stdio.h>
                 if( is_c ) {
                     CDeclarationOptions c_decl_options;
                     c_decl_options.pre_initialise_derived_type = false;
+                    c_decl_options.do_not_initialize = true;
                     func += self().convert_variable_decl(*arg, &c_decl_options);
                 } else {
                     CPPDeclarationOptions cpp_decl_options;

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5167,39 +5167,6 @@ public:
         ASR::expr_t* assign_asr_target_copy = assign_asr_target;
         this->visit_expr(*x.m_targets[0]);
         assign_asr_target = ASRUtils::EXPR(tmp);
-        //Construction-While-Assigning Problem
-        AST::exprType value_type_ast = (x.m_value)->type;
-        AST::exprType objects_to_check[3] { AST::exprType::Set,  // just check these 3 for now.
-        									AST::exprType::Dict,
-        									AST::exprType::List };  
-        for(AST::exprType &exp : objects_to_check){
-            if (exp == value_type_ast){
-                ASR::ttype_t *target_type = ASRUtils::expr_type(assign_asr_target);
-                try{
-                    this->visit_expr(*x.m_value);
-                }
-                catch (SemanticError &error){
-                    ASR::expr_t *value_ASR_after_down_cast = ASRUtils::EXPR(tmp);
-                    ASR::ttype_t *value_type = ASRUtils::expr_type(value_ASR_after_down_cast);
-                    if (!ASRUtils::check_equal_type(target_type, value_type)){
-                        std::string ltype = ASRUtils::type_to_str_python(target_type);
-                        std::string rtype = ASRUtils::type_to_str_python(value_type);
-                        diag.add(diag::Diagnostic(
-                                "Type mismatch in assignment, the types must be compatible",
-                                diag::Level::Error, diag::Stage::Semantic, {
-                                        diag::Label("type mismatch ('" + ltype + "' and '" + rtype + "')",
-                                                    {assign_asr_target->base.loc, value_ASR_after_down_cast->base.loc})
-                                })
-                        );
-                        throw SemanticAbort();
-                    }
-                }
-            }
-
-        }
-
-
-
         this->visit_expr(*x.m_value);
         assign_asr_target = assign_asr_target_copy;
         if (tmp) {
@@ -6671,9 +6638,6 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {
-                	//set the tmp to use it in the error message.(copied from the end of this function)              	
-                    ASR::ttype_t* set_type = ASRUtils::TYPE(ASR::make_Set_t(al, x.base.base.loc, type));
-                    tmp = ASR::make_SetConstant_t(al, x.base.base.loc, elements.p, elements.size(), set_type);
                     throw SemanticError("All Set values must be of the same type for now",
                                         x.base.base.loc);
                 }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5204,6 +5204,38 @@ public:
         ASR::expr_t* assign_asr_target_copy = assign_asr_target;
         this->visit_expr(*x.m_targets[0]);
         assign_asr_target = ASRUtils::EXPR(tmp);
+        //Construction-While-Assigning Problem
+        AST::exprType value_type_ast = (x.m_value)->type;
+        AST::exprType objects_to_check[4] {AST::exprType::Set,AST::exprType::Dict, // just check these 4 for now.
+                                           AST::exprType::Tuple,AST::exprType::List};
+        for(AST::exprType &exp : objects_to_check){
+            if (exp == value_type_ast){
+                ASR::ttype_t *target_type = ASRUtils::expr_type(assign_asr_target);
+                try{
+                    this->visit_expr(*x.m_value);
+                }
+                catch (SemanticError &error){
+                    ASR::expr_t *value_ASR_after_down_cast = ASRUtils::EXPR(tmp);
+                    ASR::ttype_t *value_type = ASRUtils::expr_type(value_ASR_after_down_cast);
+                    if (!ASRUtils::check_equal_type(target_type, value_type)){
+                        std::string ltype = ASRUtils::type_to_str_python(target_type);
+                        std::string rtype = ASRUtils::type_to_str_python(value_type);
+                        diag.add(diag::Diagnostic(
+                                "Type mismatch in assignment, the types must be compatible",
+                                diag::Level::Error, diag::Stage::Semantic, {
+                                        diag::Label("type mismatch ('" + ltype + "' and '" + rtype + "')",
+                                                    {assign_asr_target->base.loc, value_ASR_after_down_cast->base.loc})
+                                })
+                        );
+                        throw SemanticAbort();
+                    }
+                }
+            }
+
+        }
+
+
+
         this->visit_expr(*x.m_value);
         assign_asr_target = assign_asr_target_copy;
         if (tmp) {
@@ -6666,6 +6698,9 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {
+                    //set the tmp to use it in the error message.
+                    ASR::ttype_t* set_type = ASRUtils::TYPE(ASR::make_Set_t(al, x.base.base.loc, type));
+                    tmp = ASR::make_SetConstant_t(al, x.base.base.loc, elements.p, elements.size(), set_type);
                     throw SemanticError("All Set values must be of the same type for now",
                                         x.base.base.loc);
                 }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1143,7 +1143,7 @@ public:
                 visit_expr_list(pos_args, n_pos_args, kwargs, n_kwargs,
                                 args, rt_subs, func, loc);
             }
-        	if((n_pos_args+ n_kwargs) < func->n_args){
+        	if((n_pos_args+ n_kwargs) < func->n_args && (args.size() < func->n_args) ){
                 for(size_t def_arg = (n_pos_args+ n_kwargs) ; def_arg <(func->n_args) ;def_arg++){
                     if(! ((func->m_args)[def_arg]) ) {
                         break;
@@ -1152,7 +1152,7 @@ public:
                     args.push_back(al,call_arg);
                     ASR::symbol_t* sym = (ASR::down_cast<ASR::Var_t>((func->m_args)[def_arg]))->m_v;
                     ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
-                    // args.p[def_arg].loc = ((var->m_value)->base).loc;
+                    args.p[def_arg].loc = ((var->m_value)->base).loc;
                     args.p[def_arg].m_value = (var->m_value);
                 }
             }
@@ -1200,6 +1200,7 @@ public:
                 return make_call_helper(al, t, current_scope, new_args, new_call_name, loc);
             }
             if (args.size() != func->n_args) {
+                std::cout<<"\nthis happened";
                 std::string fnd = std::to_string(args.size());
                 std::string org = std::to_string(func->n_args);
                 diag.add(diag::Diagnostic(

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -705,6 +705,8 @@ public:
             call_args_vec.p[arg_pos].m_value = expr;
         }
         // Filling missing arguments with their defaults passed in function definition (if present).
+        std::string missed_args_names;
+        size_t missed_args_count =0;
         for(size_t i = 0; i < orig_func->n_args; i++ ){
             if(call_args_vec.p[i].m_value == nullptr){
                 ASR::Variable_t* var = ASRUtils::EXPR2VAR(orig_func->m_args[i]);
@@ -6690,7 +6692,7 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {
-                	throw SemanticError("All Set values must be of the same type for now",
+                    throw SemanticError("All Set values must be of the same type for now",
                                         x.base.base.loc);
                 }
             }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1145,13 +1145,13 @@ public:
             }
         	if((n_pos_args+ n_kwargs) < func->n_args && (args.size() < func->n_args) ){
                 for(size_t def_arg = (n_pos_args+ n_kwargs) ; def_arg <(func->n_args) ;def_arg++){
-                    if(! ((func->m_args)[def_arg]) ) {
-                        break;
-                    }
                     ASR::call_arg_t call_arg;
                     args.push_back(al,call_arg);
                     ASR::symbol_t* sym = (ASR::down_cast<ASR::Var_t>((func->m_args)[def_arg]))->m_v;
                     ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
+                    if(!(var->m_value)) {
+                        break;
+                    }
                     args.p[def_arg].loc = ((var->m_value)->base).loc;
                     args.p[def_arg].m_value = (var->m_value);
                 }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1200,7 +1200,6 @@ public:
                 return make_call_helper(al, t, current_scope, new_args, new_call_name, loc);
             }
             if (args.size() != func->n_args) {
-                std::cout<<"\nthis happened";
                 std::string fnd = std::to_string(args.size());
                 std::string org = std::to_string(func->n_args);
                 diag.add(diag::Diagnostic(

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5167,39 +5167,6 @@ public:
         ASR::expr_t* assign_asr_target_copy = assign_asr_target;
         this->visit_expr(*x.m_targets[0]);
         assign_asr_target = ASRUtils::EXPR(tmp);
-        //Construction-While-Assigning Problem
-        AST::exprType value_type_ast = (x.m_value)->type;
-        AST::exprType objects_to_check[3] { AST::exprType::Set,  // just check these 3 for now.
-        									AST::exprType::Dict,
-        									AST::exprType::List };  
-        for(AST::exprType &exp : objects_to_check){
-            if (exp == value_type_ast){
-                ASR::ttype_t *target_type = ASRUtils::expr_type(assign_asr_target);
-                try{
-                    this->visit_expr(*x.m_value);
-                }
-                catch (SemanticError &error){
-                    ASR::expr_t *value_ASR_after_down_cast = ASRUtils::EXPR(tmp);
-                    ASR::ttype_t *value_type = ASRUtils::expr_type(value_ASR_after_down_cast);
-                    if (!ASRUtils::check_equal_type(target_type, value_type)){
-                        std::string ltype = ASRUtils::type_to_str_python(target_type);
-                        std::string rtype = ASRUtils::type_to_str_python(value_type);
-                        diag.add(diag::Diagnostic(
-                                "Type mismatch in assignment, the types must be compatible",
-                                diag::Level::Error, diag::Stage::Semantic, {
-                                        diag::Label("type mismatch ('" + ltype + "' and '" + rtype + "')",
-                                                    {assign_asr_target->base.loc, value_ASR_after_down_cast->base.loc})
-                                })
-                        );
-                        throw SemanticAbort();
-                    }
-                }
-            }
-
-        }
-
-
-
         this->visit_expr(*x.m_value);
         assign_asr_target = assign_asr_target_copy;
         if (tmp) {
@@ -6682,9 +6649,6 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {
-                	//set the tmp to use it in the error message.(copied from the end of this function)              	
-                    ASR::ttype_t* set_type = ASRUtils::TYPE(ASR::make_Set_t(al, x.base.base.loc, type));
-                    tmp = ASR::make_SetConstant_t(al, x.base.base.loc, elements.p, elements.size(), set_type);
                     throw SemanticError("All Set values must be of the same type for now",
                                         x.base.base.loc);
                 }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5340,10 +5340,6 @@ public:
                 this->visit_expr(*x.m_elts[i]);
                 expr = ASRUtils::EXPR(tmp);
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(expr), type)) {
-                	//set the tmp to use it in the error message.(copied from the end of this function)              	
-        			ASR::ttype_t* list_type = ASRUtils::TYPE(ASR::make_List_t(al, x.base.base.loc, type));
-        			tmp = ASR::make_ListConstant_t(al, x.base.base.loc, list.p,
-            			list.size(), list_type);
                     throw SemanticError("All List elements must be of the same type for now",
                         x.base.base.loc);
                 }
@@ -6206,11 +6202,6 @@ public:
                 value_type = ASRUtils::expr_type(value);
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), value_type)) {
-                    //set the tmp to use it in the error message.(copied from the end of this function)
-        			 ASR::ttype_t* type = ASRUtils::TYPE(ASR::make_Dict_t(al, x.base.base.loc,
-                                             key_type, value_type));
-        			tmp = ASR::make_DictConstant_t(al, x.base.base.loc, keys.p, keys.size(),
-                                             values.p, values.size(), type);
                     throw SemanticError("All dictionary values must be of the same type",
                                         x.base.base.loc);
                 }
@@ -6675,9 +6666,6 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {
-                	//set the tmp to use it in the error message.(copied from the end of this function)              	
-                    ASR::ttype_t* set_type = ASRUtils::TYPE(ASR::make_Set_t(al, x.base.base.loc, type));
-                    tmp = ASR::make_SetConstant_t(al, x.base.base.loc, elements.p, elements.size(), set_type);
                     throw SemanticError("All Set values must be of the same type for now",
                                         x.base.base.loc);
                 }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -704,7 +704,7 @@ public:
             call_args_vec.p[arg_pos].loc = expr->base.loc;
             call_args_vec.p[arg_pos].m_value = expr;
         }
-        //Filling missing arguments with its default argument passed in function definition (if existed).
+        // Filling missing arguments with their defaults passed in function definition (if present).
         for(size_t i = 0; i < orig_func->n_args; i++ ){
             if(call_args_vec.p[i].m_value == nullptr){
                 ASR::symbol_t* sym = ASR::down_cast<ASR::Var_t>(orig_func->m_args[i])->m_v;

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5206,8 +5206,9 @@ public:
         assign_asr_target = ASRUtils::EXPR(tmp);
         //Construction-While-Assigning Problem
         AST::exprType value_type_ast = (x.m_value)->type;
-        AST::exprType objects_to_check[4] {AST::exprType::Set,AST::exprType::Dict, // just check these 4 for now.
-                                           AST::exprType::Tuple,AST::exprType::List};
+        AST::exprType objects_to_check[3] { AST::exprType::Set,  // just check these 3 for now.
+        									AST::exprType::Dict,
+        									AST::exprType::List };  
         for(AST::exprType &exp : objects_to_check){
             if (exp == value_type_ast){
                 ASR::ttype_t *target_type = ASRUtils::expr_type(assign_asr_target);
@@ -5372,6 +5373,10 @@ public:
                 this->visit_expr(*x.m_elts[i]);
                 expr = ASRUtils::EXPR(tmp);
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(expr), type)) {
+                	//set the tmp to use it in the error message.(copied from the end of this function)              	
+        			ASR::ttype_t* list_type = ASRUtils::TYPE(ASR::make_List_t(al, x.base.base.loc, type));
+        			tmp = ASR::make_ListConstant_t(al, x.base.base.loc, list.p,
+            			list.size(), list_type);
                     throw SemanticError("All List elements must be of the same type for now",
                         x.base.base.loc);
                 }
@@ -6218,6 +6223,16 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(key), key_type)) {
+                	//set the tmp to use it in the error message.(copied from the end of this function + creating values_type)
+         			Vec<ASR::expr_t*> values;
+        			ASR::ttype_t* value_type = nullptr;
+        			visit_expr(*x.m_values[0]);
+            		ASR::expr_t *value = ASRUtils::EXPR(tmp);
+        			value_type = ASRUtils::expr_type(value);          	
+        			ASR::ttype_t* type = ASRUtils::TYPE(ASR::make_Dict_t(al, x.base.base.loc,
+                                             key_type, value_type));
+       				 tmp = ASR::make_DictConstant_t(al, x.base.base.loc, keys.p, keys.size(),
+                                             values.p, values.size(), type);
                     throw SemanticError("All dictionary keys must be of the same type",
                                         x.base.base.loc);
                 }
@@ -6234,6 +6249,11 @@ public:
                 value_type = ASRUtils::expr_type(value);
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), value_type)) {
+                    //set the tmp to use it in the error message.(copied from the end of this function)
+        			 ASR::ttype_t* type = ASRUtils::TYPE(ASR::make_Dict_t(al, x.base.base.loc,
+                                             key_type, value_type));
+        			tmp = ASR::make_DictConstant_t(al, x.base.base.loc, keys.p, keys.size(),
+                                             values.p, values.size(), type);
                     throw SemanticError("All dictionary values must be of the same type",
                                         x.base.base.loc);
                 }
@@ -6698,7 +6718,7 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {
-                    //set the tmp to use it in the error message.
+                	//set the tmp to use it in the error message.(copied from the end of this function)              	
                     ASR::ttype_t* set_type = ASRUtils::TYPE(ASR::make_Set_t(al, x.base.base.loc, type));
                     tmp = ASR::make_SetConstant_t(al, x.base.base.loc, elements.p, elements.size(), set_type);
                     throw SemanticError("All Set values must be of the same type for now",

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5204,39 +5204,6 @@ public:
         ASR::expr_t* assign_asr_target_copy = assign_asr_target;
         this->visit_expr(*x.m_targets[0]);
         assign_asr_target = ASRUtils::EXPR(tmp);
-        //Construction-While-Assigning Problem
-        AST::exprType value_type_ast = (x.m_value)->type;
-        AST::exprType objects_to_check[3] { AST::exprType::Set,  // just check these 3 for now.
-        									AST::exprType::Dict,
-        									AST::exprType::List };  
-        for(AST::exprType &exp : objects_to_check){
-            if (exp == value_type_ast){
-                ASR::ttype_t *target_type = ASRUtils::expr_type(assign_asr_target);
-                try{
-                    this->visit_expr(*x.m_value);
-                }
-                catch (SemanticError &error){
-                    ASR::expr_t *value_ASR_after_down_cast = ASRUtils::EXPR(tmp);
-                    ASR::ttype_t *value_type = ASRUtils::expr_type(value_ASR_after_down_cast);
-                    if (!ASRUtils::check_equal_type(target_type, value_type)){
-                        std::string ltype = ASRUtils::type_to_str_python(target_type);
-                        std::string rtype = ASRUtils::type_to_str_python(value_type);
-                        diag.add(diag::Diagnostic(
-                                "Type mismatch in assignment, the types must be compatible",
-                                diag::Level::Error, diag::Stage::Semantic, {
-                                        diag::Label("type mismatch ('" + ltype + "' and '" + rtype + "')",
-                                                    {assign_asr_target->base.loc, value_ASR_after_down_cast->base.loc})
-                                })
-                        );
-                        throw SemanticAbort();
-                    }
-                }
-            }
-
-        }
-
-
-
         this->visit_expr(*x.m_value);
         assign_asr_target = assign_asr_target_copy;
         if (tmp) {
@@ -6223,16 +6190,6 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(key), key_type)) {
-                	//set the tmp to use it in the error message.(copied from the end of this function + creating values_type)
-         			Vec<ASR::expr_t*> values;
-        			ASR::ttype_t* value_type = nullptr;
-        			visit_expr(*x.m_values[0]);
-            		ASR::expr_t *value = ASRUtils::EXPR(tmp);
-        			value_type = ASRUtils::expr_type(value);          	
-        			ASR::ttype_t* type = ASRUtils::TYPE(ASR::make_Dict_t(al, x.base.base.loc,
-                                             key_type, value_type));
-       				 tmp = ASR::make_DictConstant_t(al, x.base.base.loc, keys.p, keys.size(),
-                                             values.p, values.size(), type);
                     throw SemanticError("All dictionary keys must be of the same type",
                                         x.base.base.loc);
                 }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5167,6 +5167,38 @@ public:
         ASR::expr_t* assign_asr_target_copy = assign_asr_target;
         this->visit_expr(*x.m_targets[0]);
         assign_asr_target = ASRUtils::EXPR(tmp);
+        //Construction-While-Assigning Problem
+        AST::exprType value_type_ast = (x.m_value)->type;
+        AST::exprType objects_to_check[4] {AST::exprType::Set,AST::exprType::Dict, // just check these 4 for now.
+                                           AST::exprType::Tuple,AST::exprType::List};
+        for(AST::exprType &exp : objects_to_check){
+            if (exp == value_type_ast){
+                ASR::ttype_t *target_type = ASRUtils::expr_type(assign_asr_target);
+                try{
+                    this->visit_expr(*x.m_value);
+                }
+                catch (SemanticError &error){
+                    ASR::expr_t *value_ASR_after_down_cast = ASRUtils::EXPR(tmp);
+                    ASR::ttype_t *value_type = ASRUtils::expr_type(value_ASR_after_down_cast);
+                    if (!ASRUtils::check_equal_type(target_type, value_type)){
+                        std::string ltype = ASRUtils::type_to_str_python(target_type);
+                        std::string rtype = ASRUtils::type_to_str_python(value_type);
+                        diag.add(diag::Diagnostic(
+                                "Type mismatch in assignment, the types must be compatible",
+                                diag::Level::Error, diag::Stage::Semantic, {
+                                        diag::Label("type mismatch ('" + ltype + "' and '" + rtype + "')",
+                                                    {assign_asr_target->base.loc, value_ASR_after_down_cast->base.loc})
+                                })
+                        );
+                        throw SemanticAbort();
+                    }
+                }
+            }
+
+        }
+
+
+
         this->visit_expr(*x.m_value);
         assign_asr_target = assign_asr_target_copy;
         if (tmp) {
@@ -6153,17 +6185,6 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(key), key_type)) {
-                	//set the tmp to use it in the error message.(copied from the end of this function + creating values_type)
-         			Vec<ASR::expr_t*> values;
-         			values.reserve(al, x.n_values);
-        			ASR::ttype_t* value_type = nullptr;
-        			visit_expr(*x.m_values[0]);
-            		ASR::expr_t *value = ASRUtils::EXPR(tmp);
-        			value_type = ASRUtils::expr_type(value);          	
-        			ASR::ttype_t* type = ASRUtils::TYPE(ASR::make_Dict_t(al, x.base.base.loc,
-                                             key_type, value_type));
-       				 tmp = ASR::make_DictConstant_t(al, x.base.base.loc, keys.p, keys.size(),
-                                             values.p, values.size(), type);
                     throw SemanticError("All dictionary keys must be of the same type",
                                         x.base.base.loc);
                 }
@@ -6649,6 +6670,9 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {
+                    //set the tmp to use it in the error message.
+                    ASR::ttype_t* set_type = ASRUtils::TYPE(ASR::make_Set_t(al, x.base.base.loc, type));
+                    tmp = ASR::make_SetConstant_t(al, x.base.base.loc, elements.p, elements.size(), set_type);
                     throw SemanticError("All Set values must be of the same type for now",
                                         x.base.base.loc);
                 }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5167,6 +5167,38 @@ public:
         ASR::expr_t* assign_asr_target_copy = assign_asr_target;
         this->visit_expr(*x.m_targets[0]);
         assign_asr_target = ASRUtils::EXPR(tmp);
+        //Construction-While-Assigning Problem
+        AST::exprType value_type_ast = (x.m_value)->type;
+        AST::exprType objects_to_check[4] {AST::exprType::Set,AST::exprType::Dict, // just check these 4 for now.
+                                           AST::exprType::Tuple,AST::exprType::List};
+        for(AST::exprType &exp : objects_to_check){
+            if (exp == value_type_ast){
+                ASR::ttype_t *target_type = ASRUtils::expr_type(assign_asr_target);
+                try{
+                    this->visit_expr(*x.m_value);
+                }
+                catch (SemanticError &error){
+                    ASR::expr_t *value_ASR_after_down_cast = ASRUtils::EXPR(tmp);
+                    ASR::ttype_t *value_type = ASRUtils::expr_type(value_ASR_after_down_cast);
+                    if (!ASRUtils::check_equal_type(target_type, value_type)){
+                        std::string ltype = ASRUtils::type_to_str_python(target_type);
+                        std::string rtype = ASRUtils::type_to_str_python(value_type);
+                        diag.add(diag::Diagnostic(
+                                "Type mismatch in assignment, the types must be compatible",
+                                diag::Level::Error, diag::Stage::Semantic, {
+                                        diag::Label("type mismatch ('" + ltype + "' and '" + rtype + "')",
+                                                    {assign_asr_target->base.loc, value_ASR_after_down_cast->base.loc})
+                                })
+                        );
+                        throw SemanticAbort();
+                    }
+                }
+            }
+
+        }
+
+
+
         this->visit_expr(*x.m_value);
         assign_asr_target = assign_asr_target_copy;
         if (tmp) {
@@ -6629,6 +6661,9 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {
+                    //set the tmp to use it in the error message.
+                    ASR::ttype_t* set_type = ASRUtils::TYPE(ASR::make_Set_t(al, x.base.base.loc, type));
+                    tmp = ASR::make_SetConstant_t(al, x.base.base.loc, elements.p, elements.size(), set_type);
                     throw SemanticError("All Set values must be of the same type for now",
                                         x.base.base.loc);
                 }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6223,16 +6223,6 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(key), key_type)) {
-                	//set the tmp to use it in the error message.(copied from the end of this function + creating values_type)
-         			Vec<ASR::expr_t*> values;
-        			ASR::ttype_t* value_type = nullptr;
-        			visit_expr(*x.m_values[0]);
-            		ASR::expr_t *value = ASRUtils::EXPR(tmp);
-        			value_type = ASRUtils::expr_type(value);          	
-        			ASR::ttype_t* type = ASRUtils::TYPE(ASR::make_Dict_t(al, x.base.base.loc,
-                                             key_type, value_type));
-       				 tmp = ASR::make_DictConstant_t(al, x.base.base.loc, keys.p, keys.size(),
-                                             values.p, values.size(), type);
                     throw SemanticError("All dictionary keys must be of the same type",
                                         x.base.base.loc);
                 }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -713,8 +713,7 @@ public:
                 if (var->m_symbolic_value == nullptr){
                     missed_args_names+="'" + (std::string) var->m_name + "' and ";
                     missed_args_count++;
-                }
-                else{
+                } else {
                     call_args_vec.p[i].m_value = var->m_symbolic_value;
                 }
             }
@@ -1176,7 +1175,7 @@ public:
                     if(var->m_symbolic_value == nullptr) {
                         missed_args_names+= "'" + std::string(var->m_name) + "' and ";
                         missed_args_count++;
-                    } else{
+                    } else {
                         ASR::call_arg_t call_arg;
                         call_arg.m_value = var->m_symbolic_value;
                         call_arg.loc = (var->m_symbolic_value->base).loc;

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1174,11 +1174,9 @@ public:
                 for (size_t def_arg = args.size(); def_arg < func->n_args; def_arg++){
                     ASR::Variable_t* var = ASRUtils::EXPR2VAR(func->m_args[def_arg]);
                     if(var->m_symbolic_value == nullptr) {
-                        missed_args_names+= "'" + (std::string)var->m_name + "' and ";
+                        missed_args_names+= "'" + std::string(var->m_name) + "' and ";
                         missed_args_count++;
-                    }
-                    else{
-
+                    } else{
                         ASR::call_arg_t call_arg;
                         call_arg.m_value = var->m_symbolic_value;
                         call_arg.loc = (var->m_symbolic_value->base).loc;

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5169,8 +5169,9 @@ public:
         assign_asr_target = ASRUtils::EXPR(tmp);
         //Construction-While-Assigning Problem
         AST::exprType value_type_ast = (x.m_value)->type;
-        AST::exprType objects_to_check[4] {AST::exprType::Set,AST::exprType::Dict, // just check these 4 for now.
-                                           AST::exprType::Tuple,AST::exprType::List};
+        AST::exprType objects_to_check[3] { AST::exprType::Set,  // just check these 3 for now.
+        									AST::exprType::Dict,
+        									AST::exprType::List };  
         for(AST::exprType &exp : objects_to_check){
             if (exp == value_type_ast){
                 ASR::ttype_t *target_type = ASRUtils::expr_type(assign_asr_target);
@@ -6670,7 +6671,7 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {
-                    //set the tmp to use it in the error message.
+                	//set the tmp to use it in the error message.(copied from the end of this function)              	
                     ASR::ttype_t* set_type = ASRUtils::TYPE(ASR::make_Set_t(al, x.base.base.loc, type));
                     tmp = ASR::make_SetConstant_t(al, x.base.base.loc, elements.p, elements.size(), set_type);
                     throw SemanticError("All Set values must be of the same type for now",

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5169,8 +5169,9 @@ public:
         assign_asr_target = ASRUtils::EXPR(tmp);
         //Construction-While-Assigning Problem
         AST::exprType value_type_ast = (x.m_value)->type;
-        AST::exprType objects_to_check[4] {AST::exprType::Set,AST::exprType::Dict, // just check these 4 for now.
-                                           AST::exprType::Tuple,AST::exprType::List};
+        AST::exprType objects_to_check[3] { AST::exprType::Set,  // just check these 3 for now.
+        									AST::exprType::Dict,
+        									AST::exprType::List };  
         for(AST::exprType &exp : objects_to_check){
             if (exp == value_type_ast){
                 ASR::ttype_t *target_type = ASRUtils::expr_type(assign_asr_target);
@@ -5335,6 +5336,10 @@ public:
                 this->visit_expr(*x.m_elts[i]);
                 expr = ASRUtils::EXPR(tmp);
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(expr), type)) {
+                	//set the tmp to use it in the error message.(copied from the end of this function)              	
+        			ASR::ttype_t* list_type = ASRUtils::TYPE(ASR::make_List_t(al, x.base.base.loc, type));
+        			tmp = ASR::make_ListConstant_t(al, x.base.base.loc, list.p,
+            			list.size(), list_type);
                     throw SemanticError("All List elements must be of the same type for now",
                         x.base.base.loc);
                 }
@@ -6181,6 +6186,16 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(key), key_type)) {
+                	//set the tmp to use it in the error message.(copied from the end of this function + creating values_type)
+         			Vec<ASR::expr_t*> values;
+        			ASR::ttype_t* value_type = nullptr;
+        			visit_expr(*x.m_values[0]);
+            		ASR::expr_t *value = ASRUtils::EXPR(tmp);
+        			value_type = ASRUtils::expr_type(value);          	
+        			ASR::ttype_t* type = ASRUtils::TYPE(ASR::make_Dict_t(al, x.base.base.loc,
+                                             key_type, value_type));
+       				 tmp = ASR::make_DictConstant_t(al, x.base.base.loc, keys.p, keys.size(),
+                                             values.p, values.size(), type);
                     throw SemanticError("All dictionary keys must be of the same type",
                                         x.base.base.loc);
                 }
@@ -6197,6 +6212,11 @@ public:
                 value_type = ASRUtils::expr_type(value);
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), value_type)) {
+                    //set the tmp to use it in the error message.(copied from the end of this function)
+        			 ASR::ttype_t* type = ASRUtils::TYPE(ASR::make_Dict_t(al, x.base.base.loc,
+                                             key_type, value_type));
+        			tmp = ASR::make_DictConstant_t(al, x.base.base.loc, keys.p, keys.size(),
+                                             values.p, values.size(), type);
                     throw SemanticError("All dictionary values must be of the same type",
                                         x.base.base.loc);
                 }
@@ -6661,7 +6681,7 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {
-                    //set the tmp to use it in the error message.
+                	//set the tmp to use it in the error message.(copied from the end of this function)              	
                     ASR::ttype_t* set_type = ASRUtils::TYPE(ASR::make_Set_t(al, x.base.base.loc, type));
                     tmp = ASR::make_SetConstant_t(al, x.base.base.loc, elements.p, elements.size(), set_type);
                     throw SemanticError("All Set values must be of the same type for now",

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1152,7 +1152,7 @@ public:
                     args.push_back(al,call_arg);
                     ASR::symbol_t* sym = (ASR::down_cast<ASR::Var_t>((func->m_args)[def_arg]))->m_v;
                     ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
-                    args.p[def_arg].loc = ((var->m_value)->base).loc;
+                    // args.p[def_arg].loc = ((var->m_value)->base).loc;
                     args.p[def_arg].m_value = (var->m_value);
                 }
             }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6188,6 +6188,7 @@ public:
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(key), key_type)) {
                 	//set the tmp to use it in the error message.(copied from the end of this function + creating values_type)
          			Vec<ASR::expr_t*> values;
+         			values.reserve(al, x.n_values);
         			ASR::ttype_t* value_type = nullptr;
         			visit_expr(*x.m_values[0]);
             		ASR::expr_t *value = ASRUtils::EXPR(tmp);

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1157,8 +1157,7 @@ public:
                 args.reserve(al, func->n_args);
                 visit_expr_list(pos_args, n_pos_args, kwargs, n_kwargs,
                                 args, rt_subs, func, loc);
-            }
-        	else if(args.size() < func->n_args){
+            } else if (args.size() < func->n_args) {
                 for (size_t def_arg = args.size(); def_arg < func->n_args; def_arg++){
                     ASR::symbol_t* sym = ASR::down_cast<ASR::Var_t>(func->m_args[def_arg])->m_v;
                     std::string variable_name = ASR::down_cast<ASR::Variable_t>(sym)->m_name;

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1145,13 +1145,13 @@ public:
             }
         	if((n_pos_args+ n_kwargs) < func->n_args && (args.size() < func->n_args) ){
                 for(size_t def_arg = (n_pos_args+ n_kwargs) ; def_arg <(func->n_args) ;def_arg++){
-                    ASR::call_arg_t call_arg;
-                    args.push_back(al,call_arg);
                     ASR::symbol_t* sym = (ASR::down_cast<ASR::Var_t>((func->m_args)[def_arg]))->m_v;
                     ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
                     if(!(var->m_value)) {
                         break;
                     }
+                    ASR::call_arg_t call_arg;
+                    args.push_back(al,call_arg);
                     args.p[def_arg].loc = ((var->m_value)->base).loc;
                     args.p[def_arg].m_value = (var->m_value);
                 }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -5228,39 +5228,6 @@ public:
         ASR::expr_t* assign_asr_target_copy = assign_asr_target;
         this->visit_expr(*x.m_targets[0]);
         assign_asr_target = ASRUtils::EXPR(tmp);
-        //Construction-While-Assigning Problem
-        AST::exprType value_type_ast = (x.m_value)->type;
-        AST::exprType objects_to_check[3] { AST::exprType::Set,  // just check these 3 for now.
-        									AST::exprType::Dict,
-        									AST::exprType::List };  
-        for(AST::exprType &exp : objects_to_check){
-            if (exp == value_type_ast){
-                ASR::ttype_t *target_type = ASRUtils::expr_type(assign_asr_target);
-                try{
-                    this->visit_expr(*x.m_value);
-                }
-                catch (SemanticError &error){
-                    ASR::expr_t *value_ASR_after_down_cast = ASRUtils::EXPR(tmp);
-                    ASR::ttype_t *value_type = ASRUtils::expr_type(value_ASR_after_down_cast);
-                    if (!ASRUtils::check_equal_type(target_type, value_type)){
-                        std::string ltype = ASRUtils::type_to_str_python(target_type);
-                        std::string rtype = ASRUtils::type_to_str_python(value_type);
-                        diag.add(diag::Diagnostic(
-                                "Type mismatch in assignment, the types must be compatible",
-                                diag::Level::Error, diag::Stage::Semantic, {
-                                        diag::Label("type mismatch ('" + ltype + "' and '" + rtype + "')",
-                                                    {assign_asr_target->base.loc, value_ASR_after_down_cast->base.loc})
-                                })
-                        );
-                        throw SemanticAbort();
-                    }
-                }
-            }
-
-        }
-
-
-
         this->visit_expr(*x.m_value);
         assign_asr_target = assign_asr_target_copy;
         if (tmp) {
@@ -5397,10 +5364,6 @@ public:
                 this->visit_expr(*x.m_elts[i]);
                 expr = ASRUtils::EXPR(tmp);
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(expr), type)) {
-                	//set the tmp to use it in the error message.(copied from the end of this function)              	
-        			ASR::ttype_t* list_type = ASRUtils::TYPE(ASR::make_List_t(al, x.base.base.loc, type));
-        			tmp = ASR::make_ListConstant_t(al, x.base.base.loc, list.p,
-            			list.size(), list_type);
                     throw SemanticError("All List elements must be of the same type for now",
                         x.base.base.loc);
                 }
@@ -6263,11 +6226,6 @@ public:
                 value_type = ASRUtils::expr_type(value);
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), value_type)) {
-                    //set the tmp to use it in the error message.(copied from the end of this function)
-        			 ASR::ttype_t* type = ASRUtils::TYPE(ASR::make_Dict_t(al, x.base.base.loc,
-                                             key_type, value_type));
-        			tmp = ASR::make_DictConstant_t(al, x.base.base.loc, keys.p, keys.size(),
-                                             values.p, values.size(), type);
                     throw SemanticError("All dictionary values must be of the same type",
                                         x.base.base.loc);
                 }
@@ -6732,10 +6690,7 @@ public:
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {
-                	//set the tmp to use it in the error message.(copied from the end of this function)              	
-                    ASR::ttype_t* set_type = ASRUtils::TYPE(ASR::make_Set_t(al, x.base.base.loc, type));
-                    tmp = ASR::make_SetConstant_t(al, x.base.base.loc, elements.p, elements.size(), set_type);
-                    throw SemanticError("All Set values must be of the same type for now",
+                	throw SemanticError("All Set values must be of the same type for now",
                                         x.base.base.loc);
                 }
             }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1144,10 +1144,10 @@ public:
                                 args, rt_subs, func, loc);
             }
         	if((n_pos_args+ n_kwargs) < func->n_args && (args.size() < func->n_args) ){
-                for(size_t def_arg = (n_pos_args+ n_kwargs) ; def_arg <(func->n_args) ;def_arg++){
-                    ASR::symbol_t* sym = (ASR::down_cast<ASR::Var_t>((func->m_args)[def_arg]))->m_v;
+                for (size_t def_arg = (n_pos_args+ n_kwargs); def_arg < func->n_args; def_arg++){
+                    ASR::symbol_t* sym = ASR::down_cast<ASR::Var_t>(func->m_args[def_arg])->m_v;
                     ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
-                    if(!(var->m_value)) {
+                    if (var->m_value == nullptr) {
                         break;
                     }
                     ASR::call_arg_t call_arg;
@@ -4329,7 +4329,7 @@ public:
             }
             ASR::accessType s_access = ASR::accessType::Public;
             ASR::presenceType s_presence = ASR::presenceType::Required;
-        	if (i >= default_arg_index_start){                
+        if (i >= default_arg_index_start){                
             	s_presence = ASR::presenceType::Optional;
             }
             bool value_attr = false;

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1143,8 +1143,8 @@ public:
                 visit_expr_list(pos_args, n_pos_args, kwargs, n_kwargs,
                                 args, rt_subs, func, loc);
             }
-        	if((n_pos_args+ n_kwargs) < func->n_args && (args.size() < func->n_args) ){
-                for (size_t def_arg = (n_pos_args+ n_kwargs); def_arg < func->n_args; def_arg++){
+        	if(args.size() < func->n_args){
+                for (size_t def_arg = args.size(); def_arg < func->n_args; def_arg++){
                     ASR::symbol_t* sym = ASR::down_cast<ASR::Var_t>(func->m_args[def_arg])->m_v;
                     ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(sym);
                     if (var->m_value == nullptr) {

--- a/tests/errors/def_func_01.py
+++ b/tests/errors/def_func_01.py
@@ -1,3 +1,4 @@
+from lpython import i32
 def func_01(x : str) -> str:
     print(x)
 

--- a/tests/errors/def_func_01.py
+++ b/tests/errors/def_func_01.py
@@ -1,0 +1,4 @@
+def func_01(x : str) -> str:
+    print(x)
+
+func_01()

--- a/tests/errors/def_func_02.py
+++ b/tests/errors/def_func_02.py
@@ -1,0 +1,5 @@
+from lpython import i32
+def func_02(x : i32 ,y : i32) -> i32 :
+    print(x,y)
+
+func_02()

--- a/tests/errors/def_func_03.py
+++ b/tests/errors/def_func_03.py
@@ -1,0 +1,5 @@
+from lpython import i32
+def func_03(x : i32 ,y : i32) -> i32 :
+    print(x,y)
+
+func_03(1)

--- a/tests/errors/def_func_04.py
+++ b/tests/errors/def_func_04.py
@@ -1,0 +1,5 @@
+from lpython import i32
+def func_04(x : i32 ,y : i32) -> i32 :
+    print(x,y)
+
+func_04(y=3)

--- a/tests/errors/def_func_05.py
+++ b/tests/errors/def_func_05.py
@@ -1,0 +1,5 @@
+from lpython import i32
+def func_05(x : i32 ,y : i32,z : i32) -> i32 :
+    print(x,y,z)
+
+func_05(1,2)

--- a/tests/errors/def_func_06.py
+++ b/tests/errors/def_func_06.py
@@ -1,0 +1,5 @@
+from lpython import i32
+def func_05(x : i32 ,y : i32,z : i32) -> i32 :
+    print(x,y,z)
+
+func_05(z=3)

--- a/tests/reference/asr-def_func_01-1c7f4cd.json
+++ b/tests/reference/asr-def_func_01-1c7f4cd.json
@@ -2,12 +2,12 @@
     "basename": "asr-def_func_01-1c7f4cd",
     "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/errors/def_func_01.py",
-    "infile_hash": "61daf4e2823865c57c501d99dceee1553856e2e142e8d6276fcf5a35",
+    "infile_hash": "fda645ec7920824250cc2b5c28663061fe629b1dc341fc70ba3a691c",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-def_func_01-1c7f4cd.stderr",
-    "stderr_hash": "0914547db8dc99e767e8817786e1c94c1bc72c695bd5ec6d810a9cdb",
+    "stderr_hash": "e96fc67b26c68ef0954595fb87bf261a1bfe6e9f55d83baf28e73032",
     "returncode": 2
 }

--- a/tests/reference/asr-def_func_01-1c7f4cd.json
+++ b/tests/reference/asr-def_func_01-1c7f4cd.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-def_func_01-1c7f4cd",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/def_func_01.py",
+    "infile_hash": "61daf4e2823865c57c501d99dceee1553856e2e142e8d6276fcf5a35",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-def_func_01-1c7f4cd.stderr",
+    "stderr_hash": "0914547db8dc99e767e8817786e1c94c1bc72c695bd5ec6d810a9cdb",
+    "returncode": 2
+}

--- a/tests/reference/asr-def_func_01-1c7f4cd.stderr
+++ b/tests/reference/asr-def_func_01-1c7f4cd.stderr
@@ -1,0 +1,5 @@
+semantic error: Number of arguments does not match in the function call
+ --> tests/errors/def_func_01.py:4:1
+  |
+4 | func_01()
+  | ^^^^^^^^^ missing 1 required arguments : 'x'

--- a/tests/reference/asr-def_func_01-1c7f4cd.stderr
+++ b/tests/reference/asr-def_func_01-1c7f4cd.stderr
@@ -1,5 +1,5 @@
 semantic error: Number of arguments does not match in the function call
- --> tests/errors/def_func_01.py:4:1
+ --> tests/errors/def_func_01.py:5:1
   |
-4 | func_01()
+5 | func_01()
   | ^^^^^^^^^ missing 1 required arguments : 'x'

--- a/tests/reference/asr-def_func_02-8bf7092.json
+++ b/tests/reference/asr-def_func_02-8bf7092.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-def_func_02-8bf7092",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/def_func_02.py",
+    "infile_hash": "fe3a3789ece86f790691ead17887dfebb8d60b882f58e06d333c9bb2",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-def_func_02-8bf7092.stderr",
+    "stderr_hash": "61aea2e70bfee634a40291abc98afa838c6ca173201d9d16f9dfb428",
+    "returncode": 2
+}

--- a/tests/reference/asr-def_func_02-8bf7092.stderr
+++ b/tests/reference/asr-def_func_02-8bf7092.stderr
@@ -1,0 +1,5 @@
+semantic error: Number of arguments does not match in the function call
+ --> tests/errors/def_func_02.py:5:1
+  |
+5 | func_02()
+  | ^^^^^^^^^ missing 2 required arguments : 'x' and 'y'

--- a/tests/reference/asr-def_func_03-58ad7c5.json
+++ b/tests/reference/asr-def_func_03-58ad7c5.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-def_func_03-58ad7c5",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/def_func_03.py",
+    "infile_hash": "e69f130e474a8757368e7ad3e9afcd3553eaff1e819173febb66fd06",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-def_func_03-58ad7c5.stderr",
+    "stderr_hash": "5ac45e87ffbe795b9ca06dc4a82d3743c762f4f0a1f6bbfdc3e14ca2",
+    "returncode": 2
+}

--- a/tests/reference/asr-def_func_03-58ad7c5.stderr
+++ b/tests/reference/asr-def_func_03-58ad7c5.stderr
@@ -1,0 +1,5 @@
+semantic error: Number of arguments does not match in the function call
+ --> tests/errors/def_func_03.py:5:1
+  |
+5 | func_03(1)
+  | ^^^^^^^^^^ missing 1 required arguments : 'y'

--- a/tests/reference/asr-def_func_04-4af8c0d.json
+++ b/tests/reference/asr-def_func_04-4af8c0d.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-def_func_04-4af8c0d",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/def_func_04.py",
+    "infile_hash": "522166d0c6c1a0cb273d67ce577ec42330f02822c75b1b317c97608c",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-def_func_04-4af8c0d.stderr",
+    "stderr_hash": "11bd3ae2f41227fd383927fa2f9fc4feff50c19784df51b56f50d3e9",
+    "returncode": 2
+}

--- a/tests/reference/asr-def_func_04-4af8c0d.stderr
+++ b/tests/reference/asr-def_func_04-4af8c0d.stderr
@@ -1,0 +1,5 @@
+semantic error: Number of arguments does not match in the function call
+ --> tests/errors/def_func_04.py:5:1
+  |
+5 | func_04(y=3)
+  | ^^^^^^^^^^^^ missing 1 required arguments :'x'

--- a/tests/reference/asr-def_func_05-6c33b29.json
+++ b/tests/reference/asr-def_func_05-6c33b29.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-def_func_05-6c33b29",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/def_func_05.py",
+    "infile_hash": "bc8d5377ec564a4d5758653dea39d5c6237992a54ec33fdef88f63f2",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-def_func_05-6c33b29.stderr",
+    "stderr_hash": "9dad35128e5da8dcc73f9c96bdb43ce15e3309d590bb794b14e3133c",
+    "returncode": 2
+}

--- a/tests/reference/asr-def_func_05-6c33b29.stderr
+++ b/tests/reference/asr-def_func_05-6c33b29.stderr
@@ -1,0 +1,5 @@
+semantic error: Number of arguments does not match in the function call
+ --> tests/errors/def_func_05.py:5:1
+  |
+5 | func_05(1,2)
+  | ^^^^^^^^^^^^ missing 1 required arguments : 'z'

--- a/tests/reference/asr-def_func_06-9a3ebfc.json
+++ b/tests/reference/asr-def_func_06-9a3ebfc.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-def_func_06-9a3ebfc",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/def_func_06.py",
+    "infile_hash": "5ad73c3f18ab4d9fe82108e65e0013687a70acc3eff495a402d4297e",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-def_func_06-9a3ebfc.stderr",
+    "stderr_hash": "f9c79e62d7ef7f411870195bfeb99615cb7da9216af328fda2fb0cd2",
+    "returncode": 2
+}

--- a/tests/reference/asr-def_func_06-9a3ebfc.stderr
+++ b/tests/reference/asr-def_func_06-9a3ebfc.stderr
@@ -1,0 +1,5 @@
+semantic error: Number of arguments does not match in the function call
+ --> tests/errors/def_func_06.py:5:1
+  |
+5 | func_05(z=3)
+  | ^^^^^^^^^^^^ missing 2 required arguments :'x' and 'y'

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1443,3 +1443,27 @@ run_with_dbg = true
 [[test]]
 filename = "errors/test_optional.py"
 asr = true
+
+[[test]]
+filename = "errors/def_func_01.py"
+asr = true
+
+[[test]]
+filename = "errors/def_func_02.py"
+asr = true
+
+[[test]]
+filename = "errors/def_func_03.py"
+asr = true
+
+[[test]]
+filename = "errors/def_func_04.py"
+asr = true
+
+[[test]]
+filename = "errors/def_func_05.py"
+asr = true
+
+[[test]]
+filename = "errors/def_func_06.py"
+asr = true


### PR DESCRIPTION
fixes #2509 
fixes #2109  
completed the implementation of default arguments in functions.
# Code Flow
- `AST::functiondef` has `arguments` object as one of its members, this object has `m_defaults` and `n_defaults` which preserve the number of default arguments and `AST::expr_t` of the default constants.
- When we're building the variables of the function in `visit_functiondef( )` , we start pushing the ASR::expr_t of the defaults as a value for the variable when we reach the difference of `n_args` and `n_defaults` .
- When we start to call the function, we check if `n_pos_args` is less than `func.n_args` , if so, we start pushing the data from varibles in ASR::function_t  to ` Vec<ASR::call_arg_t>`,starting from the index n_pos_args.

# The code handles keyword arguments.

# serious issue to handle
The solution is build upon the idea of starting to make variable for the last number of  parameters. If the user writes a code like this 
```python
def whatever(first :str ="lpython",second :str):
    print(second)

whatever("foo") # result => lpython

``` 
as the lpython would be matched with the last parameter.

This should arise a syntax error like how Cpython does.
