### PR TITLE
Add support for `tuple` and `set` in intrinsic `type(object)`

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -831,7 +831,8 @@ RUN(NAME callback_04       IMPORT_PATH .. LABELS cpython)
 # Intrinsic Functions
 RUN(NAME intrinsics_01     LABELS cpython llvm llvm_jit NOFAST) # any
 RUN(NAME intrinsics_02     LABELS cpython llvm llvm_jit c) # floordiv
-RUN(NAME test_builtin_type LABELS cpython llvm llvm_jit) # type
+RUN(NAME test_builtin_type LABELS cpython llvm llvm_jit c) # type
+RUN(NAME test_builtin_type_set LABELS cpython llvm llvm_jit) # type (specifically for `set`)
 
 # lpython decorator
 RUN(NAME lpython_decorator_01    LABELS cpython)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -831,7 +831,7 @@ RUN(NAME callback_04       IMPORT_PATH .. LABELS cpython)
 # Intrinsic Functions
 RUN(NAME intrinsics_01     LABELS cpython llvm llvm_jit NOFAST) # any
 RUN(NAME intrinsics_02     LABELS cpython llvm llvm_jit c) # floordiv
-RUN(NAME test_builtin_type LABELS cpython llvm llvm_jit c) # type
+RUN(NAME test_builtin_type LABELS cpython llvm llvm_jit) # type
 
 # lpython decorator
 RUN(NAME lpython_decorator_01    LABELS cpython)

--- a/integration_tests/test_builtin_type.py
+++ b/integration_tests/test_builtin_type.py
@@ -7,7 +7,6 @@ def test_builtin_type():
     l: list[i32] = [1, 2, 3, 4, 5]
     d: dict[str, i32] = {"a": 1, "b": 2, "c": 3}
     t: tuple[str, i32] = ("a", 1)
-    st: set[i32] = {1, 2, 3, 4}
     res: str = ""
 
     res = str(type(i))
@@ -28,9 +27,6 @@ def test_builtin_type():
     res = str(type(t))
     print(res)
     assert res == "<class 'tuple'>"
-    res = str(type(st))
-    print(res)
-    assert res == "<class 'set'>"
     
 
 test_builtin_type()

--- a/integration_tests/test_builtin_type.py
+++ b/integration_tests/test_builtin_type.py
@@ -6,6 +6,8 @@ def test_builtin_type():
     s: str = "Hello, LPython!"
     l: list[i32] = [1, 2, 3, 4, 5]
     d: dict[str, i32] = {"a": 1, "b": 2, "c": 3}
+    t: tuple[str, i32] = ("a", 1)
+    st: set[i32] = {1, 2, 3, 4}
     res: str = ""
 
     res = str(type(i))
@@ -23,5 +25,12 @@ def test_builtin_type():
     res = str(type(d))
     print(res)
     assert res == "<class 'dict'>"
+    res = str(type(t))
+    print(res)
+    assert res == "<class 'tuple'>"
+    res = str(type(st))
+    print(res)
+    assert res == "<class 'set'>"
+    
 
 test_builtin_type()

--- a/integration_tests/test_builtin_type_set.py
+++ b/integration_tests/test_builtin_type_set.py
@@ -1,0 +1,11 @@
+from lpython import i32
+
+def test_builtin_type_set():
+    st: set[i32] = {1, 2, 3, 4}
+
+    res = str(type(st))
+    print(res)
+    assert res == "<class 'set'>"
+    
+
+test_builtin_type_set()

--- a/integration_tests/test_builtin_type_set.py
+++ b/integration_tests/test_builtin_type_set.py
@@ -3,7 +3,7 @@ from lpython import i32
 def test_builtin_type_set():
     st: set[i32] = {1, 2, 3, 4}
 
-    res = str(type(st))
+    res: str = str(type(st))
     print(res)
     assert res == "<class 'set'>"
     

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -540,6 +540,10 @@ namespace ObjectType {
                 object_type += "list"; break;
             } case ASR::ttypeType::Dict : {
                object_type += "dict"; break;
+            } case ASR::ttypeType::Set : {
+               object_type += "set"; break;
+            } case ASR::ttypeType::Tuple : {
+               object_type += "tuple"; break;
             } default: {
                 LCOMPILERS_ASSERT_MSG(false, "Unsupported type");
                 break;


### PR DESCRIPTION
```python
my_tuple: tuple[str, i32] = ("A", 1)
my_set: set[str] = {"A", "B", "C"}

print(type(my_tuple))
print(type(my_set))
```
```console
(lp) saurabh-kumar@Awadh:~/Projects/System/lpython$ ./src/bin/lpython ./examples/example.py
<class 'tuple'>
<class 'set'>
```