### PR TITLE
WASM: Use release build

### DIFF
--- a/build_to_wasm.sh
+++ b/build_to_wasm.sh
@@ -9,8 +9,9 @@ cp -r src/runtime/lpython src/bin/asset_dir
 
 ./build0.sh
 emcmake cmake \
-    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_FLAGS_DEBUG="-Wall -Wextra -fexceptions" \
+    -DCMAKE_CXX_FLAGS_RELEASE="-Wall -Wextra -fexceptions" \
     -DWITH_LLVM=no \
     -DLPYTHON_BUILD_ALL=yes \
     -DLPYTHON_BUILD_TO_WASM=yes \

--- a/src/lpython/parser/parser_stype.h
+++ b/src/lpython/parser/parser_stype.h
@@ -113,8 +113,8 @@ static_assert(std::is_trivial<YYSTYPE>::value);
 // YYSTYPE must be at least as big, but it should not be bigger, otherwise it
 // would reduce performance.
 // A temporary fix for PowerPC 32-bit, where the following assert fails with (16 == 12).
-#ifndef __ppc__
-static_assert(sizeof(YYSTYPE) == sizeof(Vec<LPython::AST::ast_t*>));
+#if !defined(HAVE_BUILD_TO_WASM) && !defined(__ppc__)
+static_assert(sizeof(YYSTYPE) == sizeof(Vec<AST::ast_t*>));
 #endif
 
 static_assert(std::is_standard_layout<Location>::value);


### PR DESCRIPTION
Inspired by the patch added here(https://github.com/emscripten-forge/recipes/pull/883/files) to build lpython against the emscripten compiler package