### PR TITLE
Detect unhashable object types at the ASR level

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -1590,6 +1590,15 @@ public:
         }
     }
 
+    bool is_hashable(ASR::ttype_t* object_type) {
+        if (ASR::is_a<ASR::List_t>(*object_type)
+            || ASR::is_a<ASR::Dict_t>(*object_type)
+            || ASR::is_a<ASR::Set_t>(*object_type)) {
+                return false;
+            }
+        return true;
+    }
+
     AST::expr_t* get_var_intent_and_annotation(AST::expr_t *annotation, ASR::intentType &intent) {
         if (AST::is_a<AST::Subscript_t>(*annotation)) {
             AST::Subscript_t *s = AST::down_cast<AST::Subscript_t>(annotation);
@@ -6096,10 +6105,9 @@ public:
             ASR::expr_t *key = ASRUtils::EXPR(tmp);
             if (key_type == nullptr) {
                 key_type = ASRUtils::expr_type(key);
-                if (ASR::is_a<ASR::List_t>(*key_type)
-                    || ASR::is_a<ASR::Dict_t>(*key_type)
-                    || ASR::is_a<ASR::Set_t>(*key_type)) {
-                        throw SemanticError("unhashable type: '" + ASRUtils::type_to_str(key_type) + "'", key->base.loc);
+                if (!is_hashable(key_type)) {
+                    throw SemanticError("unhashable type: '" + ASRUtils::type_to_str(key_type) + "'",
+                                        key->base.loc);
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(key), key_type)) {
@@ -6570,6 +6578,10 @@ public:
             ASR::expr_t *value = ASRUtils::EXPR(tmp);
             if (type == nullptr) {
                 type = ASRUtils::expr_type(value);
+                if (!is_hashable(type)) {
+                    throw SemanticError("unhashable type: '" + ASRUtils::type_to_str(type) + "'",
+                                        type->base.loc);
+                }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {
                     throw SemanticError("All Set values must be of the same type for now",

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6096,6 +6096,11 @@ public:
             ASR::expr_t *key = ASRUtils::EXPR(tmp);
             if (key_type == nullptr) {
                 key_type = ASRUtils::expr_type(key);
+                if (ASR::is_a<ASR::List_t>(*key_type)
+                    || ASR::is_a<ASR::Dict_t>(*key_type)
+                    || ASR::is_a<ASR::Set_t>(*key_type)) {
+                        throw SemanticError("unhashable type: '" + ASRUtils::type_to_str(key_type) + "'", key->base.loc);
+                }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(key), key_type)) {
                     throw SemanticError("All dictionary keys must be of the same type",

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -6129,14 +6129,14 @@ public:
                 key_type = ASRUtils::expr_type(key);
                 if (!is_hashable(key_type)) {
                     diag.add(diag::Diagnostic(
-                            "Unhashable type: '" + ASRUtils::type_to_str(key_type) + "'",
-                            diag::Level::Error, diag::Stage::Semantic, {
-                                diag::Label("Mutable type '" + ASRUtils::type_to_str(key_type) 
-                                + "' cannot become a key in dict. Hint: Use an immutable type for key.",
-                                        {key->base.loc})
-                            })
-                        );
-                        throw SemanticAbort();
+                        "Unhashable type: '" + ASRUtils::type_to_str(key_type) + "'",
+                        diag::Level::Error, diag::Stage::Semantic, {
+                            diag::Label("Mutable type '" + ASRUtils::type_to_str(key_type) 
+                            + "' cannot become a key in dict. Hint: Use an immutable type for key.",
+                                    {key->base.loc})
+                        })
+                    );
+                    throw SemanticAbort();
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(key), key_type)) {
@@ -6609,14 +6609,14 @@ public:
                 type = ASRUtils::expr_type(value);
                 if (!is_hashable(type)) {
                     diag.add(diag::Diagnostic(
-                            "Unhashable type: '" + ASRUtils::type_to_str(type) + "'",
-                            diag::Level::Error, diag::Stage::Semantic, {
-                                diag::Label("Mutable type '" + ASRUtils::type_to_str(type) 
-                                + "' cannot be stored in a set.",
-                                        {value->base.loc})
-                            })
-                        );
-                        throw SemanticAbort();
+                        "Unhashable type: '" + ASRUtils::type_to_str(type) + "'",
+                        diag::Level::Error, diag::Stage::Semantic, {
+                            diag::Label("Mutable type '" + ASRUtils::type_to_str(type) 
+                            + "' cannot be stored in a set.",
+                                    {value->base.loc})
+                        })
+                    );
+                    throw SemanticAbort();
                 }
             } else {
                 if (!ASRUtils::check_equal_type(ASRUtils::expr_type(value), type)) {

--- a/tests/errors/test_dict_key1.py
+++ b/tests/errors/test_dict_key1.py
@@ -1,0 +1,6 @@
+from lpython import i32
+
+def test_dict_key1():
+    my_dict: dict[list[i32], str] = {[1, 2]: "first", [3, 4]: "second"}
+
+test_dict_key1()

--- a/tests/errors/test_dict_key2.py
+++ b/tests/errors/test_dict_key2.py
@@ -1,0 +1,6 @@
+from lpython import i32
+
+def test_dict_key2():
+    my_dict: dict[dict[i32, str], str] = {{1: "a", 2: "b"}: "first", {3: "c", 4: "d"}: "second"}
+
+test_dict_key2()

--- a/tests/errors/test_dict_key3.py
+++ b/tests/errors/test_dict_key3.py
@@ -1,0 +1,6 @@
+from lpython import i32
+
+def test_dict_key3():
+    my_dict: dict[set[str], str] = {{1, 2}: "first", {3, 4}: "second"}
+
+test_dict_key3()

--- a/tests/errors/test_dict_key4.py
+++ b/tests/errors/test_dict_key4.py
@@ -1,0 +1,4 @@
+def test_dict_key4():
+    print({[1, 2]: "first", [3, 4]: "second"})
+
+test_dict_key4()

--- a/tests/errors/test_dict_key5.py
+++ b/tests/errors/test_dict_key5.py
@@ -1,0 +1,4 @@
+def test_dict_key5():
+    print({{1: "a", 2: "b"}: "first", {3: "c", 4: "d"}: "second"})
+
+test_dict_key5()

--- a/tests/errors/test_dict_key6.py
+++ b/tests/errors/test_dict_key6.py
@@ -1,0 +1,4 @@
+def test_dict_key6():
+    print({{1, 2}: "first", {3, 4}: "second"})
+
+test_dict_key6()

--- a/tests/errors/test_set_object1.py
+++ b/tests/errors/test_set_object1.py
@@ -1,0 +1,6 @@
+from lpython import i32
+
+def test_set_object1():
+    my_set: set[list[i32]] = {[1, 2], [3, 4]}
+
+test_set_object1()

--- a/tests/errors/test_set_object2.py
+++ b/tests/errors/test_set_object2.py
@@ -1,0 +1,6 @@
+from lpython import i32
+
+def test_set_object2():
+    my_set: set[dict[i32, str]] = {{1: "a", 2: "b"}, {3: "c", 4: "d"}}
+
+test_set_object2()

--- a/tests/errors/test_set_object3.py
+++ b/tests/errors/test_set_object3.py
@@ -1,6 +1,6 @@
 from lpython import i32
 
 def test_set_object3():
-    my_set: set[set[str]] = {{1, 2}, {3, 4}}
+    my_set: set[set[i32]] = {{1, 2}, {3, 4}}
 
 test_set_object3()

--- a/tests/errors/test_set_object3.py
+++ b/tests/errors/test_set_object3.py
@@ -1,0 +1,6 @@
+from lpython import i32
+
+def test_set_object3():
+    my_set: set[set[str]] = {{1, 2}, {3, 4}}
+
+test_set_object3()

--- a/tests/errors/test_set_object4.py
+++ b/tests/errors/test_set_object4.py
@@ -1,0 +1,4 @@
+def test_set_object4():
+    print({[1, 2], [3, 4]})
+
+test_set_object4()

--- a/tests/errors/test_set_object5.py
+++ b/tests/errors/test_set_object5.py
@@ -1,0 +1,4 @@
+def test_set_object5():
+    print({{1: "a", 2: "b"}, {3: "c", 4: "d"}})
+
+test_set_object5()

--- a/tests/errors/test_set_object6.py
+++ b/tests/errors/test_set_object6.py
@@ -1,0 +1,4 @@
+def test_set_object6():
+    print({{1, 2}, {3, 4}})
+
+test_set_object6()

--- a/tests/reference/asr-test_dict7-1415e14.json
+++ b/tests/reference/asr-test_dict7-1415e14.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_dict7-1415e14.stderr",
-    "stderr_hash": "a51d1d4a46839e1f4258410e979ba83a14abe8c011482e30be2336cd",
+    "stderr_hash": "843409ee199a2581d9cd1abab45bb59e5e0372d56ef94f1b15aea584",
     "returncode": 2
 }

--- a/tests/reference/asr-test_dict7-1415e14.stderr
+++ b/tests/reference/asr-test_dict7-1415e14.stderr
@@ -1,4 +1,4 @@
-semantic error: unhashable type in dict: 'slice'
+semantic error: Unhashable type in dict: 'slice'
  --> tests/errors/test_dict7.py:4:11
   |
 4 |     print(d[1:2])

--- a/tests/reference/asr-test_dict_key1-6e57a28.json
+++ b/tests/reference/asr-test_dict_key1-6e57a28.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_dict_key1-6e57a28",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_dict_key1.py",
+    "infile_hash": "0ee4ab5e47edab5de323d7cf97cf3e726e54882e4a5fadb82ee9aedc",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_dict_key1-6e57a28.stderr",
+    "stderr_hash": "ef02b1cd47e2290bcfb63a8e2d840795e9d40aa1c3b3f7f809239a25",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_dict_key1-6e57a28.json
+++ b/tests/reference/asr-test_dict_key1-6e57a28.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_dict_key1-6e57a28.stderr",
-    "stderr_hash": "ef02b1cd47e2290bcfb63a8e2d840795e9d40aa1c3b3f7f809239a25",
+    "stderr_hash": "4ee828a6b9a93bfb8285c2006843243b5327f915f9548a2f1b3f1480",
     "returncode": 2
 }

--- a/tests/reference/asr-test_dict_key1-6e57a28.stderr
+++ b/tests/reference/asr-test_dict_key1-6e57a28.stderr
@@ -1,5 +1,5 @@
-semantic error: unhashable type: 'list'
- --> tests/errors/test_dict_key1.py:4:38
+semantic error: Unhashable type: 'list'
+ --> tests/errors/test_dict_key1.py:4:19
   |
 4 |     my_dict: dict[list[i32], str] = {[1, 2]: "first", [3, 4]: "second"}
-  |                                      ^^^^^^ 
+  |                   ^^^^^^^^^ Mutable type 'list' cannot become a key in dict. Hint: Use an immutable type for key.

--- a/tests/reference/asr-test_dict_key1-6e57a28.stderr
+++ b/tests/reference/asr-test_dict_key1-6e57a28.stderr
@@ -1,0 +1,5 @@
+semantic error: unhashable type: 'list'
+ --> tests/errors/test_dict_key1.py:4:38
+  |
+4 |     my_dict: dict[list[i32], str] = {[1, 2]: "first", [3, 4]: "second"}
+  |                                      ^^^^^^ 

--- a/tests/reference/asr-test_dict_key2-18ea6fb.json
+++ b/tests/reference/asr-test_dict_key2-18ea6fb.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_dict_key2-18ea6fb",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_dict_key2.py",
+    "infile_hash": "25b325264991082018c989f990a6b71409e7af0df4a27e5b5142a349",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_dict_key2-18ea6fb.stderr",
+    "stderr_hash": "0b270d5c247762ec2f34814f686b4d044f53b582383778b399cfb5eb",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_dict_key2-18ea6fb.json
+++ b/tests/reference/asr-test_dict_key2-18ea6fb.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_dict_key2-18ea6fb.stderr",
-    "stderr_hash": "0b270d5c247762ec2f34814f686b4d044f53b582383778b399cfb5eb",
+    "stderr_hash": "5883683aaf0a4ae56b5fd86f56f6900e3e752a72bc675af9c607d998",
     "returncode": 2
 }

--- a/tests/reference/asr-test_dict_key2-18ea6fb.stderr
+++ b/tests/reference/asr-test_dict_key2-18ea6fb.stderr
@@ -1,0 +1,5 @@
+semantic error: unhashable type: 'dict'
+ --> tests/errors/test_dict_key2.py:4:43
+  |
+4 |     my_dict: dict[dict[i32, str], str] = {{1: "a", 2: "b"}: "first", {3: "c", 4: "d"}: "second"}
+  |                                           ^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-test_dict_key2-18ea6fb.stderr
+++ b/tests/reference/asr-test_dict_key2-18ea6fb.stderr
@@ -1,5 +1,5 @@
-semantic error: unhashable type: 'dict'
- --> tests/errors/test_dict_key2.py:4:43
+semantic error: Unhashable type: 'dict'
+ --> tests/errors/test_dict_key2.py:4:19
   |
 4 |     my_dict: dict[dict[i32, str], str] = {{1: "a", 2: "b"}: "first", {3: "c", 4: "d"}: "second"}
-  |                                           ^^^^^^^^^^^^^^^^ 
+  |                   ^^^^^^^^^^^^^^ Mutable type 'dict' cannot become a key in dict. Hint: Use an immutable type for key.

--- a/tests/reference/asr-test_dict_key3-9fc7793.json
+++ b/tests/reference/asr-test_dict_key3-9fc7793.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_dict_key3-9fc7793",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_dict_key3.py",
+    "infile_hash": "9675711d37ed0e58ddd82a53ec580cc21c58a9b94ad598b706fb78f8",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_dict_key3-9fc7793.stderr",
+    "stderr_hash": "58ded690768c5c32ca9e82afce7a9b40458f3873ecc5056aa8d164e6",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_dict_key3-9fc7793.json
+++ b/tests/reference/asr-test_dict_key3-9fc7793.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_dict_key3-9fc7793.stderr",
-    "stderr_hash": "58ded690768c5c32ca9e82afce7a9b40458f3873ecc5056aa8d164e6",
+    "stderr_hash": "bd995f8512a83892aa1be985c6f7ff1761691829150549ba4ac84f17",
     "returncode": 2
 }

--- a/tests/reference/asr-test_dict_key3-9fc7793.stderr
+++ b/tests/reference/asr-test_dict_key3-9fc7793.stderr
@@ -1,0 +1,5 @@
+semantic error: unhashable type: 'set'
+ --> tests/errors/test_dict_key3.py:4:37
+  |
+4 |     my_dict: dict[set[str], str] = {{1, 2}: "first", {3, 4}: "second"}
+  |                                     ^^^^^^ 

--- a/tests/reference/asr-test_dict_key3-9fc7793.stderr
+++ b/tests/reference/asr-test_dict_key3-9fc7793.stderr
@@ -1,5 +1,5 @@
-semantic error: unhashable type: 'set'
- --> tests/errors/test_dict_key3.py:4:37
+semantic error: Unhashable type: 'set'
+ --> tests/errors/test_dict_key3.py:4:19
   |
 4 |     my_dict: dict[set[str], str] = {{1, 2}: "first", {3, 4}: "second"}
-  |                                     ^^^^^^ 
+  |                   ^^^^^^^^ Mutable type 'set' cannot become a key in dict. Hint: Use an immutable type for key.

--- a/tests/reference/asr-test_dict_key4-dc7abfc.json
+++ b/tests/reference/asr-test_dict_key4-dc7abfc.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_dict_key4-dc7abfc",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_dict_key4.py",
+    "infile_hash": "197ac00a9a0a5763f939d8b5aec2e33a5b3ec769d93149a1c93999c1",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_dict_key4-dc7abfc.stderr",
+    "stderr_hash": "ff55c824acc6a3bc2c7f8845b345bcf5d66d13374526ab958a005dc7",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_dict_key4-dc7abfc.stderr
+++ b/tests/reference/asr-test_dict_key4-dc7abfc.stderr
@@ -1,0 +1,5 @@
+semantic error: Unhashable type: 'list'
+ --> tests/errors/test_dict_key4.py:2:12
+  |
+2 |     print({[1, 2]: "first", [3, 4]: "second"})
+  |            ^^^^^^ Mutable type 'list' cannot become a key in dict. Hint: Use an immutable type for key.

--- a/tests/reference/asr-test_dict_key5-87496d1.json
+++ b/tests/reference/asr-test_dict_key5-87496d1.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_dict_key5-87496d1",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_dict_key5.py",
+    "infile_hash": "08a7118a664a5ac63f470b5a47d19ed7c35a06e3c8ae40a7b44010ea",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_dict_key5-87496d1.stderr",
+    "stderr_hash": "c7ae39bf80d3a6d1817fbd7aba5455e96623b1225abeb9428af2c73a",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_dict_key5-87496d1.stderr
+++ b/tests/reference/asr-test_dict_key5-87496d1.stderr
@@ -1,0 +1,5 @@
+semantic error: Unhashable type: 'dict'
+ --> tests/errors/test_dict_key5.py:2:12
+  |
+2 |     print({{1: "a", 2: "b"}: "first", {3: "c", 4: "d"}: "second"})
+  |            ^^^^^^^^^^^^^^^^ Mutable type 'dict' cannot become a key in dict. Hint: Use an immutable type for key.

--- a/tests/reference/asr-test_dict_key6-1d334b2.json
+++ b/tests/reference/asr-test_dict_key6-1d334b2.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_dict_key6-1d334b2",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_dict_key6.py",
+    "infile_hash": "14ea00618e1414afe9f93d0aa0d4fd5b4332883465126cbba6faab76",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_dict_key6-1d334b2.stderr",
+    "stderr_hash": "74a8ee0549333b4659afc7deec824a14bbc672316b22e3c99a026846",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_dict_key6-1d334b2.stderr
+++ b/tests/reference/asr-test_dict_key6-1d334b2.stderr
@@ -1,0 +1,5 @@
+semantic error: Unhashable type: 'set'
+ --> tests/errors/test_dict_key6.py:2:12
+  |
+2 |     print({{1, 2}: "first", {3, 4}: "second"})
+  |            ^^^^^^ Mutable type 'set' cannot become a key in dict. Hint: Use an immutable type for key.

--- a/tests/reference/asr-test_set_object1-d9bd2e1.json
+++ b/tests/reference/asr-test_set_object1-d9bd2e1.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_set_object1-d9bd2e1.stderr",
-    "stderr_hash": "41b650d67f9f8a83d7e4035b6ee06b5bc79a7c87fa1f7f3c57987b26",
+    "stderr_hash": "b528f86f591ab403348d8dd5037d2385fdb7ce29501215a69d10702f",
     "returncode": 2
 }

