### PR TITLE
ASR -> CPython: Add `SetConstant` visitor

### DIFF
--- a/src/libasr/codegen/asr_to_python.cpp
+++ b/src/libasr/codegen/asr_to_python.cpp
@@ -150,6 +150,9 @@ public:
             } case ASR::ttypeType::Logical : {
                 r = "bool";
                 break;
+            } case ASR::ttypeType::Set : {
+                r = ASRUtils::type_to_str_python(t);
+                break;
             } default : {
                 throw LCompilersException("The type `"
                     + ASRUtils::type_to_str_python(t) + "` is not handled yet");
@@ -616,6 +619,23 @@ public:
             r += s;
         }
         r += "\n";
+        s = r;
+    }
+
+    void visit_SetConstant(const ASR::SetConstant_t &x) {
+        std::string r = "";
+        r += "{";
+        size_t i = 0;
+        while (i < x.n_elements - 1) {
+            visit_expr(*x.m_elements[i]);
+            r += s;
+            r += ", ";
+            i++;
+        }
+        visit_expr(*x.m_elements[i]);
+        r += s;
+        r += "}";
+
         s = r;
     }
 


### PR DESCRIPTION
### Global scope

```python
from lpython import i32, f64

my_first_set: set[i32] = {1, 2, 3, 2, 4}
print(my_first_set)

my_second_set: set[f64] = {1.1, 2.5, 6.8}
print(my_second_set)

my_third_set: set[str] = {"a", "b", "a", "c"}
print(my_third_set)
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lpython$ ./src/bin/lpython ./examples/example.py --show-python
def __main__global_init():
    my_first_set = {1, 2, 3, 2, 4}
    my_second_set = {1.100000, 2.500000, 6.800000}
    my_third_set = {"a", "b", "a", "c"}
def __main__global_stmts():
    print(my_first_set)
    print(my_second_set)
    print(my_third_set)
```

### Local scope

```python
from lpython import i32, f64


def f():
    my_first_set: set[i32] = {1, 2, 3, 2, 4}
    print(my_first_set)

    my_second_set: set[f64] = {1.1, 2.5, 6.8}
    print(my_second_set)

    my_third_set: set[str] = {"a", "b", "a", "c"}
    print(my_third_set)


f()
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lpython$ ./src/bin/lpython ./examples/example.py --show-python
def __main__global_stmts():
    f()
def f():
    my_first_set: set[i32]
    my_second_set: set[f64]
    my_third_set: set[str]
    my_first_set = {1, 2, 3, 2, 4}
    print(my_first_set)
    my_second_set = {1.100000, 2.500000, 6.800000}
    print(my_second_set)
    my_third_set = {"a", "b", "a", "c"}
    print(my_third_set)
```

### TODO

- [ ] Add tests