### PR TITLE
ASR -> CPython: Add `DictConstant` visitor

### DIFF
--- a/src/libasr/codegen/asr_to_python.cpp
+++ b/src/libasr/codegen/asr_to_python.cpp
@@ -150,9 +150,6 @@ public:
             } case ASR::ttypeType::Logical : {
                 r = "bool";
                 break;
-            } case ASR::ttypeType::Dict : {
-                r = ASRUtils::type_to_str_python(t);
-                break;
             } default : {
                 throw LCompilersException("The type `"
                     + ASRUtils::type_to_str_python(t) + "` is not handled yet");

--- a/src/libasr/codegen/asr_to_python.cpp
+++ b/src/libasr/codegen/asr_to_python.cpp
@@ -636,7 +636,6 @@ public:
     void visit_SetConstant(const ASR::SetConstant_t &x) {
         visit_AggregateConstant(x.n_elements, x.m_elements, "{", "}");
     }
-    
 };
 
 Result<std::string> asr_to_python(Allocator& al, ASR::TranslationUnit_t &asr,

--- a/src/libasr/codegen/asr_to_python.cpp
+++ b/src/libasr/codegen/asr_to_python.cpp
@@ -620,23 +620,19 @@ public:
     }
 
     void visit_DictConstant(const ASR::DictConstant_t &x) {
+        LCOMPILERS_ASSERT(x.n_keys == x.n_values);
         std::string r = "";
         r += "{";
-        size_t i = 0;
-        while (i < x.n_keys - 1) {
+        for (size_t i = 0; i < x.n_keys; i++) {
             visit_expr(*x.m_keys[i]);
             r += s;
             r += ": ";
             visit_expr(*x.m_values[i]);
             r += s; 
-            r += ", ";
-            i++;
+            if (i < x.n_keys - 1) {
+                r += ", ";
+            }
         }
-        visit_expr(*x.m_keys[i]);
-        r += s;
-        r += ": ";
-        visit_expr(*x.m_values[i]);
-        r += s;
         r += "}";
 
         s = r;

--- a/src/libasr/codegen/asr_to_python.cpp
+++ b/src/libasr/codegen/asr_to_python.cpp
@@ -150,6 +150,9 @@ public:
             } case ASR::ttypeType::Logical : {
                 r = "bool";
                 break;
+            } case ASR::ttypeType::Dict : {
+                r = ASRUtils::type_to_str_python(t);
+                break;
             } default : {
                 throw LCompilersException("The type `"
                     + ASRUtils::type_to_str_python(t) + "` is not handled yet");
@@ -616,6 +619,29 @@ public:
             r += s;
         }
         r += "\n";
+        s = r;
+    }
+
+    void visit_DictConstant(const ASR::DictConstant_t &x) {
+        std::string r = "";
+        r += "{";
+        size_t i = 0;
+        while (i < x.n_keys - 1) {
+            visit_expr(*x.m_keys[i]);
+            r += s;
+            r += ": ";
+            visit_expr(*x.m_values[i]);
+            r += s; 
+            r += ", ";
+            i++;
+        }
+        visit_expr(*x.m_keys[i]);
+        r += s;
+        r += ": ";
+        visit_expr(*x.m_values[i]);
+        r += s;
+        r += "}";
+
         s = r;
     }
 

--- a/tests/reference/python-test_aggregate_constants-26c89d6.json
+++ b/tests/reference/python-test_aggregate_constants-26c89d6.json
@@ -2,11 +2,11 @@
     "basename": "python-test_aggregate_constants-26c89d6",
     "cmd": "lpython --no-color --show-python {infile}",
     "infile": "tests/test_aggregate_constants.py",