--- a/tests/reference/asr-test_set_object1-d9bd2e1.json
+++ b/tests/reference/asr-test_set_object1-d9bd2e1.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_set_object1-d9bd2e1",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_set_object1.py",
+    "infile_hash": "9450d7ca46f30271944800137d28413648bafdbeb7f0a7ac0906c832",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_set_object1-d9bd2e1.stderr",
+    "stderr_hash": "41b650d67f9f8a83d7e4035b6ee06b5bc79a7c87fa1f7f3c57987b26",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_set_object1-d9bd2e1.stderr
+++ b/tests/reference/asr-test_set_object1-d9bd2e1.stderr
@@ -1,0 +1,5 @@
+semantic error: unhashable type: 'list'
+ --> tests/errors/test_set_object1.py:4:31
+  |
+4 |     my_set: set[list[i32]] = {[1, 2], [3, 4]}
+  |                               ^^^^^^ 

--- a/tests/reference/asr-test_set_object1-d9bd2e1.stderr
+++ b/tests/reference/asr-test_set_object1-d9bd2e1.stderr
@@ -1,5 +1,5 @@
-semantic error: unhashable type: 'list'
- --> tests/errors/test_set_object1.py:4:31
+semantic error: Unhashable type: 'list'
+ --> tests/errors/test_set_object1.py:4:17
   |
 4 |     my_set: set[list[i32]] = {[1, 2], [3, 4]}
