### PR TITLE
 Adding support for is_integer attribute

### DIFF
--- a/integration_tests/symbolics_02.py
+++ b/integration_tests/symbolics_02.py
@@ -98,5 +98,9 @@ def test_symbolic_operations():
     print(b4)
     assert(b4 == False)
 
+    # is_integer check
+    assert(pi1.is_integer == False)
+    assert(a.is_integer == True)
+    assert(c.is_integer == True)
 
 test_symbolic_operations()

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -160,6 +160,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(SymbolicLogQ)
         INTRINSIC_NAME_CASE(SymbolicSinQ)
         INTRINSIC_NAME_CASE(SymbolicGetArgument)
+        INTRINSIC_NAME_CASE(SymbolicIsInteger)
         default : {
             throw LCompilersException("pickle: intrinsic_id not implemented");
         }
@@ -457,6 +458,8 @@ namespace IntrinsicElementalFunctionRegistry {
             {nullptr, &SymbolicSinQ::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicGetArgument),
             {nullptr, &SymbolicGetArgument::verify_args}},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicIsInteger),
+            {nullptr, &SymbolicIsInteger::verify_args}},
     };
 
     static const std::map<int64_t, std::string>& intrinsic_function_id_to_name = {
@@ -742,6 +745,8 @@ namespace IntrinsicElementalFunctionRegistry {
             "SymbolicSinQ"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicGetArgument),
             "SymbolicGetArgument"},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicIsInteger),
+            "SymbolicIsInteger"},
     };
 
 
@@ -891,6 +896,7 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"LogQ", {&SymbolicLogQ::create_SymbolicLogQ, &SymbolicLogQ::eval_SymbolicLogQ}},
                 {"SinQ", {&SymbolicSinQ::create_SymbolicSinQ, &SymbolicSinQ::eval_SymbolicSinQ}},
                 {"GetArgument", {&SymbolicGetArgument::create_SymbolicGetArgument, &SymbolicGetArgument::eval_SymbolicGetArgument}},
+                {"is_integer", {&SymbolicIsInteger::create_SymbolicIsInteger, &SymbolicIsInteger::eval_SymbolicIsInteger}},
     };
 
     static inline bool is_intrinsic_function(const std::string& name) {

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -161,6 +161,7 @@ enum class IntrinsicElementalFunctions : int64_t {
     SymbolicLogQ,
     SymbolicSinQ,
     SymbolicGetArgument,
+    SymbolicIsInteger,
     // ...
 };
 
@@ -5853,6 +5854,7 @@ create_symbolic_query_macro(SymbolicMulQ)
 create_symbolic_query_macro(SymbolicPowQ)
 create_symbolic_query_macro(SymbolicLogQ)
 create_symbolic_query_macro(SymbolicSinQ)
+create_symbolic_query_macro(SymbolicIsInteger)
 
 #define create_symbolic_unary_macro(X)                                                    \
 namespace X {                                                                             \

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -279,6 +279,7 @@ public:
                 case LCompilers::ASRUtils::IntrinsicElementalFunctions::SymbolicPowQ:
                 case LCompilers::ASRUtils::IntrinsicElementalFunctions::SymbolicLogQ:
                 case LCompilers::ASRUtils::IntrinsicElementalFunctions::SymbolicSinQ:
+                case LCompilers::ASRUtils::IntrinsicElementalFunctions::SymbolicIsInteger:
                     return true;
                 default:
                     return false;
@@ -513,6 +514,7 @@ public:
                 BASIC_ATTR(PowQ, 17)
                 BASIC_ATTR(LogQ, 29)
                 BASIC_ATTR(SinQ, 35)
+                BASIC_ATTR(IsInteger, 0)
                 default: {
                     throw LCompilersException("IntrinsicFunction: `"
                         + ASRUtils::get_intrinsic_name(intrinsic_id)

--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -48,6 +48,7 @@ struct AttributeHandler {
             {"diff", &eval_symbolic_diff},
             {"expand", &eval_symbolic_expand},
             {"has", &eval_symbolic_has_symbol},
+            {"is_integer", &eval_symbolic_is_integer}
         };
     }
 
@@ -559,6 +560,19 @@ struct AttributeHandler {
         }
         ASRUtils::create_intrinsic_function create_function =
             ASRUtils::IntrinsicElementalFunctionRegistry::get_create_function("GetArgument");
+        return create_function(al, loc, args_with_list, diag);
+    }
+
+    static ASR::asr_t* eval_symbolic_is_integer(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &diag) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicElementalFunctionRegistry::get_create_function("is_integer");
         return create_function(al, loc, args_with_list, diag);
     }
 

--- a/src/runtime/lpython/lpython.py
+++ b/src/runtime/lpython/lpython.py
@@ -15,6 +15,11 @@ __slots__ = ["i8", "i16", "i32", "i64", "u8", "u16", "u32", "u64", "f32", "f64",
 
 # data-types
 
+def get_sympy_S(x):
+    from sympy import S
+    return S(x)
+
+
 type_to_convert_func = {
     "i1": bool,
     "i8": int,
@@ -34,7 +39,7 @@ type_to_convert_func = {
     "Callable": lambda x: x,
     "Allocatable": lambda x: x,
     "Pointer": lambda x: x,
-    "S": lambda x: x,
+    "S": get_sympy_S,
 }
 
 class Type:


### PR DESCRIPTION
This Pr is trying to support the following case (and is also required for the gruntz algorithm)
```
from lpython import s
from sympy import Symbol

def main0():
    a: S = Symbol('x')
    b: S = S(10)
    x: bool = a.is_integer
    y: bool = b.is_integer
    print(x)
    print(y)
    
(lf) anutosh491@spbhat68:~/lpython/lpython$ lpython --enable-symengine examples/expr2.py 
False
True
```