### PR TITLE
Add support for is_positive attribute

### DIFF
--- a/integration_tests/symbolics_02.py
+++ b/integration_tests/symbolics_02.py
@@ -103,4 +103,9 @@ def test_symbolic_operations():
     assert(a.is_integer == True)
     assert(c.is_integer == True)
 
+    # is_positive check
+    assert(a.is_positive == True)
+    assert(b.is_positive == False)
+    assert(c.is_positive == False)
+
 test_symbolic_operations()

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -161,6 +161,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(SymbolicSinQ)
         INTRINSIC_NAME_CASE(SymbolicGetArgument)
         INTRINSIC_NAME_CASE(SymbolicIsInteger)
+        INTRINSIC_NAME_CASE(SymbolicIsPositive)
         default : {
             throw LCompilersException("pickle: intrinsic_id not implemented");
         }
@@ -460,6 +461,8 @@ namespace IntrinsicElementalFunctionRegistry {
             {nullptr, &SymbolicGetArgument::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicIsInteger),
             {nullptr, &SymbolicIsInteger::verify_args}},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicIsPositive),
+            {nullptr, &SymbolicIsPositive::verify_args}},
     };
 
     static const std::map<int64_t, std::string>& intrinsic_function_id_to_name = {
@@ -747,6 +750,8 @@ namespace IntrinsicElementalFunctionRegistry {
             "SymbolicGetArgument"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicIsInteger),
             "SymbolicIsInteger"},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicIsPositive),
+            "SymbolicIsPositive"},
     };
 
 
@@ -897,6 +902,7 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"SinQ", {&SymbolicSinQ::create_SymbolicSinQ, &SymbolicSinQ::eval_SymbolicSinQ}},
                 {"GetArgument", {&SymbolicGetArgument::create_SymbolicGetArgument, &SymbolicGetArgument::eval_SymbolicGetArgument}},
                 {"is_integer", {&SymbolicIsInteger::create_SymbolicIsInteger, &SymbolicIsInteger::eval_SymbolicIsInteger}},
+                {"is_positive", {&SymbolicIsPositive::create_SymbolicIsPositive, &SymbolicIsPositive::eval_SymbolicIsPositive}},
     };
 
     static inline bool is_intrinsic_function(const std::string& name) {

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -162,6 +162,7 @@ enum class IntrinsicElementalFunctions : int64_t {
     SymbolicSinQ,
     SymbolicGetArgument,
     SymbolicIsInteger,
+    SymbolicIsPositive,
     // ...
 };
 
@@ -5859,6 +5860,7 @@ create_symbolic_query_macro(SymbolicPowQ)
 create_symbolic_query_macro(SymbolicLogQ)
 create_symbolic_query_macro(SymbolicSinQ)
 create_symbolic_query_macro(SymbolicIsInteger)
+create_symbolic_query_macro(SymbolicIsPositive)
 
 #define create_symbolic_unary_macro(X)                                                    \
 namespace X {                                                                             \

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -268,6 +268,15 @@ public:
             ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)));
     }
 
+    ASR::expr_t *basic_is_positive(const Location &loc, ASR::expr_t *value) {
+        ASR::symbol_t* basic_is_positive_sym = create_bindc_function(loc,
+            "number_is_positive", {ASRUtils::TYPE(ASR::make_CPtr_t(al, loc))},
+            ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)));
+        return FunctionCall(loc, basic_is_positive_sym,
+            {handle_argument(al, loc, value)},
+            ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)));
+    }
+
     static inline bool is_logical_intrinsic_symbolic(ASR::expr_t* expr) {
         if (ASR::is_a<ASR::IntrinsicElementalFunction_t>(*expr)) {
             ASR::IntrinsicElementalFunction_t* intrinsic_func = ASR::down_cast<ASR::IntrinsicElementalFunction_t>(expr);
@@ -280,6 +289,7 @@ public:
                 case LCompilers::ASRUtils::IntrinsicElementalFunctions::SymbolicLogQ:
                 case LCompilers::ASRUtils::IntrinsicElementalFunctions::SymbolicSinQ:
                 case LCompilers::ASRUtils::IntrinsicElementalFunctions::SymbolicIsInteger:
+                case LCompilers::ASRUtils::IntrinsicElementalFunctions::SymbolicIsPositive:
                     return true;
                 default:
                     return false;
@@ -506,6 +516,9 @@ public:
                 case LCompilers::ASRUtils::IntrinsicElementalFunctions::SymbolicHasSymbolQ: {
                     return basic_has_symbol(loc, intrinsic_func->m_args[0],
                         intrinsic_func->m_args[1]);
+                }
+                case LCompilers::ASRUtils::IntrinsicElementalFunctions::SymbolicIsPositive: {
+                    return basic_is_positive(loc, intrinsic_func->m_args[0]);
                 }
                 // (sym_name, n) where n = 16, 15, ... as the right value of the
                 // IntegerCompare node as it represents SYMENGINE_ADD through SYMENGINE_ENUM

--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -48,7 +48,8 @@ struct AttributeHandler {
             {"diff", &eval_symbolic_diff},
             {"expand", &eval_symbolic_expand},
             {"has", &eval_symbolic_has_symbol},
-            {"is_integer", &eval_symbolic_is_integer}
+            {"is_integer", &eval_symbolic_is_integer},
+            {"is_positive", &eval_symbolic_is_positive}
         };
     }
 
@@ -573,6 +574,19 @@ struct AttributeHandler {
         }
         ASRUtils::create_intrinsic_function create_function =
             ASRUtils::IntrinsicElementalFunctionRegistry::get_create_function("is_integer");
+        return create_function(al, loc, args_with_list, diag);
+    }
+
+    static ASR::asr_t* eval_symbolic_is_positive(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &diag) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicElementalFunctionRegistry::get_create_function("is_positive");
         return create_function(al, loc, args_with_list, diag);
     }
 


### PR DESCRIPTION
This Pr is trying to support the following case (and is also required for the gruntz algorithm)
```
from lpython import S

def main0():
    a: S = S(5)/S(2)
    b: S = S(-1)/S(4)
    print(a.is_positive)
    print(b.is_positive)

main0()
```
```
(lf) anutosh491@spbhat68:~/lpython/lpython$ lpython --enable-symengine examples/expr2.py 
True
False
```