-  |                               ^^^^^^ 
+  |                 ^^^^^^^^^ Mutable type 'list' cannot be stored in a set.

--- a/tests/reference/asr-test_set_object2-41401ff.json
+++ b/tests/reference/asr-test_set_object2-41401ff.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_set_object2-41401ff",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_set_object2.py",
+    "infile_hash": "e7360eff7caf0991c5bd4c505a947d23e2bc01277e9a2966362400df",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_set_object2-41401ff.stderr",
+    "stderr_hash": "9d53f9f23c857886b5d44deec31864d7f9de7c6e31f3bd2bca23d0de",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_set_object2-41401ff.json
+++ b/tests/reference/asr-test_set_object2-41401ff.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_set_object2-41401ff.stderr",
-    "stderr_hash": "9d53f9f23c857886b5d44deec31864d7f9de7c6e31f3bd2bca23d0de",
+    "stderr_hash": "4fe845a8f949fce5b955b86d5a5ad60f0e1ae84e3c17b01572d37e2a",
     "returncode": 2
 }

--- a/tests/reference/asr-test_set_object2-41401ff.stderr
+++ b/tests/reference/asr-test_set_object2-41401ff.stderr
@@ -1,0 +1,5 @@
+semantic error: unhashable type: 'dict'
+ --> tests/errors/test_set_object2.py:4:36
+  |
+4 |     my_set: set[dict[i32, str]] = {{1: "a", 2: "b"}, {3: "c", 4: "d"}}
+  |                                    ^^^^^^^^^^^^^^^^ 

