### PR TITLE
Added support for subs attribute

### DIFF
--- a/integration_tests/symbolics_05.py
+++ b/integration_tests/symbolics_05.py
@@ -40,4 +40,12 @@ def test_operations():
     assert(c.args[0] == x)
     assert(d.args[0] == x)
 
+    # test subs
+    b1: S = b.subs(x, y)
+    b1 = b1.subs(z, y)
+    assert(a.subs(x, y) == S(4)*y**S(2))
+    assert(b1 == S(27)*y**S(3))
+    assert(c.subs(x, y) == sin(y))
+    assert(d.subs(x, z) == cos(z))
+
 test_operations()

--- a/src/libasr/pass/intrinsic_function_registry.h
+++ b/src/libasr/pass/intrinsic_function_registry.h
@@ -148,6 +148,7 @@ inline std::string get_intrinsic_name(int x) {
         INTRINSIC_NAME_CASE(SymbolicInteger)
         INTRINSIC_NAME_CASE(SymbolicDiff)
         INTRINSIC_NAME_CASE(SymbolicExpand)
+        INTRINSIC_NAME_CASE(SymbolicSubs)
         INTRINSIC_NAME_CASE(SymbolicSin)
         INTRINSIC_NAME_CASE(SymbolicCos)
         INTRINSIC_NAME_CASE(SymbolicLog)
@@ -435,6 +436,8 @@ namespace IntrinsicElementalFunctionRegistry {
             {nullptr, &SymbolicDiff::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicExpand),
             {nullptr, &SymbolicExpand::verify_args}},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicSubs),
+            {nullptr, &SymbolicSubs::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicSin),
             {nullptr, &SymbolicSin::verify_args}},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicCos),
@@ -724,6 +727,8 @@ namespace IntrinsicElementalFunctionRegistry {
             "SymbolicDiff"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicExpand),
             "SymbolicExpand"},