-    "infile_hash": "e4f25c9787536c0ecc60a1d53b4bca5f250e2a4f3646b45565867e86",
+    "infile_hash": "6e225037304a9a1222b4c356b8cd1ffc5ed4a58bb7d6916c242c7b53",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "python-test_aggregate_constants-26c89d6.stdout",
-    "stdout_hash": "813b11b4ee92df0eebccb3031a1b73355957795a72b487115093c3ce",
+    "stdout_hash": "3d5fa791404534643f6f2a096b2bc1561cf6c03a78d060b79df4f17b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/python-test_aggregate_constants-26c89d6.stdout
+++ b/tests/reference/python-test_aggregate_constants-26c89d6.stdout
@@ -13,6 +13,12 @@ def __main__global_init():
     my_second_set = {1.100000, 2.500000, 6.800000}
     my_third_set = {"a", "b", "a", "c"}
     my_fourth_set = {(1, "a"), (2, "b"), (3, "c")}
+    my_first_dict = {"a": 1, "b": 2, "c": 3}
+    my_second_dict = {1: 1.330000, 2: 2.330000, 3: 3.330000}
+    my_third_dict = {"a": "A", "b": "B", "c": "C"}
+    my_fourth_dict = {1: (1.200000, 4.500000), 2: (3.600000, 9.200000)}
+    my_fifth_dict = {"list1": [1, 2, 3], "list2": [4, 5, 6]}
+    my_sixth_dict = {"set1": {1, 2, 1}, "set2": {4, 1, 2}}
 def __main__global_stmts():
     print(my_first_list)
     print(my_second_list)
@@ -28,19 +34,31 @@ def __main__global_stmts():
     print(my_second_set)
     print(my_third_set)
     print(my_fourth_set)
+    print(my_first_dict)
+    print(my_second_dict)
+    print(my_third_dict)
+    print(my_fourth_dict)
+    print(my_fifth_dict)
+    print(my_sixth_dict)
     fn()
 def fn():
+    my_fifth_dict: dict[str, list[i32]]
     my_fifth_list: list[set[str]]
+    my_first_dict: dict[str, i32]
     my_first_list: list[i32]
     my_first_set: set[i32]
     my_first_tuple: tuple[i32, str, f64]
+    my_fourth_dict: dict[i32, tuple[f64, f64]]
     my_fourth_list: list[list[f64]]
     my_fourth_set: set[tuple[i32, str]]
     my_fourth_tuple: tuple[set[str], str]
+    my_second_dict: dict[i32, f64]
     my_second_list: list[str]
     my_second_set: set[f64]
     my_second_tuple: tuple[tuple[i32, str], str]
+    my_sixth_dict: dict[str, set[i32]]
     my_sixth_list: list[tuple[i32, str]]
+    my_third_dict: dict[str, str]
     my_third_list: list[list[i32]]
     my_third_set: set[str]
     my_third_tuple: tuple[list[str], str]
@@ -72,3 +90,15 @@ def fn():
     print(my_third_set)
     my_fourth_set = {(1, "a"), (2, "b"), (3, "c")}
     print(my_fourth_set)
+    my_first_dict = {"a": 1, "b": 2, "c": 3}
+    print(my_first_dict)
+    my_second_dict = {1: 1.330000, 2: 2.330000, 3: 3.330000}
+    print(my_second_dict)
+    my_third_dict = {"a": "A", "b": "B", "c": "C"}
+    print(my_third_dict)
+    my_fourth_dict = {1: (1.200000, 4.500000), 2: (3.600000, 9.200000)}
+    print(my_fourth_dict)
+    my_fifth_dict = {"list1": [1, 2, 3], "list2": [4, 5, 6]}
+    print(my_fifth_dict)
+    my_sixth_dict = {"set1": {1, 2, 1}, "set2": {4, 1, 2}}
+    print(my_sixth_dict)

--- a/tests/test_aggregate_constants.py
+++ b/tests/test_aggregate_constants.py
@@ -47,6 +47,25 @@ print(my_third_set)
 my_fourth_set: set[tuple[i32, str]] = {(1, "a"), (2, "b"), (3, "c")}
 print(my_fourth_set)
 