--- a/tests/reference/asr-test_set_object2-41401ff.stderr
+++ b/tests/reference/asr-test_set_object2-41401ff.stderr
@@ -1,5 +1,5 @@
-semantic error: unhashable type: 'dict'
- --> tests/errors/test_set_object2.py:4:36
+semantic error: Unhashable type: 'dict'
+ --> tests/errors/test_set_object2.py:4:17
   |
 4 |     my_set: set[dict[i32, str]] = {{1: "a", 2: "b"}, {3: "c", 4: "d"}}
-  |                                    ^^^^^^^^^^^^^^^^ 
+  |                 ^^^^^^^^^^^^^^ Mutable type 'dict' cannot be stored in a set.

--- a/tests/reference/asr-test_set_object3-680b593.json
+++ b/tests/reference/asr-test_set_object3-680b593.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_set_object3-680b593.stderr",
-    "stderr_hash": "f2259d17c5dfa48f97003781cf7d2803108c06686dc7fa8f34509085",
+    "stderr_hash": "05d3a6338fd929fef485c7403500a1f2111dc8e638a3369ff942bea2",
     "returncode": 2
 }

--- a/tests/reference/asr-test_set_object3-680b593.json
+++ b/tests/reference/asr-test_set_object3-680b593.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_set_object3-680b593",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_set_object3.py",
+    "infile_hash": "979aa9702508608399ed9aeba51d1a640d4387bec5263124e61542f7",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_set_object3-680b593.stderr",
+    "stderr_hash": "0c91ad98b93563b3ed5a9e668e1ff7244369051db205331a39bc4383",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_set_object3-680b593.json
+++ b/tests/reference/asr-test_set_object3-680b593.json
@@ -2,12 +2,12 @@
     "basename": "asr-test_set_object3-680b593",
     "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
     "infile": "tests/errors/test_set_object3.py",