+        {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicSubs),
+            "SymbolicSubs"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicSin),
             "SymbolicSin"},
         {static_cast<int64_t>(IntrinsicElementalFunctions::SymbolicCos),
@@ -889,6 +894,7 @@ namespace IntrinsicElementalFunctionRegistry {
                 {"SymbolicInteger", {&SymbolicInteger::create_SymbolicInteger, &SymbolicInteger::eval_SymbolicInteger}},
                 {"diff", {&SymbolicDiff::create_SymbolicDiff, &SymbolicDiff::eval_SymbolicDiff}},
                 {"expand", {&SymbolicExpand::create_SymbolicExpand, &SymbolicExpand::eval_SymbolicExpand}},
+                {"subs", {&SymbolicSubs::create_SymbolicSubs, &SymbolicSubs::eval_SymbolicSubs}},
                 {"SymbolicSin", {&SymbolicSin::create_SymbolicSin, &SymbolicSin::eval_SymbolicSin}},
                 {"SymbolicCos", {&SymbolicCos::create_SymbolicCos, &SymbolicCos::eval_SymbolicCos}},
                 {"SymbolicLog", {&SymbolicLog::create_SymbolicLog, &SymbolicLog::eval_SymbolicLog}},

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -57,6 +57,12 @@ public:
                 "basic_const_"#name, target));                                  \
             break; }
 
+    #define BASIC_TERNARYOP(SYM, name)                                          \
+        case LCompilers::ASRUtils::IntrinsicElementalFunctions::Symbolic##SYM: {  \
+            pass_result.push_back(al, basic_ternaryop(loc, "basic_"#name, target, \
+                    x->m_args[0], x->m_args[1], x->m_args[2]));                   \
+            break; }
+
     #define BASIC_BINOP(SYM, name)                                              \
         case LCompilers::ASRUtils::IntrinsicElementalFunctions::Symbolic##SYM: {   \
             pass_result.push_back(al, basic_binop(loc, "basic_"#name, target,   \
@@ -239,6 +245,16 @@ public:
         ASR::symbol_t* basic_const_sym = create_bindc_function(loc, fn_name,
             {ASRUtils::TYPE(ASR::make_CPtr_t(al, loc))});
         return SubroutineCall(loc, basic_const_sym, {value});
+    }
+
+    ASR::stmt_t *basic_ternaryop(const Location &loc, const std::string &fn_name,
+            ASR::expr_t* target, ASR::expr_t* op_01, ASR::expr_t* op_02, ASR::expr_t* op_03) {
+        ASR::ttype_t *cptr_type = ASRUtils::TYPE(ASR::make_CPtr_t(al, loc));
+        ASR::symbol_t* basic_ternaryop_sym = create_bindc_function(loc, fn_name,
+            {cptr_type, cptr_type, cptr_type, cptr_type});
+        return SubroutineCall(loc, basic_ternaryop_sym, {target,
+            handle_argument(al, loc, op_01), handle_argument(al, loc, op_02),
+            handle_argument(al, loc, op_03)});
     }
 
     ASR::stmt_t *basic_binop(const Location &loc, const std::string &fn_name,
@@ -462,6 +478,7 @@ public:
             BASIC_UNARYOP(Exp, exp)
             BASIC_UNARYOP(Abs, abs)
             BASIC_UNARYOP(Expand, expand)
+            BASIC_TERNARYOP(Subs, subs2)
             case LCompilers::ASRUtils::IntrinsicElementalFunctions::SymbolicGetArgument: {
                 // Define necessary function symbols
                 ASR::expr_t* value1 = handle_argument(al, loc, x->m_args[0]);

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -7565,7 +7565,7 @@ we will have to use something else.
             } else {
                 st = current_scope->resolve_symbol(mod_name);
                 std::set<std::string> symbolic_attributes = {
-                    "diff", "expand", "has"
+                    "diff", "expand", "has", "subs"
                 };
                 std::set<std::string> symbolic_constants = {
                     "pi", "E", "oo"
@@ -7640,7 +7640,7 @@ we will have to use something else.
         } else if (AST::is_a<AST::BinOp_t>(*at->m_value)) {
             AST::BinOp_t* bop = AST::down_cast<AST::BinOp_t>(at->m_value);
             std::set<std::string> symbolic_attributes = {
-                "diff", "expand", "has"
+                "diff", "expand", "has", "subs"
             };
             if (symbolic_attributes.find(at->m_attr) != symbolic_attributes.end()){
                 switch (bop->m_op) {
@@ -7687,7 +7687,7 @@ we will have to use something else.
         } else if (AST::is_a<AST::Call_t>(*at->m_value)) {
             AST::Call_t* call = AST::down_cast<AST::Call_t>(at->m_value);
             std::set<std::string> symbolic_attributes = {
-                "diff", "expand", "has"
+                "diff", "expand", "has", "subs"
             };
             if (symbolic_attributes.find(at->m_attr) != symbolic_attributes.end()){
                 std::set<std::string> symbolic_functions = {
@@ -7819,7 +7819,7 @@ we will have to use something else.
         if (!s) {
             std::string intrinsic_name = call_name;
             std::set<std::string> not_cpython_builtin = {
-                "sin", "cos", "gamma", "tan", "asin", "acos", "atan", "sinh", "cosh", "tanh", "exp", "exp2", "expm1", "Symbol", "diff", "expand", "trunc", "fix",
+                "sin", "cos", "gamma", "tan", "asin", "acos", "atan", "sinh", "cosh", "tanh", "exp", "exp2", "expm1", "Symbol", "diff", "expand", "trunc", "fix", "subs",
                 "sum" // For sum called over lists
             };
             std::set<std::string> symbolic_functions = {

--- a/src/lpython/semantics/python_attribute_eval.h
+++ b/src/lpython/semantics/python_attribute_eval.h
@@ -49,7 +49,8 @@ struct AttributeHandler {
             {"expand", &eval_symbolic_expand},
             {"has", &eval_symbolic_has_symbol},
             {"is_integer", &eval_symbolic_is_integer},
-            {"is_positive", &eval_symbolic_is_positive}
+            {"is_positive", &eval_symbolic_is_positive},
+            {"subs", &eval_symbolic_subs}
         };
     }
 
@@ -587,6 +588,19 @@ struct AttributeHandler {
         }
         ASRUtils::create_intrinsic_function create_function =
             ASRUtils::IntrinsicElementalFunctionRegistry::get_create_function("is_positive");
+        return create_function(al, loc, args_with_list, diag);
+    }
+
+    static ASR::asr_t* eval_symbolic_subs(ASR::expr_t *s, Allocator &al, const Location &loc,
+            Vec<ASR::expr_t*> &args, diag::Diagnostics &diag) {
+        Vec<ASR::expr_t*> args_with_list;
+        args_with_list.reserve(al, args.size() + 1);
+        args_with_list.push_back(al, s);
+        for(size_t i = 0; i < args.size(); i++) {
+            args_with_list.push_back(al, args[i]);
+        }
+        ASRUtils::create_intrinsic_function create_function =
+            ASRUtils::IntrinsicElementalFunctionRegistry::get_create_function("subs");
         return create_function(al, loc, args_with_list, diag);
     }
 


### PR DESCRIPTION
This allows us to address the following case 
```
from lpython import S
from sympy import Symbol, sin

def main0():
    x: S = Symbol('x')
    y: S = Symbol('y')
    z: S = sin(x)
    s: S = z.subs(x, y)
    print(s)

main0()
```
```
(lf) anutosh491@spbhat68:~/lpython/lpython$ lpython --enable-symengine examples/expr2.py 
sin(y)
(lf) anutosh491@spbhat68:~/lpython/lpython$ lpython --enable-symengine examples/expr2.py --backend=c
sin(y)
```