### PR TITLE
Fix logical comparsion for string

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -765,8 +765,8 @@ RUN(NAME test_platform       LABELS cpython llvm llvm_jit c)
 RUN(NAME test_vars_01        LABELS cpython llvm llvm_jit)
 RUN(NAME test_version        LABELS cpython llvm llvm_jit)
 RUN(NAME logical_binop1      LABELS cpython llvm llvm_jit)
-RUN(NAME test_logical_compare           LABELS cpython llvm llvm_jit)
-RUN(NAME test_logical_assignment        LABELS cpython llvm llvm_jit)
+RUN(NAME test_logical_compare           LABELS cpython llvm llvm_jit) # TODO: Add C backend after fixing issue #2708
+RUN(NAME test_logical_assignment        LABELS cpython llvm llvm_jit) # TODO: Add C backend after fixing issue #2708
 RUN(NAME vec_01              LABELS cpython llvm llvm_jit c NOFAST)
 RUN(NAME test_str_comparison LABELS cpython llvm llvm_jit c wasm)
 RUN(NAME test_bit_length     LABELS cpython llvm llvm_jit c)

--- a/integration_tests/test_logical_assignment.py
+++ b/integration_tests/test_logical_assignment.py
@@ -2,11 +2,10 @@ from lpython import i32, f64
 
 
 def test_logical_assignment():
-    # Can be uncommented after fixing the segfault
-    # _LPYTHON: str = "LPython"
-    # s_var: str = "" or _LPYTHON
-    # assert s_var == "LPython"
-    # print(s_var)
+    _LPYTHON: str = "LPython"
+    s_var: str = "" or _LPYTHON
+    assert s_var == "LPython"
+    print(s_var)
 
     _MAX_VAL: i32 = 100
     i_var: i32 = 0 and 100

--- a/integration_tests/test_logical_compare.py
+++ b/integration_tests/test_logical_compare.py
@@ -102,28 +102,27 @@ def test_logical_compare_variable():
     print(f_a - 3.0 and f_a + 3.0 or f_b - 3.0 and f_b + 3.0)
     assert (f_a - 3.0 and f_a + 3.0 or f_b - 3.0 and f_b + 3.0) == 4.67
 
-    # Can be uncommented after fixing the segfault
     # Strings
-    # s_a: str = "a"
-    # s_b: str = "b"
+    s_a: str = "a"
+    s_b: str = "b"
 
-    # print(s_a or s_b)
-    # assert (s_a or s_b) == s_a
+    print(s_a or s_b)
+    assert (s_a or s_b) == s_a
 
-    # print(s_a and s_b)
-    # assert (s_a and s_b) == s_b
+    print(s_a and s_b)
+    assert (s_a and s_b) == s_b
 
-    # print(s_a + s_b or s_b + s_a)
-    # assert (s_a + s_b or s_b + s_a) == "ab"
+    print(s_a + s_b or s_b + s_a)
+    assert (s_a + s_b or s_b + s_a) == "ab"
 
-    # print(s_a[0] or s_b[-1])
-    # assert (s_a[0] or s_b[-1]) == "a"
+    print(s_a[0] or s_b[-1])
+    assert (s_a[0] or s_b[-1]) == "a"
 
-    # print(s_a[0] and s_b[-1])
-    # assert (s_a[0] and s_b[-1]) == "b"
+    print(s_a[0] and s_b[-1])
+    assert (s_a[0] and s_b[-1]) == "b"
 
-    # print(s_a + s_b or s_b + s_a + s_a[0] and s_b[-1])
-    # assert (s_a + s_b or s_b + s_a + s_a[0] and s_b[-1]) == "ab"
+    print(s_a + s_b or s_b + s_a + s_a[0] and s_b[-1])
+    assert (s_a + s_b or s_b + s_a + s_a[0] and s_b[-1]) == "ab"
 
 
 test_logical_compare_literal()

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5897,7 +5897,7 @@ public:
             }
             cond = builder->CreateFCmpUEQ(left_val, zero);
         } else if (ASRUtils::is_character(*x.m_type)) {
-            zero = llvm::Constant::getNullValue(character_type);
+            zero = builder->CreateGlobalStringPtr("");
             cond = lfortran_str_cmp(left_val, zero, "_lpython_str_compare_eq");
         } else if (ASRUtils::is_logical(*x.m_type)) {
             zero = llvm::ConstantInt::get(context,


### PR DESCRIPTION
Fixes #2615

The problem is that `_lpython_str_compare_eq` requires pointer to pointer to char as parameters. However, the previous implementation passed a null pointer, leading to a segmentation fault.