-    "infile_hash": "979aa9702508608399ed9aeba51d1a640d4387bec5263124e61542f7",
+    "infile_hash": "f1dea0a951aa880721aa38a0dcf254983e7d50ab408c64c87b9a078e",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-test_set_object3-680b593.stderr",
-    "stderr_hash": "0c91ad98b93563b3ed5a9e668e1ff7244369051db205331a39bc4383",
+    "stderr_hash": "f2259d17c5dfa48f97003781cf7d2803108c06686dc7fa8f34509085",
     "returncode": 2
 }

--- a/tests/reference/asr-test_set_object3-680b593.stderr
+++ b/tests/reference/asr-test_set_object3-680b593.stderr
@@ -1,5 +1,5 @@
 semantic error: unhashable type: 'set'
  --> tests/errors/test_set_object3.py:4:30
   |
-4 |     my_set: set[set[str]] = {{1, 2}, {3, 4}}
+4 |     my_set: set[set[i32]] = {{1, 2}, {3, 4}}
   |                              ^^^^^^ 

--- a/tests/reference/asr-test_set_object3-680b593.stderr
+++ b/tests/reference/asr-test_set_object3-680b593.stderr
@@ -1,5 +1,5 @@
-semantic error: unhashable type: 'set'
- --> tests/errors/test_set_object3.py:4:30
+semantic error: Unhashable type: 'set'
+ --> tests/errors/test_set_object3.py:4:17
   |
 4 |     my_set: set[set[i32]] = {{1, 2}, {3, 4}}
