### PR TITLE
Prevent calling `abort` while handling the `SIGABRT` signal

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -3299,7 +3299,7 @@ void get_local_address_mac(struct Stacktrace *d) {
     printf("The stack address was not found in any shared library or"
         " the main program, the stack is probably corrupted.\n"
         "Aborting...\n");
-    abort();
+    exit(1);
 }
 #endif // HAVE_LFORTRAN_MACHO
 
@@ -3315,7 +3315,7 @@ void get_local_address(struct Stacktrace *d) {
             printf("The stack address was not found in any shared library or"
                 " the main program, the stack is probably corrupted.\n"
                 "Aborting...\n");
-            abort();
+            exit(1);
         }
 #else
 #ifdef HAVE_LFORTRAN_MACHO

--- a/src/libasr/stacktrace.cpp
+++ b/src/libasr/stacktrace.cpp
@@ -135,7 +135,7 @@ void get_local_address(StacktraceItem &item)
       // happen if the stacktrace is somehow corrupted. In that case, we simply
       // abort here.
       std::cout << "The stack address was not found in any shared library or the main program, the stack is probably corrupted. Aborting." << std::endl;
-      abort();
+      exit(1);
     }
 #else
 #ifdef HAVE_LFORTRAN_MACHO
@@ -179,7 +179,7 @@ void get_local_address(StacktraceItem &item)
         }
     }
     std::cout << "The stack address was not found in any shared library or the main program, the stack is probably corrupted. Aborting." << std::endl;
-    abort();
+    exit(1);
 #else
     item.local_pc=0;
 #endif // HAVE_LFORTRAN_MACHO


### PR DESCRIPTION
We register `loc_abort_callback_print_stack` as a callback on the `SIGABRT` signal and `loc_segfault_callback_print_stack` on the `SIGSEGV` signal. (reference: https://github.com/lcompilers/lpython/blob/main/src/libasr/stacktrace.cpp#L530-L531)

Tracing the flow of function calls:
`loc_abort_callback_print_stack` and `loc_segfault_callback_print_stack` calls `get_stacktrace` (reference: https://github.com/lcompilers/lpython/blob/main/src/libasr/stacktrace.cpp#L524 & https://github.com/lcompilers/lpython/blob/main/src/libasr/stacktrace.cpp#L516)
`get_stacktrace` calls `get_local_addresses` (reference: https://github.com/lcompilers/lpython/blob/main/src/libasr/stacktrace.cpp#L537)
`get_local_addresses` calls `get_local_address` (reference: https://github.com/lcompilers/lpython/blob/main/src/libasr/stacktrace.cpp#L561)
`get_local_address` calls `abort`. (reference: https://github.com/lcompilers/lpython/blob/main/src/libasr/stacktrace.cpp#L142)

So while handling `SIGABRT` we end up regenerating `SIGABRT` and the cycle repeats. To prevent this, I have changed the `abort()` to `exit(1)` to immediately exit.

I observed this while working on #2564 and #2595.
