### PR TITLE
ASR -> CPython: Add `TupleConstant` visitor

### DIFF
--- a/src/libasr/codegen/asr_to_python.cpp
+++ b/src/libasr/codegen/asr_to_python.cpp
@@ -150,6 +150,9 @@ public:
             } case ASR::ttypeType::Logical : {
                 r = "bool";
                 break;
+            } case ASR::ttypeType::Tuple : {
+                r = ASRUtils::type_to_str_python(t);
+                break;
             } default : {
                 throw LCompilersException("The type `"
                     + ASRUtils::type_to_str_python(t) + "` is not handled yet");
@@ -616,6 +619,23 @@ public:
             r += s;
         }
         r += "\n";
+        s = r;
+    }
+
+    void visit_TupleConstant(const ASR::TupleConstant_t &x) {
+        std::string r = "";
+        r += "(";
+        size_t i = 0;
+        while (i < x.n_elements - 1) {
+            visit_expr(*x.m_elements[i]);
+            r += s;
+            r += ", ";
+            i++;
+        }
+        visit_expr(*x.m_elements[i]);
+        r += s;
+        r += ")";
+
         s = r;
     }
 


### PR DESCRIPTION
### Global scope

```python
from lpython import i32, f64

my_first_tuple: tuple[i32, str, f64] = (1, "hello", 2.4)
print(my_first_tuple)

my_second_tuple: tuple[tuple[i32, str], str] = ((1, "hello"), "world")
print(my_second_tuple)
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lpython$ ./src/bin/lpython ./examples/example.py --show-python
def __main__global_init():
    my_first_tuple = (1, "hello", 2.400000)
    my_second_tuple = ((1, "hello"), "world")
def __main__global_stmts():
    print(my_first_tuple)
    print(my_second_tuple)
```

### Local scope

```python
from lpython import i32, f64

def f():
    my_first_tuple: tuple[i32, str, f64] = (1, "hello", 2.4)
    print(my_first_tuple)

    my_second_tuple: tuple[tuple[i32, str], str] = ((1, "hello"), "world")
    print(my_second_tuple)

f()
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lpython$ ./src/bin/lpython ./examples/example.py --show-python
def __main__global_stmts():
    f()
def f():
    my_first_tuple: tuple[i32, str, f64]
    my_second_tuple: tuple[tuple[i32, str], str]
    my_first_tuple = (1, "hello", 2.400000)
    print(my_first_tuple)
    my_second_tuple = ((1, "hello"), "world")
    print(my_second_tuple)
```

### TODO
- [ ] Add tests