-  |                              ^^^^^^ 
+  |                 ^^^^^^^^ Mutable type 'set' cannot be stored in a set.

--- a/tests/reference/asr-test_set_object3-680b593.stderr
+++ b/tests/reference/asr-test_set_object3-680b593.stderr
@@ -1,0 +1,5 @@
+semantic error: unhashable type: 'set'
+ --> tests/errors/test_set_object3.py:4:30
+  |
+4 |     my_set: set[set[str]] = {{1, 2}, {3, 4}}
+  |                              ^^^^^^ 

--- a/tests/reference/asr-test_set_object4-243eb04.json
+++ b/tests/reference/asr-test_set_object4-243eb04.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_set_object4-243eb04",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_set_object4.py",
+    "infile_hash": "0b339aaa798fca7bd12920c583b0d60d70fe2f8afeb68a1811992f59",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_set_object4-243eb04.stderr",
+    "stderr_hash": "dff44d0e30f3fed351e8df2bc1875c3a9972db927a58400df456ec12",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_set_object4-243eb04.stderr
+++ b/tests/reference/asr-test_set_object4-243eb04.stderr
@@ -1,0 +1,5 @@
+semantic error: Unhashable type: 'list'
+ --> tests/errors/test_set_object4.py:2:12
+  |
+2 |     print({[1, 2], [3, 4]})
+  |            ^^^^^^ Mutable type 'list' cannot be stored in a set.