+# Dictionary
+my_first_dict: dict[str, i32] = {"a": 1, "b": 2, "c": 3}
+print(my_first_dict)
+
+my_second_dict: dict[i32, f64] = {1: 1.33, 2: 2.33, 3: 3.33}
+print(my_second_dict)
+
+my_third_dict: dict[str, str] = {"a": "A", "b": "B", "c": "C"}
+print(my_third_dict)
+
+my_fourth_dict: dict[i32, tuple[f64, f64]] = {1: (1.2, 4.5), 2: (3.6, 9.2)}
+print(my_fourth_dict)
+
+my_fifth_dict: dict[str, list[i32]] = {"list1": [1, 2, 3], "list2": [4, 5, 6]}
+print(my_fifth_dict)
+
+my_sixth_dict: dict[str, set[i32]] = {"set1": {1, 2, 1}, "set2": {4, 1, 2}}
+print(my_sixth_dict)
+
 # Test codegen for local scope
 def fn():
     # List
@@ -93,5 +112,24 @@ def fn():
 
     my_fourth_set: set[tuple[i32, str]] = {(1, "a"), (2, "b"), (3, "c")}
     print(my_fourth_set)
+
+    # Dictionary
+    my_first_dict: dict[str, i32] = {"a": 1, "b": 2, "c": 3}
+    print(my_first_dict)
+
+    my_second_dict: dict[i32, f64] = {1: 1.33, 2: 2.33, 3: 3.33}
+    print(my_second_dict)
+
+    my_third_dict: dict[str, str] = {"a": "A", "b": "B", "c": "C"}
+    print(my_third_dict)
+
+    my_fourth_dict: dict[i32, tuple[f64, f64]] = {1: (1.2, 4.5), 2: (3.6, 9.2)}
+    print(my_fourth_dict)
+
+    my_fifth_dict: dict[str, list[i32]] = {"list1": [1, 2, 3], "list2": [4, 5, 6]}
+    print(my_fifth_dict)
+
+    my_sixth_dict: dict[str, set[i32]] = {"set1": {1, 2, 1}, "set2": {4, 1, 2}}
+    print(my_sixth_dict)
 
 fn()


### PR DESCRIPTION
### Global scope

```python
from lpython import i32, f64

my_first_dict: dict[str, i32] = {"a": 1, "b": 2, "c": 3}
print(my_first_dict)

my_second_dict: dict[i32, f64] = {1: 1.33, 2: 2.33, 3: 3.33}
print(my_second_dict)

my_third_dict: dict[str, str] = {"a": "A", "b": "B", "c": "C"}
print(my_third_dict)
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lpython$ ./src/bin/lpython ./examples/example.py --show-python
def __main__global_init():
    my_first_dict = {"a": 1, "b": 2, "c": 3}
    my_second_dict = {1: 1.330000, 2: 2.330000, 3: 3.330000}
    my_third_dict = {"a": "A", "b": "B", "c": "C"}
def __main__global_stmts():
    print(my_first_dict)
    print(my_second_dict)
    print(my_third_dict)
```

### Local scope

```python
from lpython import i32, f64


def f():
    my_first_dict: dict[str, i32] = {"a": 1, "b": 2, "c": 3}
    print(my_first_dict)

    my_second_dict: dict[i32, f64] = {1: 1.33, 2: 2.33, 3: 3.33}
    print(my_second_dict)

    my_third_dict: dict[str, str] = {"a": "A", "b": "B", "c": "C"}
    print(my_third_dict)


f()
```
```console
(base) saurabh-kumar@Awadh:~/Projects/System/lpython$ ./src/bin/lpython ./examples/example.py --show-python
def __main__global_stmts():
    f()
def f():
    my_first_dict: dict[str, i32]
    my_second_dict: dict[i32, f64]
    my_third_dict: dict[str, str]
    my_first_dict = {"a": 1, "b": 2, "c": 3}
    print(my_first_dict)
    my_second_dict = {1: 1.330000, 2: 2.330000, 3: 3.330000}
    print(my_second_dict)
    my_third_dict = {"a": "A", "b": "B", "c": "C"}
    print(my_third_dict)
```

### TODO

- [X] Add tests