### PR TITLE
Introducing Symbolic Infinity constant

### DIFF
--- a/integration_tests/symbolics_12.py
+++ b/integration_tests/symbolics_12.py
@@ -1,7 +1,9 @@
-from sympy import Symbol, E, log, exp
+from sympy import Symbol, E, log, exp, oo
 from lpython import S
 
 def main0():
+    # Testing out symbolic constants like E, oo etc
+
     # Define symbolic variables
     x: S = Symbol('x')
     y: S = Symbol('y')
@@ -30,10 +32,39 @@ def main0():
     assert expr2 == E ** S(1)
 
     # Print the results
-    print("x =", x)
-    print("z =", z)
-    print("log(E) =", expr1)
-    print("exp(1) =", expr2)
+    print("x = ", x)
+    print("z = ", z)
+    print("log(E) = ", expr1)
+    print("exp(1) = ", expr2)
+
+    # Test symbolic infinity constant
+    inf: S = oo
+
+    # Check if inf is equal to oo
+    assert inf == oo
+
+    # Perform some symbolic operations with oo
+    z = x + inf
+
+    # Check if z is equal to x + oo
+    assert z == x + oo
+
+    # Check if x is not equal to 2 * oo + y
+    assert x != S(2) * oo + y
+
+    # Evaluate some mathematical expressions with oo
+    expr1 = log(oo)
+    expr2 = exp(oo)
+
+    # Check the results
+    assert expr1 == oo
+    assert expr2 == oo
+
+    # Print the results
+    print("inf = ", inf)
+    print("z = ", z)
+    print("log(oo) = ", expr1)
+    print("exp(oo) = ", expr2)
 
 
 main0()

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -144,6 +144,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(SymbolicPow)
         INTRINSIC_NAME_CASE(SymbolicPi)
         INTRINSIC_NAME_CASE(SymbolicE)
+        INTRINSIC_NAME_CASE(SymbolicInfinity)
         INTRINSIC_NAME_CASE(SymbolicInteger)
         INTRINSIC_NAME_CASE(SymbolicDiff)
         INTRINSIC_NAME_CASE(SymbolicExpand)
@@ -424,6 +425,8 @@ namespace IntrinsicElementalFunctionRegistry {
             {nullptr, &SymbolicPi::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicE),
             {nullptr, &SymbolicE::verify_args}},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicInfinity),
+            {nullptr, &SymbolicInfinity::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicInteger),
             {nullptr, &SymbolicInteger::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicDiff),
@@ -707,6 +710,8 @@ namespace IntrinsicElementalFunctionRegistry {
             "pi"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicE),
             "E"},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicInfinity),
+            "oo"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicInteger),
             "SymbolicInteger"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicDiff),
@@ -870,6 +875,7 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"SymbolicPow", {&SymbolicPow::create_SymbolicPow, &SymbolicPow::eval_SymbolicPow}},
                 {"pi", {&SymbolicPi::create_SymbolicPi, &SymbolicPi::eval_SymbolicPi}},
                 {"E", {&SymbolicE::create_SymbolicE, &SymbolicE::eval_SymbolicE}},
+                {"oo", {&SymbolicInfinity::create_SymbolicInfinity, &SymbolicInfinity::eval_SymbolicInfinity}},
                 {"SymbolicInteger", {&SymbolicInteger::create_SymbolicInteger, &SymbolicInteger::eval_SymbolicInteger}},
                 {"diff", {&SymbolicDiff::create_SymbolicDiff, &SymbolicDiff::eval_SymbolicDiff}},
                 {"expand", {&SymbolicExpand::create_SymbolicExpand, &SymbolicExpand::eval_SymbolicExpand}},

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -145,6 +145,7 @@ enum class IntrinsicElementalFunctions : int64_t {
     SymbolicPow,
     SymbolicPi,
     SymbolicE,
+    SymbolicInfinity,
     SymbolicInteger,
     SymbolicDiff,
     SymbolicExpand,
@@ -5672,6 +5673,7 @@ namespace X {                                                                   
 
 create_symbolic_constants_macro(SymbolicPi)
 create_symbolic_constants_macro(SymbolicE)
+create_symbolic_constants_macro(SymbolicInfinity)
 
 namespace SymbolicInteger {
 

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -438,6 +438,7 @@ public:
             }
             BASIC_CONST(Pi, pi)
             BASIC_CONST(E, E)
+            BASIC_CONST(Infinity, infinity)
             BASIC_BINOP(Add, add)
             BASIC_BINOP(Sub, sub)
             BASIC_BINOP(Mul, mul)

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -3211,7 +3211,7 @@ public:
         std::string name = x.m_id;
         ASR::symbol_t *s = current_scope->resolve_symbol(name);
         std::set<std::string> not_cpython_builtin = {
-            "pi", "E"};
+            "pi", "E", "oo"};
         if (s) {
             tmp = ASR::make_Var_t(al, x.base.base.loc, s);
         } else if (name == "i32" || name == "i64" || name == "f32" ||
@@ -7508,7 +7508,7 @@ we will have to use something else.
                     "diff", "expand", "has"
                 };
                 std::set<std::string> symbolic_constants = {
-                    "pi", "E"
+                    "pi", "E", "oo"
                 };
                 if (symbolic_attributes.find(call_name) != symbolic_attributes.end() &&
                     symbolic_constants.find(mod_name) != symbolic_constants.end()){


### PR DESCRIPTION
This is needed for implementing the `limitinf` function in `test_gruntz.py`