--- a/tests/reference/asr-test_set_object5-4bd1044.json
+++ b/tests/reference/asr-test_set_object5-4bd1044.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_set_object5-4bd1044",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_set_object5.py",
+    "infile_hash": "6d88885bb6428fe2b63121d653dcdfd23ec30d6b5322eb4cb8faada6",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_set_object5-4bd1044.stderr",
+    "stderr_hash": "8727cfdabeed50ccf7989653e6607ebc8cb8b828c7388378d0fc33a6",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_set_object5-4bd1044.stderr
+++ b/tests/reference/asr-test_set_object5-4bd1044.stderr
@@ -1,0 +1,5 @@
+semantic error: Unhashable type: 'dict'
+ --> tests/errors/test_set_object5.py:2:12
+  |
+2 |     print({{1: "a", 2: "b"}, {3: "c", 4: "d"}})
+  |            ^^^^^^^^^^^^^^^^ Mutable type 'dict' cannot be stored in a set.

--- a/tests/reference/asr-test_set_object6-01b4fa7.json
+++ b/tests/reference/asr-test_set_object6-01b4fa7.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-test_set_object6-01b4fa7",
+    "cmd": "lpython --show-asr --no-color {infile} -o {outfile}",
+    "infile": "tests/errors/test_set_object6.py",
+    "infile_hash": "528a4e950b464e2915259ef826f2322c55efc268b2b5245add9fb6be",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "asr-test_set_object6-01b4fa7.stderr",
+    "stderr_hash": "45b2d173c7081a5410321802a3055c10e6277ec48ad0f2d1ef4dc60e",
+    "returncode": 2
+}

