### PR TITLE
Implement `reversed()`

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -1792,7 +1792,7 @@ public:
         tmp = builder->CreateFSub(exp, one);
     }
 
-    void generate_ListReverse(ASR::expr_t* m_arg) {
+    void generate_ListReverse(ASR::expr_t* m_arg, bool is_intrinsic_function) {
         ASR::ttype_t* asr_el_type = ASRUtils::get_contained_type(ASRUtils::expr_type(m_arg));
         int64_t ptr_loads_copy = ptr_loads;
         ptr_loads = 0;
@@ -1802,6 +1802,8 @@ public:
         ptr_loads = !LLVM::is_llvm_struct(asr_el_type);
         ptr_loads = ptr_loads_copy;
         list_api->reverse(plist, *module);
+
+        if (is_intrinsic_function) tmp = plist;
     }
 
     void generate_ListPop_0(ASR::expr_t* m_arg) {
@@ -1954,8 +1956,12 @@ public:
                 generate_ListIndex(m_arg, m_ele, m_start, m_end);
                 break ;
             }
+            case ASRUtils::IntrinsicElementalFunctions::Reversed: {
+                generate_ListReverse(x.m_args[0], true);
+                break;
+            }
             case ASRUtils::IntrinsicElementalFunctions::ListReverse: {
-                generate_ListReverse(x.m_args[0]);
+                generate_ListReverse(x.m_args[0], false);
                 break;
             }
             case ASRUtils::IntrinsicElementalFunctions::ListPop: {

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -19,6 +19,7 @@ namespace ASRUtils {
 inline std::string get_intrinsic_name(int x) {
     switch (x) {
         INTRINSIC_NAME_CASE(ObjectType)
+        INTRINSIC_NAME_CASE(Reversed)
         INTRINSIC_NAME_CASE(Kind)
         INTRINSIC_NAME_CASE(Rank)
         INTRINSIC_NAME_CASE(Sin)
@@ -172,6 +173,8 @@ namespace IntrinsicElementalFunctionRegistry {
                    verify_function>>& intrinsic_function_by_id_db = {
         {static_cast<int64_t>(IntrinsicElementalFunctions::ObjectType),
             {nullptr, &ObjectType::verify_args}},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::Reversed),
+            {nullptr, &Reversed::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Gamma),
             {&Gamma::instantiate_Gamma, &UnaryIntrinsicFunction::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Log10),
@@ -459,6 +462,8 @@ namespace IntrinsicElementalFunctionRegistry {
     static const std::map<int64_t, std::string>& intrinsic_function_id_to_name = {
         {static_cast<int64_t>(IntrinsicElementalFunctions::ObjectType),
             "type"},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::Reversed),
+            "reversed"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Gamma),
             "gamma"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::Log),
@@ -744,6 +749,7 @@ namespace IntrinsicElementalFunctionRegistry {
         std::tuple<create_intrinsic_function,
                     eval_intrinsic_function>>& intrinsic_function_by_name_db = {
                 {"type", {&ObjectType::create_ObjectType, &ObjectType::eval_ObjectType}},
+                {"reversed", {&Reversed::create_Reversed, &Reversed::eval_Reversed}},
                 {"gamma", {&Gamma::create_Gamma, &Gamma::eval_Gamma}},
                 {"log", {&Log::create_Log, &Log::eval_Log}},
                 {"log10", {&Log10::create_Log10, &Log10::eval_Log10}},


### PR DESCRIPTION
### Working

```python
def fn():
    alphabets: list[str] = ["a", "b", "c", "d", "e"]
    print("Original:", alphabets)

    reversed_alphabets: list[str] = reversed(alphabets)
    print("Reversed:", reversed_alphabets)


fn()
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lpython$ ./src/bin/lpython ./examples/example.py
Original: ['a', 'b', 'c', 'd', 'e']
Reversed: ['e', 'd', 'c', 'b', 'a']
```