### PR TITLE
Fix LLVM code generation error in List comparsion

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -555,6 +555,7 @@ RUN(NAME test_list_pop       LABELS cpython llvm llvm_jit NOFAST) # TODO: Remove
 RUN(NAME test_list_pop2       LABELS cpython llvm llvm_jit NOFAST) # TODO: Remove NOFAST from here.
 RUN(NAME test_list_pop3      LABELS cpython llvm llvm_jit)
 RUN(NAME test_list_compare   LABELS cpython llvm llvm_jit)
+RUN(NAME test_list_compare2   LABELS cpython llvm llvm_jit)
 RUN(NAME test_list_concat    LABELS cpython llvm llvm_jit c NOFAST)
 RUN(NAME test_list_reserve   LABELS cpython llvm llvm_jit)
 RUN(NAME test_const_list     LABELS cpython llvm llvm_jit)

--- a/integration_tests/test_list_compare2.py
+++ b/integration_tests/test_list_compare2.py
@@ -1,0 +1,8 @@
+from lpython import i32
+
+x: list[i32] = [1, 2, 3, 4]
+y: list[i32] = [5, 6, 7, 8]
+z: list[i32] = [1, 2, 3, 4]
+
+assert(x != y)
+assert(x == z)

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -4985,6 +4985,7 @@ namespace LCompilers {
         llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont");
         builder->CreateCondBr(cond, thenBB, elseBB);
         builder->SetInsertPoint(thenBB);
+        builder0.SetInsertPoint(&entry_block, entry_block.getFirstInsertionPt());
         llvm::AllocaInst *idx = builder0.CreateAlloca(llvm::Type::getInt32Ty(context), nullptr);
         LLVM::CreateStore(*builder, llvm::ConstantInt::get(
                                     context, llvm::APInt(32, 0)), idx);
@@ -5066,6 +5067,7 @@ namespace LCompilers {
 
         llvm::Value *a_len = llvm_utils->list_api->len(l1);
         llvm::Value *b_len = llvm_utils->list_api->len(l2);
+        builder0.SetInsertPoint(&entry_block, entry_block.getFirstInsertionPt());
         llvm::AllocaInst *idx = builder0.CreateAlloca(llvm::Type::getInt32Ty(context), nullptr);
         LLVM::CreateStore(*builder, llvm::ConstantInt::get(
                                     context, llvm::APInt(32, 0)), idx);


### PR DESCRIPTION
Fixes: #2676

There was an issue where `builder0` and `builder` shared the same insertion point. As a result, `builder0` would append `alloca` instruction after instructions created by `builder`.