--- a/tests/reference/asr-test_set_object6-01b4fa7.stderr
+++ b/tests/reference/asr-test_set_object6-01b4fa7.stderr
@@ -1,0 +1,5 @@
+semantic error: Unhashable type: 'set'
+ --> tests/errors/test_set_object6.py:2:12
+  |
+2 |     print({{1, 2}, {3, 4}})
+  |            ^^^^^^ Mutable type 'set' cannot be stored in a set.

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1034,6 +1034,18 @@ filename = "errors/test_dict_key3.py"
 asr = true
 
 [[test]]
+filename = "errors/test_set_object1.py"
+asr = true
+
+[[test]]
+filename = "errors/test_set_object2.py"
+asr = true
+
+[[test]]
+filename = "errors/test_set_object3.py"
+asr = true
+
+[[test]]
 filename = "errors/test_dict8.py"
 asr = true
 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1034,6 +1034,18 @@ filename = "errors/test_dict_key3.py"
 asr = true
 
 [[test]]
+filename = "errors/test_dict_key4.py"
+asr = true
+
+[[test]]
+filename = "errors/test_dict_key5.py"
+asr = true
+
+[[test]]
+filename = "errors/test_dict_key6.py"
+asr = true
+
+[[test]]
 filename = "errors/test_set_object1.py"
 asr = true
 
@@ -1043,6 +1055,18 @@ asr = true
 
 [[test]]
 filename = "errors/test_set_object3.py"
+asr = true
+
+[[test]]
+filename = "errors/test_set_object4.py"
+asr = true
+
+[[test]]
+filename = "errors/test_set_object5.py"
+asr = true
+
+[[test]]
+filename = "errors/test_set_object6.py"
 asr = true
 
 [[test]]

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1022,6 +1022,18 @@ filename = "errors/test_dict1.py"
 asr = true
 
 [[test]]
+filename = "errors/test_dict_key1.py"
+asr = true
+
+[[test]]
+filename = "errors/test_dict_key2.py"
+asr = true
+
+[[test]]
+filename = "errors/test_dict_key3.py"
+asr = true
+
+[[test]]
 filename = "errors/test_dict8.py"
 asr = true
 


### PR DESCRIPTION
Fixes #2663 

Working for `dict` is shown below. It is the same for `set`.

### List
```python
from lpython import i32

my_dict: dict[list[i32], str] = {[1, 2]: "first", [3, 4]: "second"}
```

```console
(base) saurabh-kumar@Awadh:~/Projects/System/lpython$ ./src/bin/lpython ./examples/example.py
semantic error: Unhashable type: 'list'
 --> ./examples/example.py:3:15
  |
3 | my_dict: dict[list[i32], str] = {[1, 2]: "first", [3, 4]: "second"}
  |               ^^^^^^^^^ Mutable type 'list' cannot become a key in dict. Hint: Use an immutable type for key.


Note: Please report unclear or confusing messages as bugs at
https://github.com/lcompilers/lpython/issues.
```

### Dictionary
```python
from lpython import i32

my_dict: dict[dict[i32, str], str] = {{1: "a", 2: "b"}: "first", {3: "c", 4: "d"}: "second"}
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lpython$ ./src/bin/lpython ./examples/example.py
semantic error: Unhashable type: 'dict'
 --> ./examples/example.py:3:15
  |
3 | my_dict: dict[dict[i32, str], str] = {{1: "a", 2: "b"}: "first", {3: "c", 4: "d"}: "second"}
  |               ^^^^^^^^^^^^^^ Mutable type 'dict' cannot become a key in dict. Hint: Use an immutable type for key.


Note: Please report unclear or confusing messages as bugs at
https://github.com/lcompilers/lpython/issues.
```

### Set
```python
from lpython import i32

my_dict: dict[set[str], str] = {{1, 2}: "first", {3, 4}: "second"}
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lpython$ ./src/bin/lpython ./examples/example.py
semantic error: Unhashable type: 'set'
 --> ./examples/example.py:3:15
  |
3 | my_dict: dict[set[str], str] = {{1, 2}: "first", {3, 4}: "second"}
  |               ^^^^^^^^ Mutable type 'set' cannot become a key in dict. Hint: Use an immutable type for key.


Note: Please report unclear or confusing messages as bugs at
https://github.com/lcompilers/lpython/issues.
```