### PR TITLE
removing _lfortran_caimag and _lfortran_zaimag functions

### DIFF
--- a/src/runtime/lpython_builtin.py
+++ b/src/runtime/lpython_builtin.py
@@ -64,7 +64,7 @@ def abs(c: c32) -> f32:
     a: f32
     b: f32
     a = c.real
-    b = _lfortran_caimag(c)
+    b = c.imag
     return f32((a**f32(2) + b**f32(2))**f32(1/2))
 
 @overload
@@ -72,7 +72,7 @@ def abs(c: c64) -> f64:
     a: f64
     b: f64
     a = c.real
-    b = _lfortran_zaimag(c)
+    b = c.imag
     return (a**2.0 + b**2.0)**(1/2)
 
 @interface
@@ -434,22 +434,13 @@ def lbound(x: i32[:], dim: i32) -> i32:
 def ubound(x: i32[:], dim: i32) -> i32:
     pass
 
-
-@ccall
-def _lfortran_caimag(x: c32) -> f32:
-    pass
-
-@ccall
-def _lfortran_zaimag(x: c64) -> f64:
-    pass
-
 @overload
 def _lpython_imag(x: c64) -> f64:
-    return _lfortran_zaimag(x)
+    return x.imag
 
 @overload
 def _lpython_imag(x: c32) -> f32:
-    return _lfortran_caimag(x)
+    return x.imag
 
 
 @overload

--- a/tests/reference/asr-array_01_decl-39cf894.json
+++ b/tests/reference/asr-array_01_decl-39cf894.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_01_decl-39cf894.stdout",
-    "stdout_hash": "292194a8fe4110a90c90bbcbf94f66b70f82978e14108ded75104711",
+    "stdout_hash": "3a65f3ea0a230ad60dcabd62518f2ee3d52a8aa788fc1f7d3835ad72",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_01_decl-39cf894.stdout
+++ b/tests/reference/asr-array_01_decl-39cf894.stdout
@@ -10,11 +10,11 @@
                             ArraySizes:
                                 (EnumType
                                     (SymbolTable
-                                        228
+                                        226
                                         {
                                             SIZE_10:
                                                 (Variable
-                                                    228
+                                                    226
                                                     SIZE_10
                                                     []
                                                     Local
@@ -30,7 +30,7 @@
                                                 ),
                                             SIZE_3:
                                                 (Variable
-                                                    228
+                                                    226
                                                     SIZE_3
                                                     []
                                                     Local
@@ -58,7 +58,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        235
+                                        233
                                         {
                                             
                                         })
@@ -94,11 +94,11 @@
                             accept_f32_array:
                                 (Function
                                     (SymbolTable
-                                        232
+                                        230
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    232
+                                                    230
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -114,7 +114,7 @@
                                                 ),
                                             xf32:
                                                 (Variable
-                                                    232
+                                                    230
                                                     xf32
                                                     []
                                                     InOut
@@ -155,10 +155,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 232 xf32)]
+                                    [(Var 230 xf32)]
                                     [(Assignment
                                         (ArrayItem
-                                            (Var 232 xf32)
+                                            (Var 230 xf32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -181,9 +181,9 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 _lpython_return_variable)
+                                        (Var 230 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 232 xf32)
+                                            (Var 230 xf32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -194,7 +194,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 232 _lpython_return_variable)
+                                    (Var 230 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -203,11 +203,11 @@
                             accept_f64_array:
                                 (Function
                                     (SymbolTable
-                                        233
+                                        231
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    233
+                                                    231
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -223,7 +223,7 @@
                                                 ),
                                             xf64:
                                                 (Variable
-                                                    233
+                                                    231
                                                     xf64
                                                     []
                                                     InOut
@@ -264,10 +264,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 233 xf64)]
+                                    [(Var 231 xf64)]
                                     [(Assignment
                                         (ArrayItem
-                                            (Var 233 xf64)
+                                            (Var 231 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -282,9 +282,9 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 233 _lpython_return_variable)
+                                        (Var 231 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 233 xf64)
+                                            (Var 231 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -295,7 +295,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 233 _lpython_return_variable)
+                                    (Var 231 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -304,11 +304,11 @@
                             accept_i16_array:
                                 (Function
                                     (SymbolTable
-                                        229
+                                        227
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    229
+                                                    227
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -324,7 +324,7 @@
                                                 ),
                                             xi16:
                                                 (Variable
-                                                    229
+                                                    227
                                                     xi16
                                                     []
                                                     InOut
@@ -365,10 +365,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 229 xi16)]
+                                    [(Var 227 xi16)]
                                     [(Assignment
                                         (ArrayItem
-                                            (Var 229 xi16)
+                                            (Var 227 xi16)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -385,9 +385,9 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 229 _lpython_return_variable)
+                                        (Var 227 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 229 xi16)
+                                            (Var 227 xi16)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -398,7 +398,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 229 _lpython_return_variable)
+                                    (Var 227 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -407,11 +407,11 @@
                             accept_i32_array:
                                 (Function
                                     (SymbolTable
-                                        230
+                                        228
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    230
+                                                    228
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -427,7 +427,7 @@
                                                 ),
                                             xi32:
                                                 (Variable
-                                                    230
+                                                    228
                                                     xi32
                                                     []
                                                     InOut
@@ -468,10 +468,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 230 xi32)]
+                                    [(Var 228 xi32)]
                                     [(Assignment
                                         (ArrayItem
-                                            (Var 230 xi32)
+                                            (Var 228 xi32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -483,9 +483,9 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 230 _lpython_return_variable)
+                                        (Var 228 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 230 xi32)
+                                            (Var 228 xi32)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -496,7 +496,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 230 _lpython_return_variable)
+                                    (Var 228 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -505,11 +505,11 @@
                             accept_i64_array:
                                 (Function
                                     (SymbolTable
-                                        231
+                                        229
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    231
+                                                    229
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -525,7 +525,7 @@
                                                 ),
                                             xi64:
                                                 (Variable
-                                                    231
+                                                    229
                                                     xi64
                                                     []
                                                     InOut
@@ -566,10 +566,10 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 231 xi64)]
+                                    [(Var 229 xi64)]
                                     [(Assignment
                                         (ArrayItem
-                                            (Var 231 xi64)
+                                            (Var 229 xi64)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -586,9 +586,9 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 231 _lpython_return_variable)
+                                        (Var 229 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 231 xi64)
+                                            (Var 229 xi64)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -599,7 +599,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 231 _lpython_return_variable)
+                                    (Var 229 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -608,11 +608,11 @@
                             declare_arrays:
                                 (Function
                                     (SymbolTable
-                                        234
+                                        232
                                         {
                                             ac32:
                                                 (Variable
-                                                    234
+                                                    232
                                                     ac32
                                                     []
                                                     Local
@@ -633,7 +633,7 @@
                                                 ),
                                             ac64:
                                                 (Variable
-                                                    234
+                                                    232
                                                     ac64
                                                     []
                                                     Local
@@ -654,7 +654,7 @@
                                                 ),
                                             af32:
                                                 (Variable
-                                                    234
+                                                    232
                                                     af32
                                                     []
                                                     Local
@@ -675,7 +675,7 @@
                                                 ),
                                             af64:
                                                 (Variable
-                                                    234
+                                                    232
                                                     af64
                                                     []
                                                     Local
@@ -696,7 +696,7 @@
                                                 ),
                                             ai16:
                                                 (Variable
-                                                    234
+                                                    232
                                                     ai16
                                                     []
                                                     Local
@@ -717,7 +717,7 @@
                                                 ),
                                             ai32:
                                                 (Variable
-                                                    234
+                                                    232
                                                     ai32
                                                     []
                                                     Local
@@ -738,7 +738,7 @@
                                                 ),
                                             ai64:
                                                 (Variable
-                                                    234
+                                                    232
                                                     ai64
                                                     []
                                                     Local
@@ -780,7 +780,7 @@
                                     accept_f64_array]
                                     []
                                     [(Assignment
-                                        (Var 234 ai16)
+                                        (Var 232 ai16)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -795,7 +795,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 234 ai32)
+                                        (Var 232 ai32)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -810,7 +810,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 234 ai64)
+                                        (Var 232 ai64)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -825,7 +825,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 234 af32)
+                                        (Var 232 af32)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -840,7 +840,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 234 af64)
+                                        (Var 232 af64)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -855,7 +855,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 234 ac32)
+                                        (Var 232 ac32)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -870,7 +870,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 234 ac64)
+                                        (Var 232 ac64)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -889,7 +889,7 @@
                                             2 accept_i16_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 234 ai16)
+                                                (Var 232 ai16)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -912,7 +912,7 @@
                                             2 accept_i32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 234 ai32)
+                                                (Var 232 ai32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -935,7 +935,7 @@
                                             2 accept_i64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 234 ai64)
+                                                (Var 232 ai64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -958,7 +958,7 @@
                                             2 accept_f32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 234 af32)
+                                                (Var 232 af32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -981,7 +981,7 @@
                                             2 accept_f64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 234 af64)
+                                                (Var 232 af64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -1016,11 +1016,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        236
+                        234
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    236
+                                    234
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1032,7 +1032,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        236 __main__global_stmts
+                        234 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-array_02_decl-e8f6874.json
+++ b/tests/reference/asr-array_02_decl-e8f6874.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-array_02_decl-e8f6874.stdout",
-    "stdout_hash": "7b506405f2db787df8d5e04ea40bb26baf200b5ea75a29f8410dcaaa",
+    "stdout_hash": "71ec0bc14f8e98abf82cd10195f0949c765bc136b357701653ef100b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-array_02_decl-e8f6874.stdout
+++ b/tests/reference/asr-array_02_decl-e8f6874.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        233
+                                        231
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             accept_multidim_f32_array:
                                 (Function
                                     (SymbolTable
-                                        230
+                                        228
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    230
+                                                    228
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -66,7 +66,7 @@
                                                 ),
                                             xf32:
                                                 (Variable
-                                                    230
+                                                    228
                                                     xf32
                                                     []
                                                     InOut
@@ -107,11 +107,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 230 xf32)]
+                                    [(Var 228 xf32)]
                                     [(Assignment
-                                        (Var 230 _lpython_return_variable)
+                                        (Var 228 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 230 xf32)
+                                            (Var 228 xf32)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -122,7 +122,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 230 _lpython_return_variable)
+                                    (Var 228 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -131,11 +131,11 @@
                             accept_multidim_f64_array:
                                 (Function
                                     (SymbolTable
-                                        231
+                                        229
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    231
+                                                    229
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -151,7 +151,7 @@
                                                 ),
                                             xf64:
                                                 (Variable
-                                                    231
+                                                    229
                                                     xf64
                                                     []
                                                     InOut
@@ -196,11 +196,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 231 xf64)]
+                                    [(Var 229 xf64)]
                                     [(Assignment
-                                        (Var 231 _lpython_return_variable)
+                                        (Var 229 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 231 xf64)
+                                            (Var 229 xf64)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -214,7 +214,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 231 _lpython_return_variable)
+                                    (Var 229 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -223,11 +223,11 @@
                             accept_multidim_i32_array:
                                 (Function
                                     (SymbolTable
-                                        228
+                                        226
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    228
+                                                    226
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -243,7 +243,7 @@
                                                 ),
                                             xi32:
                                                 (Variable
-                                                    228
+                                                    226
                                                     xi32
                                                     []
                                                     InOut
@@ -288,11 +288,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 228 xi32)]
+                                    [(Var 226 xi32)]
                                     [(Assignment
-                                        (Var 228 _lpython_return_variable)
+                                        (Var 226 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 228 xi32)
+                                            (Var 226 xi32)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -306,7 +306,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 228 _lpython_return_variable)
+                                    (Var 226 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -315,11 +315,11 @@
                             accept_multidim_i64_array:
                                 (Function
                                     (SymbolTable
-                                        229
+                                        227
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    229
+                                                    227
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -335,7 +335,7 @@
                                                 ),
                                             xi64:
                                                 (Variable
-                                                    229
+                                                    227
                                                     xi64
                                                     []
                                                     InOut
@@ -384,11 +384,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 229 xi64)]
+                                    [(Var 227 xi64)]
                                     [(Assignment
-                                        (Var 229 _lpython_return_variable)
+                                        (Var 227 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 229 xi64)
+                                            (Var 227 xi64)
                                             [(()
                                             (IntegerConstant 9 (Integer 4))
                                             ())
@@ -405,7 +405,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 229 _lpython_return_variable)
+                                    (Var 227 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -414,11 +414,11 @@
                             declare_arrays:
                                 (Function
                                     (SymbolTable
-                                        232
+                                        230
                                         {
                                             ac32:
                                                 (Variable
-                                                    232
+                                                    230
                                                     ac32
                                                     []
                                                     Local
@@ -443,7 +443,7 @@
                                                 ),
                                             ac64:
                                                 (Variable
-                                                    232
+                                                    230
                                                     ac64
                                                     []
                                                     Local
@@ -470,7 +470,7 @@
                                                 ),
                                             af32:
                                                 (Variable
-                                                    232
+                                                    230
                                                     af32
                                                     []
                                                     Local
@@ -491,7 +491,7 @@
                                                 ),
                                             af64:
                                                 (Variable
-                                                    232
+                                                    230
                                                     af64
                                                     []
                                                     Local
@@ -514,7 +514,7 @@
                                                 ),
                                             ai32:
                                                 (Variable
-                                                    232
+                                                    230
                                                     ai32
                                                     []
                                                     Local
@@ -537,7 +537,7 @@
                                                 ),
                                             ai64:
                                                 (Variable
-                                                    232
+                                                    230
                                                     ai64
                                                     []
                                                     Local
@@ -582,7 +582,7 @@
                                     accept_multidim_f64_array]
                                     []
                                     [(Assignment
-                                        (Var 232 ai32)
+                                        (Var 230 ai32)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -599,7 +599,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 ai64)
+                                        (Var 230 ai64)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -618,7 +618,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 af32)
+                                        (Var 230 af32)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -633,7 +633,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 af64)
+                                        (Var 230 af64)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -650,7 +650,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 ac32)
+                                        (Var 230 ac32)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -669,7 +669,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 ac64)
+                                        (Var 230 ac64)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -694,7 +694,7 @@
                                             2 accept_multidim_i32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 232 ai32)
+                                                (Var 230 ai32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -719,7 +719,7 @@
                                             2 accept_multidim_i64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 232 ai64)
+                                                (Var 230 ai64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -746,7 +746,7 @@
                                             2 accept_multidim_f32_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 232 af32)
+                                                (Var 230 af32)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -769,7 +769,7 @@
                                             2 accept_multidim_f64_array
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 232 af64)
+                                                (Var 230 af64)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -806,11 +806,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        234
+                        232
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    234
+                                    232
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -822,7 +822,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        234 __main__global_stmts
+                        232 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-bindc_02-bc1a7ea.json
+++ b/tests/reference/asr-bindc_02-bc1a7ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-bindc_02-bc1a7ea.stdout",
-    "stdout_hash": "0b63ac37d3c2fadcacabe7c8c985e02c6d3db8f19f945ab2a88414f7",
+    "stdout_hash": "71473316455dc06eda99f7a7bcf0ac3ed2e6a69d0e1f0893d9a0c48f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-bindc_02-bc1a7ea.stdout
+++ b/tests/reference/asr-bindc_02-bc1a7ea.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        229
+                                        227
                                         {
                                             
                                         })
@@ -76,11 +76,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        228
+                                        226
                                         {
                                             y:
                                                 (Variable
-                                                    228
+                                                    226
                                                     y
                                                     []
                                                     Local
@@ -101,7 +101,7 @@
                                                 ),
                                             yptr1:
                                                 (Variable
-                                                    228
+                                                    226
                                                     yptr1
                                                     []
                                                     Local
@@ -124,7 +124,7 @@
                                                 ),
                                             yq:
                                                 (Variable
-                                                    228
+                                                    226
                                                     yq
                                                     []
                                                     Local
@@ -157,14 +157,14 @@
                                     []
                                     []
                                     [(Assignment
-                                        (Var 228 yq)
+                                        (Var 226 yq)
                                         (PointerNullConstant
                                             (CPtr)
                                         )
                                         ()
                                     )
                                     (Assignment
-                                        (Var 228 y)
+                                        (Var 226 y)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -180,7 +180,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 228 y)
+                                            (Var 226 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -198,7 +198,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 228 y)
+                                            (Var 226 y)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -215,9 +215,9 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 228 yptr1)
+                                        (Var 226 yptr1)
                                         (GetPointer
-                                            (Var 228 y)
+                                            (Var 226 y)
                                             (Pointer
                                                 (Array
                                                     (Integer 2)
@@ -232,7 +232,7 @@
                                     )
                                     (Print
                                         [(GetPointer
-                                            (Var 228 y)
+                                            (Var 226 y)
                                             (Pointer
                                                 (Array
                                                     (Integer 2)
@@ -243,13 +243,13 @@
                                             )
                                             ()
                                         )
-                                        (Var 228 yptr1)]
+                                        (Var 226 yptr1)]
                                         ()
                                         ()
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 228 yptr1)
+                                            (Var 226 yptr1)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -258,7 +258,7 @@
                                             ()
                                         )
                                         (ArrayItem
-                                            (Var 228 yptr1)
+                                            (Var 226 yptr1)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -272,7 +272,7 @@
                                     (Assert
                                         (IntegerCompare
                                             (ArrayItem
-                                                (Var 228 yptr1)
+                                                (Var 226 yptr1)
                                                 [(()
                                                 (IntegerConstant 0 (Integer 4))
                                                 ())]
@@ -295,7 +295,7 @@
                                     (Assert
                                         (IntegerCompare
                                             (ArrayItem
-                                                (Var 228 yptr1)
+                                                (Var 226 yptr1)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -316,8 +316,8 @@
                                         ()
                                     )
                                     (CPtrToPointer
-                                        (Var 228 yq)
-                                        (Var 228 yptr1)
+                                        (Var 226 yq)
+                                        (Var 226 yptr1)
                                         (ArrayConstant
                                             [(IntegerConstant 2 (Integer 4))]
                                             (Array
@@ -340,8 +340,8 @@
                                         )
                                     )
                                     (Print
-                                        [(Var 228 yq)
-                                        (Var 228 yptr1)]
+                                        [(Var 226 yq)
+                                        (Var 226 yptr1)]
                                         ()
                                         ()
                                     )]
@@ -405,11 +405,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        230
+                        228
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    230
+                                    228
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -421,7 +421,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        230 __main__global_stmts
+                        228 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-cast-435c233.json
+++ b/tests/reference/asr-cast-435c233.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-cast-435c233.stdout",
-    "stdout_hash": "57cf8fa21e9a019ea1b4e9c13ecfc8500bd40140ab73e3706f4a548b",
+    "stdout_hash": "9d4368f1a04a24fa6209f6a540719cfeffe42ca14994adca08f2f8de",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-cast-435c233.stdout
+++ b/tests/reference/asr-cast-435c233.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        144
+                                        142
                                         {
                                             
                                         })
@@ -285,11 +285,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        145
+                        143
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    145
+                                    143
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -301,7 +301,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        145 __main__global_stmts
+                        143 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-complex1-f26c460.json
+++ b/tests/reference/asr-complex1-f26c460.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-complex1-f26c460.stdout",
-    "stdout_hash": "187cdc6930877e015c5c561fcab7e91901fdf598059e5b81435617e3",
+    "stdout_hash": "ae33d701d4d343cafa7615c300a6c694a61b708244326bc8b0053ce2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-complex1-f26c460.stdout
+++ b/tests/reference/asr-complex1-f26c460.stdout
@@ -776,7 +776,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        145
+                        143
                         {
                             
                         })

--- a/tests/reference/asr-constants1-5828e8a.json
+++ b/tests/reference/asr-constants1-5828e8a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-constants1-5828e8a.stdout",
-    "stdout_hash": "40a4972efc12a829102ca7c72203bfff3548b6a3dae12848310271a7",
+    "stdout_hash": "5fb0df2d4db52331b704c1654c77872bcfb83423b7d4911fb86fdf20",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-constants1-5828e8a.stdout
+++ b/tests/reference/asr-constants1-5828e8a.stdout
@@ -1778,7 +1778,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        153
+                        151
                         {
                             
                         })

--- a/tests/reference/asr-elemental_01-b58df26.json
+++ b/tests/reference/asr-elemental_01-b58df26.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-elemental_01-b58df26.stdout",
-    "stdout_hash": "4c513521bada6163ac63fa332b183b73632bc0c1e8598ad0b75d8424",
+    "stdout_hash": "a0f93dd97eb3511199ce735fe6dc8dd0e08595a6b477816c65b1b4b7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-elemental_01-b58df26.stdout
+++ b/tests/reference/asr-elemental_01-b58df26.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        261
+                                        259
                                         {
                                             
                                         })
@@ -84,11 +84,11 @@
                             elemental_cos:
                                 (Function
                                     (SymbolTable
-                                        236
+                                        234
                                         {
                                             array2d:
                                                 (Variable
-                                                    236
+                                                    234
                                                     array2d
                                                     []
                                                     Local
@@ -111,7 +111,7 @@
                                                 ),
                                             cos2d:
                                                 (Variable
-                                                    236
+                                                    234
                                                     cos2d
                                                     []
                                                     Local
@@ -134,7 +134,7 @@
                                                 ),
                                             cos@__lpython_overloaded_0__cos:
                                                 (ExternalSymbol
-                                                    236
+                                                    234
                                                     cos@__lpython_overloaded_0__cos
                                                     3 __lpython_overloaded_0__cos
                                                     numpy
@@ -144,7 +144,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    236
+                                                    234
                                                     i
                                                     []
                                                     Local
@@ -160,7 +160,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    236
+                                                    234
                                                     j
                                                     []
                                                     Local
@@ -193,7 +193,7 @@
                                     [verify2d]
                                     []
                                     [(Assignment
-                                        (Var 236 array2d)
+                                        (Var 234 array2d)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -210,7 +210,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 236 cos2d)
+                                        (Var 234 cos2d)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -228,7 +228,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 236 i)
+                                        ((Var 234 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -240,7 +240,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 236 j)
+                                            ((Var 234 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 64 (Integer 4))
@@ -252,12 +252,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(Assignment
                                                 (ArrayItem
-                                                    (Var 236 array2d)
+                                                    (Var 234 array2d)
                                                     [(()
-                                                    (Var 236 i)
+                                                    (Var 234 i)
                                                     ())
                                                     (()
-                                                    (Var 236 j)
+                                                    (Var 234 j)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -265,9 +265,9 @@
                                                 )
                                                 (Cast
                                                     (IntegerBinOp
-                                                        (Var 236 i)
+                                                        (Var 234 i)
                                                         Add
-                                                        (Var 236 j)
+                                                        (Var 234 j)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -282,12 +282,12 @@
                                         []
                                     )
                                     (Assignment
-                                        (Var 236 cos2d)
+                                        (Var 234 cos2d)
                                         (RealBinOp
                                             (FunctionCall
-                                                236 cos@__lpython_overloaded_0__cos
+                                                234 cos@__lpython_overloaded_0__cos
                                                 2 cos
-                                                [((Var 236 array2d))]
+                                                [((Var 234 array2d))]
                                                 (Array
                                                     (Real 8)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -320,7 +320,7 @@
                                         2 verify2d
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 236 array2d)
+                                            (Var 234 array2d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -334,7 +334,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 236 cos2d)
+                                            (Var 234 cos2d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -360,11 +360,11 @@
                             elemental_mul:
                                 (Function
                                     (SymbolTable
-                                        234
+                                        232
                                         {
                                             array_a:
                                                 (Variable
-                                                    234
+                                                    232
                                                     array_a
                                                     []
                                                     Local
@@ -385,7 +385,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    234
+                                                    232
                                                     array_b
                                                     []
                                                     Local
@@ -406,7 +406,7 @@
                                                 ),
                                             array_c:
                                                 (Variable
-                                                    234
+                                                    232
                                                     array_c
                                                     []
                                                     Local
@@ -427,7 +427,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    234
+                                                    232
                                                     i
                                                     []
                                                     Local
@@ -443,7 +443,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    234
+                                                    232
                                                     j
                                                     []
                                                     Local
@@ -459,7 +459,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    234
+                                                    232
                                                     k
                                                     []
                                                     Local
@@ -492,7 +492,7 @@
                                     [verify1d_mul]
                                     []
                                     [(Assignment
-                                        (Var 234 array_a)
+                                        (Var 232 array_a)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -507,7 +507,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 234 array_b)
+                                        (Var 232 array_b)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -522,7 +522,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 234 array_c)
+                                        (Var 232 array_c)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -538,7 +538,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 234 i)
+                                        ((Var 232 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -550,16 +550,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
                                             (ArrayItem
-                                                (Var 234 array_a)
+                                                (Var 232 array_a)
                                                 [(()
-                                                (Var 234 i)
+                                                (Var 232 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 234 i)
+                                                (Var 232 i)
                                                 IntegerToReal
                                                 (Real 8)
                                                 ()
@@ -570,7 +570,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 234 j)
+                                        ((Var 232 j)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -582,9 +582,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
                                             (ArrayItem
-                                                (Var 234 array_b)
+                                                (Var 232 array_b)
                                                 [(()
-                                                (Var 234 j)
+                                                (Var 232 j)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -592,7 +592,7 @@
                                             )
                                             (Cast
                                                 (IntegerBinOp
-                                                    (Var 234 j)
+                                                    (Var 232 j)
                                                     Add
                                                     (IntegerConstant 5 (Integer 4))
                                                     (Integer 4)
@@ -607,11 +607,11 @@
                                         []
                                     )
                                     (Assignment
-                                        (Var 234 array_c)
+                                        (Var 232 array_c)
                                         (RealBinOp
                                             (RealBinOp
                                                 (RealBinOp
-                                                    (Var 234 array_a)
+                                                    (Var 232 array_a)
                                                     Pow
                                                     (RealConstant
                                                         2.000000
@@ -640,7 +640,7 @@
                                             )
                                             Mul
                                             (RealBinOp
-                                                (Var 234 array_b)
+                                                (Var 232 array_b)
                                                 Pow
                                                 (RealConstant
                                                     3.000000
@@ -668,7 +668,7 @@
                                         2 verify1d_mul
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 234 array_a)
+                                            (Var 232 array_a)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -680,7 +680,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 234 array_b)
+                                            (Var 232 array_b)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -692,7 +692,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 234 array_c)
+                                            (Var 232 array_c)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -715,11 +715,11 @@
                             elemental_sin:
                                 (Function
                                     (SymbolTable
-                                        235
+                                        233
                                         {
                                             array1d:
                                                 (Variable
-                                                    235
+                                                    233
                                                     array1d
                                                     []
                                                     Local
@@ -740,7 +740,7 @@
                                                 ),
                                             arraynd:
                                                 (Variable
-                                                    235
+                                                    233
                                                     arraynd
                                                     []
                                                     Local
@@ -765,7 +765,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    235
+                                                    233
                                                     i
                                                     []
                                                     Local
@@ -781,7 +781,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    235
+                                                    233
                                                     j
                                                     []
                                                     Local
@@ -797,7 +797,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    235
+                                                    233
                                                     k
                                                     []
                                                     Local
@@ -813,7 +813,7 @@
                                                 ),
                                             sin1d:
                                                 (Variable
-                                                    235
+                                                    233
                                                     sin1d
                                                     []
                                                     Local
@@ -834,7 +834,7 @@
                                                 ),
                                             sin@__lpython_overloaded_0__sin:
                                                 (ExternalSymbol
-                                                    235
+                                                    233
                                                     sin@__lpython_overloaded_0__sin
                                                     3 __lpython_overloaded_0__sin
                                                     numpy
@@ -844,7 +844,7 @@
                                                 ),
                                             sin@__lpython_overloaded_1__sin:
                                                 (ExternalSymbol
-                                                    235
+                                                    233
                                                     sin@__lpython_overloaded_1__sin
                                                     3 __lpython_overloaded_1__sin
                                                     numpy
@@ -854,7 +854,7 @@
                                                 ),
                                             sinnd:
                                                 (Variable
-                                                    235
+                                                    233
                                                     sinnd
                                                     []
                                                     Local
@@ -897,7 +897,7 @@
                                     verifynd]
                                     []
                                     [(Assignment
-                                        (Var 235 array1d)
+                                        (Var 233 array1d)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -912,7 +912,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 235 sin1d)
+                                        (Var 233 sin1d)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -928,7 +928,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 235 i)
+                                        ((Var 233 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -940,16 +940,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
                                             (ArrayItem
-                                                (Var 235 array1d)
+                                                (Var 233 array1d)
                                                 [(()
-                                                (Var 235 i)
+                                                (Var 233 i)
                                                 ())]
                                                 (Real 4)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 235 i)
+                                                (Var 233 i)
                                                 IntegerToReal
                                                 (Real 4)
                                                 ()
@@ -959,14 +959,14 @@
                                         []
                                     )
                                     (Assignment
-                                        (Var 235 sin1d)
+                                        (Var 233 sin1d)
                                         (FunctionCall
-                                            235 sin@__lpython_overloaded_1__sin
+                                            233 sin@__lpython_overloaded_1__sin
                                             2 sin
                                             [((FunctionCall
-                                                235 sin@__lpython_overloaded_1__sin
+                                                233 sin@__lpython_overloaded_1__sin
                                                 2 sin
-                                                [((Var 235 array1d))]
+                                                [((Var 233 array1d))]
                                                 (Array
                                                     (Real 4)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -991,7 +991,7 @@
                                         2 verify1d
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 235 array1d)
+                                            (Var 233 array1d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1003,7 +1003,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 235 sin1d)
+                                            (Var 233 sin1d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1018,7 +1018,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 235 arraynd)
+                                        (Var 233 arraynd)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1037,7 +1037,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 235 sinnd)
+                                        (Var 233 sinnd)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1057,7 +1057,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 235 i)
+                                        ((Var 233 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 200 (Integer 4))
@@ -1069,7 +1069,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 235 j)
+                                            ((Var 233 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 64 (Integer 4))
@@ -1081,7 +1081,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 235 k)
+                                                ((Var 233 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 16 (Integer 4))
@@ -1093,15 +1093,15 @@
                                                 (IntegerConstant 1 (Integer 4)))
                                                 [(Assignment
                                                     (ArrayItem
-                                                        (Var 235 arraynd)
+                                                        (Var 233 arraynd)
                                                         [(()
-                                                        (Var 235 i)
+                                                        (Var 233 i)
                                                         ())
                                                         (()
-                                                        (Var 235 j)
+                                                        (Var 233 j)
                                                         ())
                                                         (()
-                                                        (Var 235 k)
+                                                        (Var 233 k)
                                                         ())]
                                                         (Real 8)
                                                         RowMajor
@@ -1110,14 +1110,14 @@
                                                     (Cast
                                                         (IntegerBinOp
                                                             (IntegerBinOp
-                                                                (Var 235 i)
+                                                                (Var 233 i)
                                                                 Add
-                                                                (Var 235 j)
+                                                                (Var 233 j)
                                                                 (Integer 4)
                                                                 ()
                                                             )
                                                             Add
-                                                            (Var 235 k)
+                                                            (Var 233 k)
                                                             (Integer 4)
                                                             ()
                                                         )
@@ -1134,12 +1134,12 @@
                                         []
                                     )
                                     (Assignment
-                                        (Var 235 sinnd)
+                                        (Var 233 sinnd)
                                         (RealBinOp
                                             (FunctionCall
-                                                235 sin@__lpython_overloaded_0__sin
+                                                233 sin@__lpython_overloaded_0__sin
                                                 2 sin
-                                                [((Var 235 arraynd))]
+                                                [((Var 233 arraynd))]
                                                 (Array
                                                     (Real 8)
                                                     [((IntegerConstant 0 (Integer 4))
@@ -1176,7 +1176,7 @@
                                         2 verifynd
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 235 arraynd)
+                                            (Var 233 arraynd)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1192,7 +1192,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 235 sinnd)
+                                            (Var 233 sinnd)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1221,11 +1221,11 @@
                             elemental_sum:
                                 (Function
                                     (SymbolTable
-                                        233
+                                        231
                                         {
                                             array_a:
                                                 (Variable
-                                                    233
+                                                    231
                                                     array_a
                                                     []
                                                     Local
@@ -1246,7 +1246,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    233
+                                                    231
                                                     array_b
                                                     []
                                                     Local
@@ -1267,7 +1267,7 @@
                                                 ),
                                             array_c:
                                                 (Variable
-                                                    233
+                                                    231
                                                     array_c
                                                     []
                                                     Local
@@ -1288,7 +1288,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    233
+                                                    231
                                                     i
                                                     []
                                                     Local
@@ -1304,7 +1304,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    233
+                                                    231
                                                     j
                                                     []
                                                     Local
@@ -1320,7 +1320,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    233
+                                                    231
                                                     k
                                                     []
                                                     Local
@@ -1353,7 +1353,7 @@
                                     [verify1d_sum]
                                     []
                                     [(Assignment
-                                        (Var 233 array_a)
+                                        (Var 231 array_a)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1368,7 +1368,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 233 array_b)
+                                        (Var 231 array_b)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1383,7 +1383,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 233 array_c)
+                                        (Var 231 array_c)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1399,7 +1399,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 233 i)
+                                        ((Var 231 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -1411,16 +1411,16 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
                                             (ArrayItem
-                                                (Var 233 array_a)
+                                                (Var 231 array_a)
                                                 [(()
-                                                (Var 233 i)
+                                                (Var 231 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (Cast
-                                                (Var 233 i)
+                                                (Var 231 i)
                                                 IntegerToReal
                                                 (Real 8)
                                                 ()
@@ -1431,7 +1431,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 233 j)
+                                        ((Var 231 j)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 100 (Integer 4))
@@ -1443,9 +1443,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
                                             (ArrayItem
-                                                (Var 233 array_b)
+                                                (Var 231 array_b)
                                                 [(()
-                                                (Var 233 j)
+                                                (Var 231 j)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -1453,7 +1453,7 @@
                                             )
                                             (Cast
                                                 (IntegerBinOp
-                                                    (Var 233 j)
+                                                    (Var 231 j)
                                                     Add
                                                     (IntegerConstant 5 (Integer 4))
                                                     (Integer 4)
@@ -1468,10 +1468,10 @@
                                         []
                                     )
                                     (Assignment
-                                        (Var 233 array_c)
+                                        (Var 231 array_c)
                                         (RealBinOp
                                             (RealBinOp
-                                                (Var 233 array_a)
+                                                (Var 231 array_a)
                                                 Pow
                                                 (RealConstant
                                                     2.000000
@@ -1493,7 +1493,7 @@
                                                 )
                                                 Mul
                                                 (RealBinOp
-                                                    (Var 233 array_b)
+                                                    (Var 231 array_b)
                                                     Pow
                                                     (RealConstant
                                                         3.000000
@@ -1529,7 +1529,7 @@
                                         2 verify1d_sum
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 233 array_a)
+                                            (Var 231 array_a)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1541,7 +1541,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 233 array_b)
+                                            (Var 231 array_b)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1553,7 +1553,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 233 array_c)
+                                            (Var 231 array_c)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1576,11 +1576,11 @@
                             elemental_trig_identity:
                                 (Function
                                     (SymbolTable
-                                        237
+                                        235
                                         {
                                             arraynd:
                                                 (Variable
-                                                    237
+                                                    235
                                                     arraynd
                                                     []
                                                     Local
@@ -1607,7 +1607,7 @@
                                                 ),
                                             cos@__lpython_overloaded_1__cos:
                                                 (ExternalSymbol
-                                                    237
+                                                    235
                                                     cos@__lpython_overloaded_1__cos
                                                     3 __lpython_overloaded_1__cos
                                                     numpy
@@ -1617,7 +1617,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    237
+                                                    235
                                                     eps
                                                     []
                                                     Local
@@ -1633,7 +1633,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    237
+                                                    235
                                                     i
                                                     []
                                                     Local
@@ -1649,7 +1649,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    237
+                                                    235
                                                     j
                                                     []
                                                     Local
@@ -1665,7 +1665,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    237
+                                                    235
                                                     k
                                                     []
                                                     Local
@@ -1681,7 +1681,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    237
+                                                    235
                                                     l
                                                     []
                                                     Local
@@ -1697,7 +1697,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    237
+                                                    235
                                                     newshape
                                                     []
                                                     Local
@@ -1718,7 +1718,7 @@
                                                 ),
                                             observed:
                                                 (Variable
-                                                    237
+                                                    235
                                                     observed
                                                     []
                                                     Local
@@ -1745,7 +1745,7 @@
                                                 ),
                                             observed1d:
                                                 (Variable
-                                                    237
+                                                    235
                                                     observed1d
                                                     []
                                                     Local
@@ -1766,7 +1766,7 @@
                                                 ),
                                             sin@__lpython_overloaded_1__sin:
                                                 (ExternalSymbol
-                                                    237
+                                                    235
                                                     sin@__lpython_overloaded_1__sin
                                                     3 __lpython_overloaded_1__sin
                                                     numpy
@@ -1793,7 +1793,7 @@
                                     []
                                     []
                                     [(Assignment
-                                        (Var 237 eps)
+                                        (Var 235 eps)
                                         (Cast
                                             (RealConstant
                                                 0.000001
@@ -1809,7 +1809,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 237 arraynd)
+                                        (Var 235 arraynd)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1830,7 +1830,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 237 observed)
+                                        (Var 235 observed)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1851,7 +1851,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 237 observed1d)
+                                        (Var 235 observed1d)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1867,7 +1867,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 237 i)
+                                        ((Var 235 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 64 (Integer 4))
@@ -1879,7 +1879,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 237 j)
+                                            ((Var 235 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 32 (Integer 4))
@@ -1891,7 +1891,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 237 k)
+                                                ((Var 235 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 8 (Integer 4))
@@ -1903,7 +1903,7 @@
                                                 (IntegerConstant 1 (Integer 4)))
                                                 [(DoLoop
                                                     ()
-                                                    ((Var 237 l)
+                                                    ((Var 235 l)
                                                     (IntegerConstant 0 (Integer 4))
                                                     (IntegerBinOp
                                                         (IntegerConstant 4 (Integer 4))
@@ -1915,18 +1915,18 @@
                                                     (IntegerConstant 1 (Integer 4)))
                                                     [(Assignment
                                                         (ArrayItem
-                                                            (Var 237 arraynd)
+                                                            (Var 235 arraynd)
                                                             [(()
-                                                            (Var 237 i)
+                                                            (Var 235 i)
                                                             ())
                                                             (()
-                                                            (Var 237 j)
+                                                            (Var 235 j)
                                                             ())
                                                             (()
-                                                            (Var 237 k)
+                                                            (Var 235 k)
                                                             ())
                                                             (()
-                                                            (Var 237 l)
+                                                            (Var 235 l)
                                                             ())]
                                                             (Real 4)
                                                             RowMajor
@@ -1936,19 +1936,19 @@
                                                             (IntegerBinOp
                                                                 (IntegerBinOp
                                                                     (IntegerBinOp
-                                                                        (Var 237 i)
+                                                                        (Var 235 i)
                                                                         Add
-                                                                        (Var 237 j)
+                                                                        (Var 235 j)
                                                                         (Integer 4)
                                                                         ()
                                                                     )
                                                                     Add
-                                                                    (Var 237 k)
+                                                                    (Var 235 k)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
                                                                 Add
-                                                                (Var 237 l)
+                                                                (Var 235 l)
                                                                 (Integer 4)
                                                                 ()
                                                             )
@@ -1967,13 +1967,13 @@
                                         []
                                     )
                                     (Assignment
-                                        (Var 237 observed)
+                                        (Var 235 observed)
                                         (RealBinOp
                                             (RealBinOp
                                                 (FunctionCall
-                                                    237 sin@__lpython_overloaded_1__sin
+                                                    235 sin@__lpython_overloaded_1__sin
                                                     2 sin
-                                                    [((Var 237 arraynd))]
+                                                    [((Var 235 arraynd))]
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
@@ -2016,9 +2016,9 @@
                                             Add
                                             (RealBinOp
                                                 (FunctionCall
-                                                    237 cos@__lpython_overloaded_1__cos
+                                                    235 cos@__lpython_overloaded_1__cos
                                                     2 cos
-                                                    [((Var 237 arraynd))]
+                                                    [((Var 235 arraynd))]
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
@@ -2075,7 +2075,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 237 newshape)
+                                        (Var 235 newshape)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -2091,7 +2091,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 237 newshape)
+                                            (Var 235 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -2103,11 +2103,11 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 237 observed1d)
+                                        (Var 235 observed1d)
                                         (ArrayReshape
-                                            (Var 237 observed)
+                                            (Var 235 observed)
                                             (ArrayPhysicalCast
-                                                (Var 237 newshape)
+                                                (Var 235 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -2130,7 +2130,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 237 i)
+                                        ((Var 235 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 65536 (Integer 4))
@@ -2146,9 +2146,9 @@
                                                     Abs
                                                     [(RealBinOp
                                                         (ArrayItem
-                                                            (Var 237 observed1d)
+                                                            (Var 235 observed1d)
                                                             [(()
-                                                            (Var 237 i)
+                                                            (Var 235 i)
                                                             ())]
                                                             (Real 4)
                                                             RowMajor
@@ -2175,7 +2175,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 237 eps)
+                                                (Var 235 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2202,11 +2202,11 @@
                             verify1d:
                                 (Function
                                     (SymbolTable
-                                        228
+                                        226
                                         {
                                             array:
                                                 (Variable
-                                                    228
+                                                    226
                                                     array
                                                     []
                                                     InOut
@@ -2228,11 +2228,11 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        238
+                                                        236
                                                         {
                                                             sin@__lpython_overloaded_1__sin:
                                                                 (ExternalSymbol
-                                                                    238
+                                                                    236
                                                                     sin@__lpython_overloaded_1__sin
                                                                     3 __lpython_overloaded_1__sin
                                                                     numpy
@@ -2248,15 +2248,15 @@
                                                                 Abs
                                                                 [(RealBinOp
                                                                     (FunctionCall
-                                                                        238 sin@__lpython_overloaded_1__sin
+                                                                        236 sin@__lpython_overloaded_1__sin
                                                                         2 sin
                                                                         [((FunctionCall
-                                                                            238 sin@__lpython_overloaded_1__sin
+                                                                            236 sin@__lpython_overloaded_1__sin
                                                                             2 sin
                                                                             [((ArrayItem
-                                                                                (Var 228 array)
+                                                                                (Var 226 array)
                                                                                 [(()
-                                                                                (Var 228 i)
+                                                                                (Var 226 i)
                                                                                 ())]
                                                                                 (Real 4)
                                                                                 RowMajor
@@ -2272,9 +2272,9 @@
                                                                     )
                                                                     Sub
                                                                     (ArrayItem
-                                                                        (Var 228 result)
+                                                                        (Var 226 result)
                                                                         [(()
-                                                                        (Var 228 i)
+                                                                        (Var 226 i)
                                                                         ())]
                                                                         (Real 4)
                                                                         RowMajor
@@ -2288,7 +2288,7 @@
                                                                 ()
                                                             )
                                                             LtE
-                                                            (Var 228 eps)
+                                                            (Var 226 eps)
                                                             (Logical 4)
                                                             ()
                                                         )
@@ -2297,7 +2297,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    228
+                                                    226
                                                     eps
                                                     []
                                                     Local
@@ -2313,7 +2313,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    228
+                                                    226
                                                     i
                                                     []
                                                     Local
@@ -2329,7 +2329,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    228
+                                                    226
                                                     result
                                                     []
                                                     InOut
@@ -2350,7 +2350,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    228
+                                                    226
                                                     size
                                                     []
                                                     In
@@ -2393,11 +2393,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 228 array)
-                                    (Var 228 result)
-                                    (Var 228 size)]
+                                    [(Var 226 array)
+                                    (Var 226 result)
+                                    (Var 226 size)]
                                     [(Assignment
-                                        (Var 228 eps)
+                                        (Var 226 eps)
                                         (Cast
                                             (RealConstant
                                                 0.000001
@@ -2414,10 +2414,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 228 i)
+                                        ((Var 226 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 228 size)
+                                            (Var 226 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2426,7 +2426,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            228 block
+                                            226 block
                                         )]
                                         []
                                     )]
@@ -2439,11 +2439,11 @@
                             verify1d_mul:
                                 (Function
                                     (SymbolTable
-                                        232
+                                        230
                                         {
                                             array_a:
                                                 (Variable
-                                                    232
+                                                    230
                                                     array_a
                                                     []
                                                     InOut
@@ -2464,7 +2464,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    232
+                                                    230
                                                     array_b
                                                     []
                                                     InOut
@@ -2485,7 +2485,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    232
+                                                    230
                                                     eps
                                                     []
                                                     Local
@@ -2501,7 +2501,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    232
+                                                    230
                                                     i
                                                     []
                                                     Local
@@ -2517,7 +2517,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    232
+                                                    230
                                                     result
                                                     []
                                                     InOut
@@ -2538,7 +2538,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    232
+                                                    230
                                                     size
                                                     []
                                                     In
@@ -2587,12 +2587,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 232 array_a)
-                                    (Var 232 array_b)
-                                    (Var 232 result)
-                                    (Var 232 size)]
+                                    [(Var 230 array_a)
+                                    (Var 230 array_b)
+                                    (Var 230 result)
+                                    (Var 230 size)]
                                     [(Assignment
-                                        (Var 232 eps)
+                                        (Var 230 eps)
                                         (RealConstant
                                             0.000010
                                             (Real 8)
@@ -2601,10 +2601,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 232 i)
+                                        ((Var 230 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 232 size)
+                                            (Var 230 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2620,9 +2620,9 @@
                                                             (RealBinOp
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 232 array_a)
+                                                                        (Var 230 array_a)
                                                                         [(()
-                                                                        (Var 232 i)
+                                                                        (Var 230 i)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -2647,9 +2647,9 @@
                                                             Mul
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 232 array_b)
+                                                                    (Var 230 array_b)
                                                                     [(()
-                                                                    (Var 232 i)
+                                                                    (Var 230 i)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -2668,9 +2668,9 @@
                                                         )
                                                         Sub
                                                         (ArrayItem
-                                                            (Var 232 result)
+                                                            (Var 230 result)
                                                             [(()
-                                                            (Var 232 i)
+                                                            (Var 230 i)
                                                             ())]
                                                             (Real 8)
                                                             RowMajor
@@ -2684,7 +2684,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 232 eps)
+                                                (Var 230 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2701,11 +2701,11 @@
                             verify1d_sum:
                                 (Function
                                     (SymbolTable
-                                        231
+                                        229
                                         {
                                             array_a:
                                                 (Variable
-                                                    231
+                                                    229
                                                     array_a
                                                     []
                                                     InOut
@@ -2726,7 +2726,7 @@
                                                 ),
                                             array_b:
                                                 (Variable
-                                                    231
+                                                    229
                                                     array_b
                                                     []
                                                     InOut
@@ -2747,7 +2747,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    231
+                                                    229
                                                     eps
                                                     []
                                                     Local
@@ -2763,7 +2763,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    231
+                                                    229
                                                     i
                                                     []
                                                     Local
@@ -2779,7 +2779,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    231
+                                                    229
                                                     result
                                                     []
                                                     InOut
@@ -2800,7 +2800,7 @@
                                                 ),
                                             size:
                                                 (Variable
-                                                    231
+                                                    229
                                                     size
                                                     []
                                                     In
@@ -2849,12 +2849,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 231 array_a)
-                                    (Var 231 array_b)
-                                    (Var 231 result)
-                                    (Var 231 size)]
+                                    [(Var 229 array_a)
+                                    (Var 229 array_b)
+                                    (Var 229 result)
+                                    (Var 229 size)]
                                     [(Assignment
-                                        (Var 231 eps)
+                                        (Var 229 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -2863,10 +2863,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 231 i)
+                                        ((Var 229 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 231 size)
+                                            (Var 229 size)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -2881,9 +2881,9 @@
                                                         (RealBinOp
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 231 array_a)
+                                                                    (Var 229 array_a)
                                                                     [(()
-                                                                    (Var 231 i)
+                                                                    (Var 229 i)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -2906,9 +2906,9 @@
                                                                 Mul
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 231 array_b)
+                                                                        (Var 229 array_b)
                                                                         [(()
-                                                                        (Var 231 i)
+                                                                        (Var 229 i)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -2930,9 +2930,9 @@
                                                         )
                                                         Sub
                                                         (ArrayItem
-                                                            (Var 231 result)
+                                                            (Var 229 result)
                                                             [(()
-                                                            (Var 231 i)
+                                                            (Var 229 i)
                                                             ())]
                                                             (Real 8)
                                                             RowMajor
@@ -2946,7 +2946,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 231 eps)
+                                                (Var 229 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -2963,11 +2963,11 @@
                             verify2d:
                                 (Function
                                     (SymbolTable
-                                        230
+                                        228
                                         {
                                             array:
                                                 (Variable
-                                                    230
+                                                    228
                                                     array
                                                     []
                                                     InOut
@@ -2991,16 +2991,16 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        242
+                                                        240
                                                         {
                                                             block:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        243
+                                                                        241
                                                                         {
                                                                             cos@__lpython_overloaded_0__cos:
                                                                                 (ExternalSymbol
-                                                                                    243
+                                                                                    241
                                                                                     cos@__lpython_overloaded_0__cos
                                                                                     3 __lpython_overloaded_0__cos
                                                                                     numpy
@@ -3017,15 +3017,15 @@
                                                                                 [(RealBinOp
                                                                                     (RealBinOp
                                                                                         (FunctionCall
-                                                                                            243 cos@__lpython_overloaded_0__cos
+                                                                                            241 cos@__lpython_overloaded_0__cos
                                                                                             2 cos
                                                                                             [((ArrayItem
-                                                                                                (Var 230 array)
+                                                                                                (Var 228 array)
                                                                                                 [(()
-                                                                                                (Var 230 i)
+                                                                                                (Var 228 i)
                                                                                                 ())
                                                                                                 (()
-                                                                                                (Var 230 j)
+                                                                                                (Var 228 j)
                                                                                                 ())]
                                                                                                 (Real 8)
                                                                                                 RowMajor
@@ -3045,12 +3045,12 @@
                                                                                     )
                                                                                     Sub
                                                                                     (ArrayItem
-                                                                                        (Var 230 result)
+                                                                                        (Var 228 result)
                                                                                         [(()
-                                                                                        (Var 230 i)
+                                                                                        (Var 228 i)
                                                                                         ())
                                                                                         (()
-                                                                                        (Var 230 j)
+                                                                                        (Var 228 j)
                                                                                         ())]
                                                                                         (Real 8)
                                                                                         RowMajor
@@ -3064,7 +3064,7 @@
                                                                                 ()
                                                                             )
                                                                             LtE
-                                                                            (Var 230 eps)
+                                                                            (Var 228 eps)
                                                                             (Logical 4)
                                                                             ()
                                                                         )
@@ -3075,10 +3075,10 @@
                                                     block
                                                     [(DoLoop
                                                         ()
-                                                        ((Var 230 j)
+                                                        ((Var 228 j)
                                                         (IntegerConstant 0 (Integer 4))
                                                         (IntegerBinOp
-                                                            (Var 230 size2)
+                                                            (Var 228 size2)
                                                             Sub
                                                             (IntegerConstant 1 (Integer 4))
                                                             (Integer 4)
@@ -3087,14 +3087,14 @@
                                                         (IntegerConstant 1 (Integer 4)))
                                                         [(BlockCall
                                                             -1
-                                                            242 block
+                                                            240 block
                                                         )]
                                                         []
                                                     )]
                                                 ),
                                             eps:
                                                 (Variable
-                                                    230
+                                                    228
                                                     eps
                                                     []
                                                     Local
@@ -3110,7 +3110,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    230
+                                                    228
                                                     i
                                                     []
                                                     Local
@@ -3126,7 +3126,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    230
+                                                    228
                                                     j
                                                     []
                                                     Local
@@ -3142,7 +3142,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    230
+                                                    228
                                                     result
                                                     []
                                                     InOut
@@ -3165,7 +3165,7 @@
                                                 ),
                                             size1:
                                                 (Variable
-                                                    230
+                                                    228
                                                     size1
                                                     []
                                                     In
@@ -3181,7 +3181,7 @@
                                                 ),
                                             size2:
                                                 (Variable
-                                                    230
+                                                    228
                                                     size2
                                                     []
                                                     In
@@ -3229,12 +3229,12 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 230 array)
-                                    (Var 230 result)
-                                    (Var 230 size1)
-                                    (Var 230 size2)]
+                                    [(Var 228 array)
+                                    (Var 228 result)
+                                    (Var 228 size1)
+                                    (Var 228 size2)]
                                     [(Assignment
-                                        (Var 230 eps)
+                                        (Var 228 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -3243,10 +3243,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 230 i)
+                                        ((Var 228 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 230 size1)
+                                            (Var 228 size1)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -3255,7 +3255,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            230 block
+                                            228 block
                                         )]
                                         []
                                     )]
@@ -3268,11 +3268,11 @@
                             verifynd:
                                 (Function
                                     (SymbolTable
-                                        229
+                                        227
                                         {
                                             array:
                                                 (Variable
-                                                    229
+                                                    227
                                                     array
                                                     []
                                                     InOut
@@ -3298,21 +3298,21 @@
                                             block:
                                                 (Block
                                                     (SymbolTable
-                                                        239
+                                                        237
                                                         {
                                                             block:
                                                                 (Block
                                                                     (SymbolTable
-                                                                        240
+                                                                        238
                                                                         {
                                                                             block:
                                                                                 (Block
                                                                                     (SymbolTable
-                                                                                        241
+                                                                                        239
                                                                                         {
                                                                                             sin@__lpython_overloaded_0__sin:
                                                                                                 (ExternalSymbol
-                                                                                                    241
+                                                                                                    239
                                                                                                     sin@__lpython_overloaded_0__sin
                                                                                                     3 __lpython_overloaded_0__sin
                                                                                                     numpy
@@ -3329,18 +3329,18 @@
                                                                                                 [(RealBinOp
                                                                                                     (RealBinOp
                                                                                                         (FunctionCall
-                                                                                                            241 sin@__lpython_overloaded_0__sin
+                                                                                                            239 sin@__lpython_overloaded_0__sin
                                                                                                             2 sin
                                                                                                             [((ArrayItem
-                                                                                                                (Var 229 array)
+                                                                                                                (Var 227 array)
                                                                                                                 [(()
-                                                                                                                (Var 229 i)
+                                                                                                                (Var 227 i)
                                                                                                                 ())
                                                                                                                 (()
-                                                                                                                (Var 229 j)
+                                                                                                                (Var 227 j)
                                                                                                                 ())
                                                                                                                 (()
-                                                                                                                (Var 229 k)
+                                                                                                                (Var 227 k)
                                                                                                                 ())]
                                                                                                                 (Real 8)
                                                                                                                 RowMajor
@@ -3360,15 +3360,15 @@
                                                                                                     )
                                                                                                     Sub
                                                                                                     (ArrayItem
-                                                                                                        (Var 229 result)
+                                                                                                        (Var 227 result)
                                                                                                         [(()
-                                                                                                        (Var 229 i)
+                                                                                                        (Var 227 i)
                                                                                                         ())
                                                                                                         (()
-                                                                                                        (Var 229 j)
+                                                                                                        (Var 227 j)
                                                                                                         ())
                                                                                                         (()
-                                                                                                        (Var 229 k)
+                                                                                                        (Var 227 k)
                                                                                                         ())]
                                                                                                         (Real 8)
                                                                                                         RowMajor
@@ -3382,7 +3382,7 @@
                                                                                                 ()
                                                                                             )
                                                                                             LtE
-                                                                                            (Var 229 eps)
+                                                                                            (Var 227 eps)
                                                                                             (Logical 4)
                                                                                             ()
                                                                                         )
@@ -3393,10 +3393,10 @@
                                                                     block
                                                                     [(DoLoop
                                                                         ()
-                                                                        ((Var 229 k)
+                                                                        ((Var 227 k)
                                                                         (IntegerConstant 0 (Integer 4))
                                                                         (IntegerBinOp
-                                                                            (Var 229 size3)
+                                                                            (Var 227 size3)
                                                                             Sub
                                                                             (IntegerConstant 1 (Integer 4))
                                                                             (Integer 4)
@@ -3405,7 +3405,7 @@
                                                                         (IntegerConstant 1 (Integer 4)))
                                                                         [(BlockCall
                                                                             -1
-                                                                            240 block
+                                                                            238 block
                                                                         )]
                                                                         []
                                                                     )]
@@ -3414,10 +3414,10 @@
                                                     block
                                                     [(DoLoop
                                                         ()
-                                                        ((Var 229 j)
+                                                        ((Var 227 j)
                                                         (IntegerConstant 0 (Integer 4))
                                                         (IntegerBinOp
-                                                            (Var 229 size2)
+                                                            (Var 227 size2)
                                                             Sub
                                                             (IntegerConstant 1 (Integer 4))
                                                             (Integer 4)
@@ -3426,14 +3426,14 @@
                                                         (IntegerConstant 1 (Integer 4)))
                                                         [(BlockCall
                                                             -1
-                                                            239 block
+                                                            237 block
                                                         )]
                                                         []
                                                     )]
                                                 ),
                                             eps:
                                                 (Variable
-                                                    229
+                                                    227
                                                     eps
                                                     []
                                                     Local
@@ -3449,7 +3449,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    229
+                                                    227
                                                     i
                                                     []
                                                     Local
@@ -3465,7 +3465,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    229
+                                                    227
                                                     j
                                                     []
                                                     Local
@@ -3481,7 +3481,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    229
+                                                    227
                                                     k
                                                     []
                                                     Local
@@ -3497,7 +3497,7 @@
                                                 ),
                                             result:
                                                 (Variable
-                                                    229
+                                                    227
                                                     result
                                                     []
                                                     InOut
@@ -3522,7 +3522,7 @@
                                                 ),
                                             size1:
                                                 (Variable
-                                                    229
+                                                    227
                                                     size1
                                                     []
                                                     In
@@ -3538,7 +3538,7 @@
                                                 ),
                                             size2:
                                                 (Variable
-                                                    229
+                                                    227
                                                     size2
                                                     []
                                                     In
@@ -3554,7 +3554,7 @@
                                                 ),
                                             size3:
                                                 (Variable
-                                                    229
+                                                    227
                                                     size3
                                                     []
                                                     In
@@ -3607,13 +3607,13 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 229 array)
-                                    (Var 229 result)
-                                    (Var 229 size1)
-                                    (Var 229 size2)
-                                    (Var 229 size3)]
+                                    [(Var 227 array)
+                                    (Var 227 result)
+                                    (Var 227 size1)
+                                    (Var 227 size2)
+                                    (Var 227 size3)]
                                     [(Assignment
-                                        (Var 229 eps)
+                                        (Var 227 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -3622,10 +3622,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 229 i)
+                                        ((Var 227 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 229 size1)
+                                            (Var 227 size1)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -3634,7 +3634,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(BlockCall
                                             -1
-                                            229 block
+                                            227 block
                                         )]
                                         []
                                     )]
@@ -3655,11 +3655,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        262
+                        260
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    262
+                                    260
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -3671,7 +3671,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        262 __main__global_stmts
+                        260 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-expr10-efcbb1b.json
+++ b/tests/reference/asr-expr10-efcbb1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr10-efcbb1b.stdout",
-    "stdout_hash": "1fa024bb6881c7f2a9cd895a721de512777b583702f8de577a62a1c4",
+    "stdout_hash": "06b4189354d9ecb74c8561f7e7151f6a8c2b8ee9c69174e4e00d9397",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr10-efcbb1b.stdout
+++ b/tests/reference/asr-expr10-efcbb1b.stdout
@@ -440,7 +440,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        144
+                        142
                         {
                             
                         })

--- a/tests/reference/asr-expr13-81bdb5a.json
+++ b/tests/reference/asr-expr13-81bdb5a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr13-81bdb5a.stdout",
-    "stdout_hash": "4a1ca725371af5d28570e13a6a74e10d4998c18d01dbce03f9518034",
+    "stdout_hash": "2fa20279a25ddffb86a8d5ba2a732cf268dc6ee8efd04afd1b892b22",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr13-81bdb5a.stdout
+++ b/tests/reference/asr-expr13-81bdb5a.stdout
@@ -459,7 +459,7 @@
             main_program:
                 (Program
                     (SymbolTable
-                        144
+                        142
                         {
                             
                         })

--- a/tests/reference/asr-expr7-480ba2f.json
+++ b/tests/reference/asr-expr7-480ba2f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr7-480ba2f.stdout",
-    "stdout_hash": "53cee9828734c67e8e5f67fd20774b45de191ad50be7867cd1fb1d7f",
+    "stdout_hash": "56263c3c6c97259a07ece41de4b0ec499f944c6747b5426738e4ac23",
     "stderr": "asr-expr7-480ba2f.stderr",
     "stderr_hash": "6e9790ac88db1a9ead8f64a91ba8a6605de67167037908a74b77be0c",
     "returncode": 0

--- a/tests/reference/asr-expr7-480ba2f.stdout
+++ b/tests/reference/asr-expr7-480ba2f.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        146
+                                        144
                                         {
                                             
                                         })
@@ -344,11 +344,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        147
+                        145
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    147
+                                    145
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -360,7 +360,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        147 __main__global_stmts
+                        145 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-expr_05-3a37324.json
+++ b/tests/reference/asr-expr_05-3a37324.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-expr_05-3a37324.stdout",
-    "stdout_hash": "8d7c373fed48f50b1029b8e091d6ca356bc32fadc92ac016207ea166",
+    "stdout_hash": "acd60d3dea381ff7dfcc7007b224abd1fdc9ad97ccb5f2b5feeca1bd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-expr_05-3a37324.stdout
+++ b/tests/reference/asr-expr_05-3a37324.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        146
+                                        144
                                         {
                                             
                                         })
@@ -1612,11 +1612,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        147
+                        145
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    147
+                                    145
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1628,7 +1628,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        147 __main__global_stmts
+                        145 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_01-682b1b2.json
+++ b/tests/reference/asr-generics_array_01-682b1b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_01-682b1b2.stdout",
-    "stdout_hash": "d301b9bde362c7fc59f41fee850d05e676e579f591cabcabbc4b3782",
+    "stdout_hash": "1c24474ff74d53b4b6cfa3e3aabdc474896c1aa4bd9d7f8bf543599e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_01-682b1b2.stdout
+++ b/tests/reference/asr-generics_array_01-682b1b2.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_f_0:
                                 (Function
                                     (SymbolTable
-                                        230
+                                        228
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    230
+                                                    228
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -48,7 +48,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    230
+                                                    228
                                                     i
                                                     []
                                                     In
@@ -64,7 +64,7 @@
                                                 ),
                                             lst:
                                                 (Variable
-                                                    230
+                                                    228
                                                     lst
                                                     []
                                                     InOut
@@ -106,11 +106,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 230 lst)
-                                    (Var 230 i)]
+                                    [(Var 228 lst)
+                                    (Var 228 i)]
                                     [(Assignment
                                         (ArrayItem
-                                            (Var 230 lst)
+                                            (Var 228 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -118,13 +118,13 @@
                                             RowMajor
                                             ()
                                         )
-                                        (Var 230 i)
+                                        (Var 228 i)
                                         ()
                                     )
                                     (Assignment
-                                        (Var 230 _lpython_return_variable)
+                                        (Var 228 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 230 lst)
+                                            (Var 228 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -135,7 +135,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 230 _lpython_return_variable)
+                                    (Var 228 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -144,7 +144,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        231
+                                        229
                                         {
                                             
                                         })
@@ -180,11 +180,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        228
+                                        226
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    228
+                                                    226
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -202,7 +202,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    228
+                                                    226
                                                     i
                                                     []
                                                     In
@@ -220,7 +220,7 @@
                                                 ),
                                             lst:
                                                 (Variable
-                                                    228
+                                                    226
                                                     lst
                                                     []
                                                     InOut
@@ -270,11 +270,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 228 lst)
-                                    (Var 228 i)]
+                                    [(Var 226 lst)
+                                    (Var 226 i)]
                                     [(Assignment
                                         (ArrayItem
-                                            (Var 228 lst)
+                                            (Var 226 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -284,13 +284,13 @@
                                             RowMajor
                                             ()
                                         )
-                                        (Var 228 i)
+                                        (Var 226 i)
                                         ()
                                     )
                                     (Assignment
-                                        (Var 228 _lpython_return_variable)
+                                        (Var 226 _lpython_return_variable)
                                         (ArrayItem
-                                            (Var 228 lst)
+                                            (Var 226 lst)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -303,7 +303,7 @@
                                         ()
                                     )
                                     (Return)]
-                                    (Var 228 _lpython_return_variable)
+                                    (Var 226 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -312,11 +312,11 @@
                             use_array:
                                 (Function
                                     (SymbolTable
-                                        229
+                                        227
                                         {
                                             array:
                                                 (Variable
-                                                    229
+                                                    227
                                                     array
                                                     []
                                                     Local
@@ -337,7 +337,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    229
+                                                    227
                                                     x
                                                     []
                                                     Local
@@ -370,7 +370,7 @@
                                     [__asr_generic_f_0]
                                     []
                                     [(Assignment
-                                        (Var 229 array)
+                                        (Var 227 array)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -385,7 +385,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 229 x)
+                                        (Var 227 x)
                                         (IntegerConstant 69 (Integer 4))
                                         ()
                                     )
@@ -394,7 +394,7 @@
                                             2 __asr_generic_f_0
                                             ()
                                             [((ArrayPhysicalCast
-                                                (Var 229 array)
+                                                (Var 227 array)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -405,7 +405,7 @@
                                                 )
                                                 ()
                                             ))
-                                            ((Var 229 x))]
+                                            ((Var 227 x))]
                                             (Integer 4)
                                             ()
                                             ()
@@ -430,11 +430,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        232
+                        230
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    232
+                                    230
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -446,7 +446,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        232 __main__global_stmts
+                        230 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_02-22c8dc1.json
+++ b/tests/reference/asr-generics_array_02-22c8dc1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_02-22c8dc1.stdout",
-    "stdout_hash": "5ea1e152fc2fc2b47c9d880804b7c59d8ab2a7b04ece527b605b2568",
+    "stdout_hash": "3a3f6459842f4b620e9bab0b81a6a4eb53835158b0a31f4325afab97",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_02-22c8dc1.stdout
+++ b/tests/reference/asr-generics_array_02-22c8dc1.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_g_0:
                                 (Function
                                     (SymbolTable
-                                        234
+                                        232
                                         {
                                             a:
                                                 (Variable
-                                                    234
+                                                    232
                                                     a
                                                     [n]
                                                     InOut
@@ -42,7 +42,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 234 n))]
+                                                        (Var 232 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -53,7 +53,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    234
+                                                    232
                                                     b
                                                     [n]
                                                     InOut
@@ -63,7 +63,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 234 n))]
+                                                        (Var 232 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -74,7 +74,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    234
+                                                    232
                                                     i
                                                     []
                                                     Local
@@ -90,7 +90,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    234
+                                                    232
                                                     n
                                                     []
                                                     In
@@ -106,7 +106,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    234
+                                                    232
                                                     r
                                                     [n]
                                                     Local
@@ -116,7 +116,7 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 234 n))]
+                                                        (Var 232 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -162,17 +162,17 @@
                                         .false.
                                     )
                                     [add_integer]
-                                    [(Var 234 n)
-                                    (Var 234 a)
-                                    (Var 234 b)]
+                                    [(Var 232 n)
+                                    (Var 232 a)
+                                    (Var 232 b)]
                                     [(Assignment
-                                        (Var 234 r)
+                                        (Var 232 r)
                                         (ArrayConstructor
                                             []
                                             (Array
                                                 (Integer 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 234 n))]
+                                                (Var 232 n))]
                                                 PointerToDataArray
                                             )
                                             ()
@@ -182,10 +182,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 234 i)
+                                        ((Var 232 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 234 n)
+                                            (Var 232 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -194,9 +194,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
                                             (ArrayItem
-                                                (Var 234 r)
+                                                (Var 232 r)
                                                 [(()
-                                                (Var 234 i)
+                                                (Var 232 i)
                                                 ())]
                                                 (Integer 4)
                                                 RowMajor
@@ -206,18 +206,18 @@
                                                 2 add_integer
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 234 a)
+                                                    (Var 232 a)
                                                     [(()
-                                                    (Var 234 i)
+                                                    (Var 232 i)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 234 b)
+                                                    (Var 232 b)
                                                     [(()
-                                                    (Var 234 i)
+                                                    (Var 232 i)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
@@ -233,7 +233,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 234 r)
+                                            (Var 232 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -253,11 +253,11 @@
                             __asr_generic_g_1:
                                 (Function
                                     (SymbolTable
-                                        235
+                                        233
                                         {
                                             a:
                                                 (Variable
-                                                    235
+                                                    233
                                                     a
                                                     [n]
                                                     InOut
@@ -267,7 +267,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 235 n))]
+                                                        (Var 233 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -278,7 +278,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    235
+                                                    233
                                                     b
                                                     [n]
                                                     InOut
@@ -288,7 +288,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 235 n))]
+                                                        (Var 233 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -299,7 +299,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    235
+                                                    233
                                                     i
                                                     []
                                                     Local
@@ -315,7 +315,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    235
+                                                    233
                                                     n
                                                     []
                                                     In
@@ -331,7 +331,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    235
+                                                    233
                                                     r
                                                     [n]
                                                     Local
@@ -341,7 +341,7 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 235 n))]
+                                                        (Var 233 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -387,17 +387,17 @@
                                         .false.
                                     )
                                     [add_float]
-                                    [(Var 235 n)
-                                    (Var 235 a)
-                                    (Var 235 b)]
+                                    [(Var 233 n)
+                                    (Var 233 a)
+                                    (Var 233 b)]
                                     [(Assignment
-                                        (Var 235 r)
+                                        (Var 233 r)
                                         (ArrayConstructor
                                             []
                                             (Array
                                                 (Real 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 235 n))]
+                                                (Var 233 n))]
                                                 PointerToDataArray
                                             )
                                             ()
@@ -407,10 +407,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 235 i)
+                                        ((Var 233 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 235 n)
+                                            (Var 233 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -419,9 +419,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
                                             (ArrayItem
-                                                (Var 235 r)
+                                                (Var 233 r)
                                                 [(()
-                                                (Var 235 i)
+                                                (Var 233 i)
                                                 ())]
                                                 (Real 4)
                                                 RowMajor
@@ -431,18 +431,18 @@
                                                 2 add_float
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 235 a)
+                                                    (Var 233 a)
                                                     [(()
-                                                    (Var 235 i)
+                                                    (Var 233 i)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 235 b)
+                                                    (Var 233 b)
                                                     [(()
-                                                    (Var 235 i)
+                                                    (Var 233 i)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
@@ -458,7 +458,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 235 r)
+                                            (Var 233 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -478,7 +478,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        236
+                                        234
                                         {
                                             
                                         })
@@ -514,11 +514,11 @@
                             add:
                                 (Function
                                     (SymbolTable
-                                        228
+                                        226
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    228
+                                                    226
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -536,7 +536,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    228
+                                                    226
                                                     x
                                                     []
                                                     In
@@ -554,7 +554,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    228
+                                                    226
                                                     y
                                                     []
                                                     In
@@ -594,10 +594,10 @@
                                         .true.
                                     )
                                     []
-                                    [(Var 228 x)
-                                    (Var 228 y)]
+                                    [(Var 226 x)
+                                    (Var 226 y)]
                                     []
-                                    (Var 228 _lpython_return_variable)
+                                    (Var 226 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -606,11 +606,11 @@
                             add_float:
                                 (Function
                                     (SymbolTable
-                                        230
+                                        228
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    230
+                                                    228
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -626,7 +626,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    230
+                                                    228
                                                     x
                                                     []
                                                     In
@@ -642,7 +642,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    230
+                                                    228
                                                     y
                                                     []
                                                     In
@@ -674,21 +674,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 230 x)
-                                    (Var 230 y)]
+                                    [(Var 228 x)
+                                    (Var 228 y)]
                                     [(Assignment
-                                        (Var 230 _lpython_return_variable)
+                                        (Var 228 _lpython_return_variable)
                                         (RealBinOp
-                                            (Var 230 x)
+                                            (Var 228 x)
                                             Add
-                                            (Var 230 y)
+                                            (Var 228 y)
                                             (Real 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 230 _lpython_return_variable)
+                                    (Var 228 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -697,11 +697,11 @@
                             add_integer:
                                 (Function
                                     (SymbolTable
-                                        229
+                                        227
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    229
+                                                    227
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -717,7 +717,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    229
+                                                    227
                                                     x
                                                     []
                                                     In
@@ -733,7 +733,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    229
+                                                    227
                                                     y
                                                     []
                                                     In
@@ -765,21 +765,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 229 x)
-                                    (Var 229 y)]
+                                    [(Var 227 x)
+                                    (Var 227 y)]
                                     [(Assignment
-                                        (Var 229 _lpython_return_variable)
+                                        (Var 227 _lpython_return_variable)
                                         (IntegerBinOp
-                                            (Var 229 x)
+                                            (Var 227 x)
                                             Add
-                                            (Var 229 y)
+                                            (Var 227 y)
                                             (Integer 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 229 _lpython_return_variable)
+                                    (Var 227 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -788,11 +788,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        231
+                                        229
                                         {
                                             a:
                                                 (Variable
-                                                    231
+                                                    229
                                                     a
                                                     [n]
                                                     InOut
@@ -804,7 +804,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 231 n))]
+                                                        (Var 229 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -815,7 +815,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    231
+                                                    229
                                                     b
                                                     [n]
                                                     InOut
@@ -827,7 +827,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 231 n))]
+                                                        (Var 229 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -838,7 +838,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    231
+                                                    229
                                                     i
                                                     []
                                                     Local
@@ -854,7 +854,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    231
+                                                    229
                                                     n
                                                     []
                                                     In
@@ -870,7 +870,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    231
+                                                    229
                                                     r
                                                     [n]
                                                     Local
@@ -882,7 +882,7 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 231 n))]
+                                                        (Var 229 n))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -932,11 +932,11 @@
                                         .false.
                                     )
                                     [add]
-                                    [(Var 231 n)
-                                    (Var 231 a)
-                                    (Var 231 b)]
+                                    [(Var 229 n)
+                                    (Var 229 a)
+                                    (Var 229 b)]
                                     [(Assignment
-                                        (Var 231 r)
+                                        (Var 229 r)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -944,7 +944,7 @@
                                                     T
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 231 n))]
+                                                (Var 229 n))]
                                                 PointerToDataArray
                                             )
                                             ()
@@ -954,10 +954,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 231 i)
+                                        ((Var 229 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 231 n)
+                                            (Var 229 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -966,9 +966,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
                                             (ArrayItem
-                                                (Var 231 r)
+                                                (Var 229 r)
                                                 [(()
-                                                (Var 231 i)
+                                                (Var 229 i)
                                                 ())]
                                                 (TypeParameter
                                                     T
@@ -980,9 +980,9 @@
                                                 2 add
                                                 ()
                                                 [((ArrayItem
-                                                    (Var 231 a)
+                                                    (Var 229 a)
                                                     [(()
-                                                    (Var 231 i)
+                                                    (Var 229 i)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -991,9 +991,9 @@
                                                     ()
                                                 ))
                                                 ((ArrayItem
-                                                    (Var 231 b)
+                                                    (Var 229 b)
                                                     [(()
-                                                    (Var 231 i)
+                                                    (Var 229 i)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -1013,7 +1013,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 231 r)
+                                            (Var 229 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1035,11 +1035,11 @@
                             main:
                                 (Function
                                     (SymbolTable
-                                        232
+                                        230
                                         {
                                             a_float:
                                                 (Variable
-                                                    232
+                                                    230
                                                     a_float
                                                     []
                                                     Local
@@ -1060,7 +1060,7 @@
                                                 ),
                                             a_int:
                                                 (Variable
-                                                    232
+                                                    230
                                                     a_int
                                                     []
                                                     Local
@@ -1081,7 +1081,7 @@
                                                 ),
                                             b_float:
                                                 (Variable
-                                                    232
+                                                    230
                                                     b_float
                                                     []
                                                     Local
@@ -1102,7 +1102,7 @@
                                                 ),
                                             b_int:
                                                 (Variable
-                                                    232
+                                                    230
                                                     b_int
                                                     []
                                                     Local
@@ -1141,7 +1141,7 @@
                                     __asr_generic_g_1]
                                     []
                                     [(Assignment
-                                        (Var 232 a_int)
+                                        (Var 230 a_int)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1157,7 +1157,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 232 a_int)
+                                            (Var 230 a_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1169,7 +1169,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 b_int)
+                                        (Var 230 b_int)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1185,7 +1185,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 232 b_int)
+                                            (Var 230 b_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1201,7 +1201,7 @@
                                         ()
                                         [((IntegerConstant 1 (Integer 4)))
                                         ((ArrayPhysicalCast
-                                            (Var 232 a_int)
+                                            (Var 230 a_int)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1213,7 +1213,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 232 b_int)
+                                            (Var 230 b_int)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1227,7 +1227,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 a_float)
+                                        (Var 230 a_float)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1243,7 +1243,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 232 a_float)
+                                            (Var 230 a_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1266,7 +1266,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 b_float)
+                                        (Var 230 b_float)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1282,7 +1282,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 232 b_float)
+                                            (Var 230 b_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1309,7 +1309,7 @@
                                         ()
                                         [((IntegerConstant 1 (Integer 4)))
                                         ((ArrayPhysicalCast
-                                            (Var 232 a_float)
+                                            (Var 230 a_float)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1321,7 +1321,7 @@
                                             ()
                                         ))
                                         ((ArrayPhysicalCast
-                                            (Var 232 b_float)
+                                            (Var 230 b_float)
                                             FixedSizeArray
                                             PointerToDataArray
                                             (Array
@@ -1369,11 +1369,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        237
+                        235
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    237
+                                    235
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1385,7 +1385,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        237 __main__global_stmts
+                        235 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-generics_array_03-fb3706c.json
+++ b/tests/reference/asr-generics_array_03-fb3706c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-generics_array_03-fb3706c.stdout",
-    "stdout_hash": "11935851be4c63bec06607453d8b7b3c550f3b4b7a69d0f199c4a596",
+    "stdout_hash": "781e8589691db46e318125a0b8bfd3f91e2ad0ce95b26f958e29d3f4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-generics_array_03-fb3706c.stdout
+++ b/tests/reference/asr-generics_array_03-fb3706c.stdout
@@ -28,11 +28,11 @@
                             __asr_generic_g_0:
                                 (Function
                                     (SymbolTable
-                                        235
+                                        233
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    235
+                                                    233
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -43,9 +43,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 235 n))
+                                                        (Var 233 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 235 m))]
+                                                        (Var 233 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -56,7 +56,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    235
+                                                    233
                                                     a
                                                     [n
                                                     m]
@@ -67,9 +67,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 235 n))
+                                                        (Var 233 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 235 m))]
+                                                        (Var 233 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -80,7 +80,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    235
+                                                    233
                                                     b
                                                     [n
                                                     m]
@@ -91,9 +91,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 235 n))
+                                                        (Var 233 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 235 m))]
+                                                        (Var 233 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -104,7 +104,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    235
+                                                    233
                                                     i
                                                     []
                                                     Local
@@ -120,7 +120,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    235
+                                                    233
                                                     j
                                                     []
                                                     Local
@@ -136,7 +136,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    235
+                                                    233
                                                     m
                                                     []
                                                     In
@@ -152,7 +152,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    235
+                                                    233
                                                     n
                                                     []
                                                     In
@@ -168,7 +168,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    235
+                                                    233
                                                     r
                                                     [n
                                                     m]
@@ -179,9 +179,9 @@
                                                     (Array
                                                         (Integer 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 235 n))
+                                                        (Var 233 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 235 m))]
+                                                        (Var 233 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -255,20 +255,20 @@
                                         .false.
                                     )
                                     [add_integer]
-                                    [(Var 235 n)
-                                    (Var 235 m)
-                                    (Var 235 a)
-                                    (Var 235 b)]
+                                    [(Var 233 n)
+                                    (Var 233 m)
+                                    (Var 233 a)
+                                    (Var 233 b)]
                                     [(Assignment
-                                        (Var 235 r)
+                                        (Var 233 r)
                                         (ArrayConstructor
                                             []
                                             (Array
                                                 (Integer 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 235 n))
+                                                (Var 233 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 235 m))]
+                                                (Var 233 m))]
                                                 PointerToDataArray
                                             )
                                             ()
@@ -278,10 +278,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 235 i)
+                                        ((Var 233 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 235 n)
+                                            (Var 233 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -290,10 +290,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 235 j)
+                                            ((Var 233 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 235 m)
+                                                (Var 233 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -302,12 +302,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(Assignment
                                                 (ArrayItem
-                                                    (Var 235 r)
+                                                    (Var 233 r)
                                                     [(()
-                                                    (Var 235 i)
+                                                    (Var 233 i)
                                                     ())
                                                     (()
-                                                    (Var 235 j)
+                                                    (Var 233 j)
                                                     ())]
                                                     (Integer 4)
                                                     RowMajor
@@ -317,24 +317,24 @@
                                                     2 add_integer
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 235 a)
+                                                        (Var 233 a)
                                                         [(()
-                                                        (Var 235 i)
+                                                        (Var 233 i)
                                                         ())
                                                         (()
-                                                        (Var 235 j)
+                                                        (Var 233 j)
                                                         ())]
                                                         (Integer 4)
                                                         RowMajor
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 235 b)
+                                                        (Var 233 b)
                                                         [(()
-                                                        (Var 235 i)
+                                                        (Var 233 i)
                                                         ())
                                                         (()
-                                                        (Var 235 j)
+                                                        (Var 233 j)
                                                         ())]
                                                         (Integer 4)
                                                         RowMajor
@@ -352,7 +352,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 235 r)
+                                            (Var 233 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -366,7 +366,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 235 _lpython_return_variable)
+                                    (Var 233 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -375,11 +375,11 @@
                             __asr_generic_g_1:
                                 (Function
                                     (SymbolTable
-                                        236
+                                        234
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    236
+                                                    234
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -390,9 +390,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 236 n))
+                                                        (Var 234 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 236 m))]
+                                                        (Var 234 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -403,7 +403,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    236
+                                                    234
                                                     a
                                                     [n
                                                     m]
@@ -414,9 +414,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 236 n))
+                                                        (Var 234 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 236 m))]
+                                                        (Var 234 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -427,7 +427,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    236
+                                                    234
                                                     b
                                                     [n
                                                     m]
@@ -438,9 +438,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 236 n))
+                                                        (Var 234 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 236 m))]
+                                                        (Var 234 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -451,7 +451,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    236
+                                                    234
                                                     i
                                                     []
                                                     Local
@@ -467,7 +467,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    236
+                                                    234
                                                     j
                                                     []
                                                     Local
@@ -483,7 +483,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    236
+                                                    234
                                                     m
                                                     []
                                                     In
@@ -499,7 +499,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    236
+                                                    234
                                                     n
                                                     []
                                                     In
@@ -515,7 +515,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    236
+                                                    234
                                                     r
                                                     [n
                                                     m]
@@ -526,9 +526,9 @@
                                                     (Array
                                                         (Real 4)
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 236 n))
+                                                        (Var 234 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 236 m))]
+                                                        (Var 234 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -602,20 +602,20 @@
                                         .false.
                                     )
                                     [add_float]
-                                    [(Var 236 n)
-                                    (Var 236 m)
-                                    (Var 236 a)
-                                    (Var 236 b)]
+                                    [(Var 234 n)
+                                    (Var 234 m)
+                                    (Var 234 a)
+                                    (Var 234 b)]
                                     [(Assignment
-                                        (Var 236 r)
+                                        (Var 234 r)
                                         (ArrayConstructor
                                             []
                                             (Array
                                                 (Real 4)
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 236 n))
+                                                (Var 234 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 236 m))]
+                                                (Var 234 m))]
                                                 PointerToDataArray
                                             )
                                             ()
@@ -625,10 +625,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 236 i)
+                                        ((Var 234 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 236 n)
+                                            (Var 234 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -637,10 +637,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 236 j)
+                                            ((Var 234 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 236 m)
+                                                (Var 234 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -649,12 +649,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(Assignment
                                                 (ArrayItem
-                                                    (Var 236 r)
+                                                    (Var 234 r)
                                                     [(()
-                                                    (Var 236 i)
+                                                    (Var 234 i)
                                                     ())
                                                     (()
-                                                    (Var 236 j)
+                                                    (Var 234 j)
                                                     ())]
                                                     (Real 4)
                                                     RowMajor
@@ -664,24 +664,24 @@
                                                     2 add_float
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 236 a)
+                                                        (Var 234 a)
                                                         [(()
-                                                        (Var 236 i)
+                                                        (Var 234 i)
                                                         ())
                                                         (()
-                                                        (Var 236 j)
+                                                        (Var 234 j)
                                                         ())]
                                                         (Real 4)
                                                         RowMajor
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 236 b)
+                                                        (Var 234 b)
                                                         [(()
-                                                        (Var 236 i)
+                                                        (Var 234 i)
                                                         ())
                                                         (()
-                                                        (Var 236 j)
+                                                        (Var 234 j)
                                                         ())]
                                                         (Real 4)
                                                         RowMajor
@@ -699,7 +699,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 236 r)
+                                            (Var 234 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -713,7 +713,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 236 _lpython_return_variable)
+                                    (Var 234 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -722,7 +722,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        237
+                                        235
                                         {
                                             
                                         })
@@ -758,11 +758,11 @@
                             add:
                                 (Function
                                     (SymbolTable
-                                        228
+                                        226
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    228
+                                                    226
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -780,7 +780,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    228
+                                                    226
                                                     x
                                                     []
                                                     In
@@ -798,7 +798,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    228
+                                                    226
                                                     y
                                                     []
                                                     In
@@ -838,10 +838,10 @@
                                         .true.
                                     )
                                     []
-                                    [(Var 228 x)
-                                    (Var 228 y)]
+                                    [(Var 226 x)
+                                    (Var 226 y)]
                                     []
-                                    (Var 228 _lpython_return_variable)
+                                    (Var 226 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -850,11 +850,11 @@
                             add_float:
                                 (Function
                                     (SymbolTable
-                                        230
+                                        228
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    230
+                                                    228
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -870,7 +870,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    230
+                                                    228
                                                     x
                                                     []
                                                     In
@@ -886,7 +886,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    230
+                                                    228
                                                     y
                                                     []
                                                     In
@@ -918,21 +918,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 230 x)
-                                    (Var 230 y)]
+                                    [(Var 228 x)
+                                    (Var 228 y)]
                                     [(Assignment
-                                        (Var 230 _lpython_return_variable)
+                                        (Var 228 _lpython_return_variable)
                                         (RealBinOp
-                                            (Var 230 x)
+                                            (Var 228 x)
                                             Add
-                                            (Var 230 y)
+                                            (Var 228 y)
                                             (Real 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 230 _lpython_return_variable)
+                                    (Var 228 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -941,11 +941,11 @@
                             add_integer:
                                 (Function
                                     (SymbolTable
-                                        229
+                                        227
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    229
+                                                    227
                                                     _lpython_return_variable
                                                     []
                                                     ReturnVar
@@ -961,7 +961,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    229
+                                                    227
                                                     x
                                                     []
                                                     In
@@ -977,7 +977,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    229
+                                                    227
                                                     y
                                                     []
                                                     In
@@ -1009,21 +1009,21 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 229 x)
-                                    (Var 229 y)]
+                                    [(Var 227 x)
+                                    (Var 227 y)]
                                     [(Assignment
-                                        (Var 229 _lpython_return_variable)
+                                        (Var 227 _lpython_return_variable)
                                         (IntegerBinOp
-                                            (Var 229 x)
+                                            (Var 227 x)
                                             Add
-                                            (Var 229 y)
+                                            (Var 227 y)
                                             (Integer 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Return)]
-                                    (Var 229 _lpython_return_variable)
+                                    (Var 227 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -1032,11 +1032,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        231
+                                        229
                                         {
                                             _lpython_return_variable:
                                                 (Variable
-                                                    231
+                                                    229
                                                     _lpython_return_variable
                                                     [n
                                                     m]
@@ -1049,9 +1049,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 231 n))
+                                                        (Var 229 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 231 m))]
+                                                        (Var 229 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1062,7 +1062,7 @@
                                                 ),
                                             a:
                                                 (Variable
-                                                    231
+                                                    229
                                                     a
                                                     [n
                                                     m]
@@ -1075,9 +1075,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 231 n))
+                                                        (Var 229 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 231 m))]
+                                                        (Var 229 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1088,7 +1088,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    231
+                                                    229
                                                     b
                                                     [n
                                                     m]
@@ -1101,9 +1101,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 231 n))
+                                                        (Var 229 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 231 m))]
+                                                        (Var 229 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1114,7 +1114,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    231
+                                                    229
                                                     i
                                                     []
                                                     Local
@@ -1130,7 +1130,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    231
+                                                    229
                                                     j
                                                     []
                                                     Local
@@ -1146,7 +1146,7 @@
                                                 ),
                                             m:
                                                 (Variable
-                                                    231
+                                                    229
                                                     m
                                                     []
                                                     In
@@ -1162,7 +1162,7 @@
                                                 ),
                                             n:
                                                 (Variable
-                                                    231
+                                                    229
                                                     n
                                                     []
                                                     In
@@ -1178,7 +1178,7 @@
                                                 ),
                                             r:
                                                 (Variable
-                                                    231
+                                                    229
                                                     r
                                                     [n
                                                     m]
@@ -1191,9 +1191,9 @@
                                                             T
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
-                                                        (Var 231 n))
+                                                        (Var 229 n))
                                                         ((IntegerConstant 0 (Integer 4))
-                                                        (Var 231 m))]
+                                                        (Var 229 m))]
                                                         PointerToDataArray
                                                     )
                                                     ()
@@ -1273,12 +1273,12 @@
                                         .false.
                                     )
                                     [add]
-                                    [(Var 231 n)
-                                    (Var 231 m)
-                                    (Var 231 a)
-                                    (Var 231 b)]
+                                    [(Var 229 n)
+                                    (Var 229 m)
+                                    (Var 229 a)
+                                    (Var 229 b)]
                                     [(Assignment
-                                        (Var 231 r)
+                                        (Var 229 r)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1286,9 +1286,9 @@
                                                     T
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
-                                                (Var 231 n))
+                                                (Var 229 n))
                                                 ((IntegerConstant 0 (Integer 4))
-                                                (Var 231 m))]
+                                                (Var 229 m))]
                                                 PointerToDataArray
                                             )
                                             ()
@@ -1298,10 +1298,10 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 231 i)
+                                        ((Var 229 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
-                                            (Var 231 n)
+                                            (Var 229 n)
                                             Sub
                                             (IntegerConstant 1 (Integer 4))
                                             (Integer 4)
@@ -1310,10 +1310,10 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 231 j)
+                                            ((Var 229 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
-                                                (Var 231 m)
+                                                (Var 229 m)
                                                 Sub
                                                 (IntegerConstant 1 (Integer 4))
                                                 (Integer 4)
@@ -1322,12 +1322,12 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(Assignment
                                                 (ArrayItem
-                                                    (Var 231 r)
+                                                    (Var 229 r)
                                                     [(()
-                                                    (Var 231 i)
+                                                    (Var 229 i)
                                                     ())
                                                     (()
-                                                    (Var 231 j)
+                                                    (Var 229 j)
                                                     ())]
                                                     (TypeParameter
                                                         T
@@ -1339,12 +1339,12 @@
                                                     2 add
                                                     ()
                                                     [((ArrayItem
-                                                        (Var 231 a)
+                                                        (Var 229 a)
                                                         [(()
-                                                        (Var 231 i)
+                                                        (Var 229 i)
                                                         ())
                                                         (()
-                                                        (Var 231 j)
+                                                        (Var 229 j)
                                                         ())]
                                                         (TypeParameter
                                                             T
@@ -1353,12 +1353,12 @@
                                                         ()
                                                     ))
                                                     ((ArrayItem
-                                                        (Var 231 b)
+                                                        (Var 229 b)
                                                         [(()
-                                                        (Var 231 i)
+                                                        (Var 229 i)
                                                         ())
                                                         (()
-                                                        (Var 231 j)
+                                                        (Var 229 j)
                                                         ())]
                                                         (TypeParameter
                                                             T
@@ -1380,7 +1380,7 @@
                                     )
                                     (Print
                                         [(ArrayItem
-                                            (Var 231 r)
+                                            (Var 229 r)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1396,7 +1396,7 @@
                                         ()
                                         ()
                                     )]
-                                    (Var 231 _lpython_return_variable)
+                                    (Var 229 _lpython_return_variable)
                                     Public
                                     .false.
                                     .false.
@@ -1423,11 +1423,11 @@
                             main:
                                 (Function
                                     (SymbolTable
-                                        232
+                                        230
                                         {
                                             __lcompilers_dummy:
                                                 (Variable
-                                                    232
+                                                    230
                                                     __lcompilers_dummy
                                                     []
                                                     Local
@@ -1450,7 +1450,7 @@
                                                 ),
                                             __lcompilers_dummy1:
                                                 (Variable
-                                                    232
+                                                    230
                                                     __lcompilers_dummy1
                                                     []
                                                     Local
@@ -1473,7 +1473,7 @@
                                                 ),
                                             a_float:
                                                 (Variable
-                                                    232
+                                                    230
                                                     a_float
                                                     []
                                                     Local
@@ -1496,7 +1496,7 @@
                                                 ),
                                             a_int:
                                                 (Variable
-                                                    232
+                                                    230
                                                     a_int
                                                     []
                                                     Local
@@ -1519,7 +1519,7 @@
                                                 ),
                                             b_float:
                                                 (Variable
-                                                    232
+                                                    230
                                                     b_float
                                                     []
                                                     Local
@@ -1542,7 +1542,7 @@
                                                 ),
                                             b_int:
                                                 (Variable
-                                                    232
+                                                    230
                                                     b_int
                                                     []
                                                     Local
@@ -1583,7 +1583,7 @@
                                     __asr_generic_g_1]
                                     []
                                     [(Assignment
-                                        (Var 232 a_int)
+                                        (Var 230 a_int)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1601,7 +1601,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 232 a_int)
+                                            (Var 230 a_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1616,7 +1616,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 b_int)
+                                        (Var 230 b_int)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1634,7 +1634,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 232 b_int)
+                                            (Var 230 b_int)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1649,14 +1649,14 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 __lcompilers_dummy)
+                                        (Var 230 __lcompilers_dummy)
                                         (FunctionCall
                                             2 __asr_generic_g_0
                                             ()
                                             [((IntegerConstant 1 (Integer 4)))
                                             ((IntegerConstant 1 (Integer 4)))
                                             ((ArrayPhysicalCast
-                                                (Var 232 a_int)
+                                                (Var 230 a_int)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1670,7 +1670,7 @@
                                                 ()
                                             ))
                                             ((ArrayPhysicalCast
-                                                (Var 232 b_int)
+                                                (Var 230 b_int)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1697,7 +1697,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 a_float)
+                                        (Var 230 a_float)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1715,7 +1715,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 232 a_float)
+                                            (Var 230 a_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1738,7 +1738,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 b_float)
+                                        (Var 230 b_float)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1756,7 +1756,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 232 b_float)
+                                            (Var 230 b_float)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())
@@ -1779,14 +1779,14 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 232 __lcompilers_dummy1)
+                                        (Var 230 __lcompilers_dummy1)
                                         (FunctionCall
                                             2 __asr_generic_g_1
                                             ()
                                             [((IntegerConstant 1 (Integer 4)))
                                             ((IntegerConstant 1 (Integer 4)))
                                             ((ArrayPhysicalCast
-                                                (Var 232 a_float)
+                                                (Var 230 a_float)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1800,7 +1800,7 @@
                                                 ()
                                             ))
                                             ((ArrayPhysicalCast
-                                                (Var 232 b_float)
+                                                (Var 230 b_float)
                                                 FixedSizeArray
                                                 PointerToDataArray
                                                 (Array
@@ -1861,11 +1861,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        238
+                        236
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    238
+                                    236
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1877,7 +1877,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        238 __main__global_stmts
+                        236 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-structs_05-fa98307.json
+++ b/tests/reference/asr-structs_05-fa98307.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_05-fa98307.stdout",
-    "stdout_hash": "fb98e79d6eed109ca6b19507d2123aafa2c994a0d7261edacacbf05b",
+    "stdout_hash": "46a6d4fc967a5081b9d2df3936f9a3696cc8383bd140ee0cb37c5e75",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_05-fa98307.stdout
+++ b/tests/reference/asr-structs_05-fa98307.stdout
@@ -10,11 +10,11 @@
                             A:
                                 (StructType
                                     (SymbolTable
-                                        228
+                                        226
                                         {
                                             a:
                                                 (Variable
-                                                    228
+                                                    226
                                                     a
                                                     []
                                                     Local
@@ -30,7 +30,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    228
+                                                    226
                                                     b
                                                     []
                                                     Local
@@ -46,7 +46,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    228
+                                                    226
                                                     c
                                                     []
                                                     Local
@@ -62,7 +62,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    228
+                                                    226
                                                     d
                                                     []
                                                     Local
@@ -78,7 +78,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    228
+                                                    226
                                                     x
                                                     []
                                                     Local
@@ -94,7 +94,7 @@
                                                 ),
                                             y:
                                                 (Variable
-                                                    228
+                                                    226
                                                     y
                                                     []
                                                     Local
@@ -110,7 +110,7 @@
                                                 ),
                                             z:
                                                 (Variable
-                                                    228
+                                                    226
                                                     z
                                                     []
                                                     Local
@@ -151,7 +151,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        234
+                                        232
                                         {
                                             
                                         })
@@ -187,11 +187,11 @@
                             g:
                                 (Function
                                     (SymbolTable
-                                        232
+                                        230
                                         {
                                             y:
                                                 (Variable
-                                                    232
+                                                    230
                                                     y
                                                     []
                                                     Local
@@ -233,7 +233,7 @@
                                     update_2]
                                     []
                                     [(Assignment
-                                        (Var 232 y)
+                                        (Var 230 y)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -251,7 +251,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 232 y)
+                                            (Var 230 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -311,7 +311,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 232 y)
+                                            (Var 230 y)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -373,7 +373,7 @@
                                         2 verify
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 232 y)
+                                            (Var 230 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -402,7 +402,7 @@
                                         2 update_1
                                         ()
                                         [((ArrayItem
-                                            (Var 232 y)
+                                            (Var 230 y)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -418,7 +418,7 @@
                                         2 update_2
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 232 y)
+                                            (Var 230 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -437,7 +437,7 @@
                                         2 verify
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 232 y)
+                                            (Var 230 y)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -471,11 +471,11 @@
                             update_1:
                                 (Function
                                     (SymbolTable
-                                        230
+                                        228
                                         {
                                             s:
                                                 (Variable
-                                                    230
+                                                    228
                                                     s
                                                     []
                                                     InOut
@@ -510,11 +510,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 230 s)]
+                                    [(Var 228 s)]
                                     [(Assignment
                                         (StructInstanceMember
-                                            (Var 230 s)
-                                            228 x
+                                            (Var 228 s)
+                                            226 x
                                             (Integer 4)
                                             ()
                                         )
@@ -523,8 +523,8 @@
                                     )
                                     (Assignment
                                         (StructInstanceMember
-                                            (Var 230 s)
-                                            228 y
+                                            (Var 228 s)
+                                            226 y
                                             (Real 8)
                                             ()
                                         )
@@ -536,8 +536,8 @@
                                     )
                                     (Assignment
                                         (StructInstanceMember
-                                            (Var 230 s)
-                                            228 z
+                                            (Var 228 s)
+                                            226 z
                                             (Integer 8)
                                             ()
                                         )
@@ -551,8 +551,8 @@
                                     )
                                     (Assignment
                                         (StructInstanceMember
-                                            (Var 230 s)
-                                            228 a
+                                            (Var 228 s)
+                                            226 a
                                             (Real 4)
                                             ()
                                         )
@@ -572,8 +572,8 @@
                                     )
                                     (Assignment
                                         (StructInstanceMember
-                                            (Var 230 s)
-                                            228 b
+                                            (Var 228 s)
+                                            226 b
                                             (Integer 2)
                                             ()
                                         )
@@ -587,8 +587,8 @@
                                     )
                                     (Assignment
                                         (StructInstanceMember
-                                            (Var 230 s)
-                                            228 c
+                                            (Var 228 s)
+                                            226 c
                                             (Integer 1)
                                             ()
                                         )
@@ -609,11 +609,11 @@
                             update_2:
                                 (Function
                                     (SymbolTable
-                                        231
+                                        229
                                         {
                                             s:
                                                 (Variable
-                                                    231
+                                                    229
                                                     s
                                                     []
                                                     InOut
@@ -658,11 +658,11 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 231 s)]
+                                    [(Var 229 s)]
                                     [(Assignment
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 231 s)
+                                                (Var 229 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -672,7 +672,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            228 x
+                                            226 x
                                             (Integer 4)
                                             ()
                                         )
@@ -682,7 +682,7 @@
                                     (Assignment
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 231 s)
+                                                (Var 229 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -692,7 +692,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            228 y
+                                            226 y
                                             (Real 8)
                                             ()
                                         )
@@ -705,7 +705,7 @@
                                     (Assignment
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 231 s)
+                                                (Var 229 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -715,7 +715,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            228 z
+                                            226 z
                                             (Integer 8)
                                             ()
                                         )
@@ -730,7 +730,7 @@
                                     (Assignment
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 231 s)
+                                                (Var 229 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -740,7 +740,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            228 a
+                                            226 a
                                             (Real 4)
                                             ()
                                         )
@@ -761,7 +761,7 @@
                                     (Assignment
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 231 s)
+                                                (Var 229 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -771,7 +771,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            228 b
+                                            226 b
                                             (Integer 2)
                                             ()
                                         )
@@ -786,7 +786,7 @@
                                     (Assignment
                                         (StructInstanceMember
                                             (ArrayItem
-                                                (Var 231 s)
+                                                (Var 229 s)
                                                 [(()
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
@@ -796,7 +796,7 @@
                                                 RowMajor
                                                 ()
                                             )
-                                            228 c
+                                            226 c
                                             (Integer 1)
                                             ()
                                         )
@@ -817,11 +817,11 @@
                             verify:
                                 (Function
                                     (SymbolTable
-                                        229
+                                        227
                                         {
                                             eps:
                                                 (Variable
-                                                    229
+                                                    227
                                                     eps
                                                     []
                                                     Local
@@ -837,7 +837,7 @@
                                                 ),
                                             s:
                                                 (Variable
-                                                    229
+                                                    227
                                                     s
                                                     []
                                                     InOut
@@ -860,7 +860,7 @@
                                                 ),
                                             s0:
                                                 (Variable
-                                                    229
+                                                    227
                                                     s0
                                                     []
                                                     Local
@@ -878,7 +878,7 @@
                                                 ),
                                             s1:
                                                 (Variable
-                                                    229
+                                                    227
                                                     s1
                                                     []
                                                     Local
@@ -896,7 +896,7 @@
                                                 ),
                                             x1:
                                                 (Variable
-                                                    229
+                                                    227
                                                     x1
                                                     []
                                                     In
@@ -912,7 +912,7 @@
                                                 ),
                                             x2:
                                                 (Variable
-                                                    229
+                                                    227
                                                     x2
                                                     []
                                                     In
@@ -928,7 +928,7 @@
                                                 ),
                                             y1:
                                                 (Variable
-                                                    229
+                                                    227
                                                     y1
                                                     []
                                                     In
@@ -944,7 +944,7 @@
                                                 ),
                                             y2:
                                                 (Variable
-                                                    229
+                                                    227
                                                     y2
                                                     []
                                                     In
@@ -986,13 +986,13 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 229 s)
-                                    (Var 229 x1)
-                                    (Var 229 y1)
-                                    (Var 229 x2)
-                                    (Var 229 y2)]
+                                    [(Var 227 s)
+                                    (Var 227 x1)
+                                    (Var 227 y1)
+                                    (Var 227 x2)
+                                    (Var 227 y2)]
                                     [(Assignment
-                                        (Var 229 eps)
+                                        (Var 227 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -1000,9 +1000,9 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 229 s0)
+                                        (Var 227 s0)
                                         (ArrayItem
-                                            (Var 229 s)
+                                            (Var 227 s)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1016,44 +1016,44 @@
                                     )
                                     (Print
                                         [(StructInstanceMember
-                                            (Var 229 s0)
-                                            228 x
+                                            (Var 227 s0)
+                                            226 x
                                             (Integer 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 229 s0)
-                                            228 y
+                                            (Var 227 s0)
+                                            226 y
                                             (Real 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 229 s0)
-                                            228 z
+                                            (Var 227 s0)
+                                            226 z
                                             (Integer 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 229 s0)
-                                            228 a
+                                            (Var 227 s0)
+                                            226 a
                                             (Real 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 229 s0)
-                                            228 b
+                                            (Var 227 s0)
+                                            226 b
                                             (Integer 2)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 229 s0)
-                                            228 c
+                                            (Var 227 s0)
+                                            226 c
                                             (Integer 1)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 229 s0)
-                                            228 d
+                                            (Var 227 s0)
+                                            226 d
                                             (Logical 4)
                                             ()
                                         )]
@@ -1063,13 +1063,13 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 229 s0)
-                                                228 x
+                                                (Var 227 s0)
+                                                226 x
                                                 (Integer 4)
                                                 ()
                                             )
                                             Eq
-                                            (Var 229 x1)
+                                            (Var 227 x1)
                                             (Logical 4)
                                             ()
                                         )
@@ -1081,13 +1081,13 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 229 s0)
-                                                        228 y
+                                                        (Var 227 s0)
+                                                        226 y
                                                         (Real 8)
                                                         ()
                                                     )
                                                     Sub
-                                                    (Var 229 y1)
+                                                    (Var 227 y1)
                                                     (Real 8)
                                                     ()
                                                 )]
@@ -1096,7 +1096,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 229 eps)
+                                            (Var 227 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -1105,14 +1105,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 229 s0)
-                                                228 z
+                                                (Var 227 s0)
+                                                226 z
                                                 (Integer 8)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 229 x1)
+                                                (Var 227 x1)
                                                 IntegerToInteger
                                                 (Integer 8)
                                                 ()
@@ -1128,14 +1128,14 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 229 s0)
-                                                        228 a
+                                                        (Var 227 s0)
+                                                        226 a
                                                         (Real 4)
                                                         ()
                                                     )
                                                     Sub
                                                     (Cast
-                                                        (Var 229 y1)
+                                                        (Var 227 y1)
                                                         RealToReal
                                                         (Real 4)
                                                         ()
@@ -1168,14 +1168,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 229 s0)
-                                                228 b
+                                                (Var 227 s0)
+                                                226 b
                                                 (Integer 2)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 229 x1)
+                                                (Var 227 x1)
                                                 IntegerToInteger
                                                 (Integer 2)
                                                 ()
@@ -1188,14 +1188,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 229 s0)
-                                                228 c
+                                                (Var 227 s0)
+                                                226 c
                                                 (Integer 1)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 229 x1)
+                                                (Var 227 x1)
                                                 IntegerToInteger
                                                 (Integer 1)
                                                 ()
@@ -1207,17 +1207,17 @@
                                     )
                                     (Assert
                                         (StructInstanceMember
-                                            (Var 229 s0)
-                                            228 d
+                                            (Var 227 s0)
+                                            226 d
                                             (Logical 4)
                                             ()
                                         )
                                         ()
                                     )
                                     (Assignment
-                                        (Var 229 s1)
+                                        (Var 227 s1)
                                         (ArrayItem
-                                            (Var 229 s)
+                                            (Var 227 s)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -1231,44 +1231,44 @@
                                     )
                                     (Print
                                         [(StructInstanceMember
-                                            (Var 229 s1)
-                                            228 x
+                                            (Var 227 s1)
+                                            226 x
                                             (Integer 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 229 s1)
-                                            228 y
+                                            (Var 227 s1)
+                                            226 y
                                             (Real 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 229 s1)
-                                            228 z
+                                            (Var 227 s1)
+                                            226 z
                                             (Integer 8)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 229 s1)
-                                            228 a
+                                            (Var 227 s1)
+                                            226 a
                                             (Real 4)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 229 s1)
-                                            228 b
+                                            (Var 227 s1)
+                                            226 b
                                             (Integer 2)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 229 s1)
-                                            228 c
+                                            (Var 227 s1)
+                                            226 c
                                             (Integer 1)
                                             ()
                                         )
                                         (StructInstanceMember
-                                            (Var 229 s1)
-                                            228 d
+                                            (Var 227 s1)
+                                            226 d
                                             (Logical 4)
                                             ()
                                         )]
@@ -1278,13 +1278,13 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 229 s1)
-                                                228 x
+                                                (Var 227 s1)
+                                                226 x
                                                 (Integer 4)
                                                 ()
                                             )
                                             Eq
-                                            (Var 229 x2)
+                                            (Var 227 x2)
                                             (Logical 4)
                                             ()
                                         )
@@ -1296,13 +1296,13 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 229 s1)
-                                                        228 y
+                                                        (Var 227 s1)
+                                                        226 y
                                                         (Real 8)
                                                         ()
                                                     )
                                                     Sub
-                                                    (Var 229 y2)
+                                                    (Var 227 y2)
                                                     (Real 8)
                                                     ()
                                                 )]
@@ -1311,7 +1311,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 229 eps)
+                                            (Var 227 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -1320,14 +1320,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 229 s1)
-                                                228 z
+                                                (Var 227 s1)
+                                                226 z
                                                 (Integer 8)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 229 x2)
+                                                (Var 227 x2)
                                                 IntegerToInteger
                                                 (Integer 8)
                                                 ()
@@ -1343,14 +1343,14 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (StructInstanceMember
-                                                        (Var 229 s1)
-                                                        228 a
+                                                        (Var 227 s1)
+                                                        226 a
                                                         (Real 4)
                                                         ()
                                                     )
                                                     Sub
                                                     (Cast
-                                                        (Var 229 y2)
+                                                        (Var 227 y2)
                                                         RealToReal
                                                         (Real 4)
                                                         ()
@@ -1383,14 +1383,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 229 s1)
-                                                228 b
+                                                (Var 227 s1)
+                                                226 b
                                                 (Integer 2)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 229 x2)
+                                                (Var 227 x2)
                                                 IntegerToInteger
                                                 (Integer 2)
                                                 ()
@@ -1403,14 +1403,14 @@
                                     (Assert
                                         (IntegerCompare
                                             (StructInstanceMember
-                                                (Var 229 s1)
-                                                228 c
+                                                (Var 227 s1)
+                                                226 c
                                                 (Integer 1)
                                                 ()
                                             )
                                             Eq
                                             (Cast
-                                                (Var 229 x2)
+                                                (Var 227 x2)
                                                 IntegerToInteger
                                                 (Integer 1)
                                                 ()
@@ -1422,8 +1422,8 @@
                                     )
                                     (Assert
                                         (StructInstanceMember
-                                            (Var 229 s1)
-                                            228 d
+                                            (Var 227 s1)
+                                            226 d
                                             (Logical 4)
                                             ()
                                         )
@@ -1446,11 +1446,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        235
+                        233
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    235
+                                    233
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1462,7 +1462,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        235 __main__global_stmts
+                        233 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_bin-52ba9fa.json
+++ b/tests/reference/asr-test_builtin_bin-52ba9fa.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_bin-52ba9fa.stdout",
-    "stdout_hash": "c8aee3b39a3783fecd0cd685c99ea5e51bbb6306e9e9cc950150c029",
+    "stdout_hash": "4170c47c3131cbfde5fae91187c9e8182e29025f11a616ec7dde6cec",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_bin-52ba9fa.stdout
+++ b/tests/reference/asr-test_builtin_bin-52ba9fa.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        144
+                                        142
                                         {
                                             
                                         })
@@ -244,11 +244,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        145
+                        143
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    145
+                                    143
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -260,7 +260,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        145 __main__global_stmts
+                        143 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_bool-330223a.json
+++ b/tests/reference/asr-test_builtin_bool-330223a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_bool-330223a.stdout",
-    "stdout_hash": "82820e4e59677f3b6573bd8fb785a13bd4348a5a434168dcf6e1cd82",
+    "stdout_hash": "2a2c709ee60826b6a060ee48d4b6114df52b0beae2fa4e693fa6973e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_bool-330223a.stdout
+++ b/tests/reference/asr-test_builtin_bool-330223a.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        144
+                                        142
                                         {
                                             
                                         })
@@ -868,11 +868,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        145
+                        143
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    145
+                                    143
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -884,7 +884,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        145 __main__global_stmts
+                        143 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_hex-64bd268.json
+++ b/tests/reference/asr-test_builtin_hex-64bd268.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_hex-64bd268.stdout",
-    "stdout_hash": "166a01a7f5b86e7f5034942c02e5b9d0136d3017e1ddf7dfd7fd4cc0",
+    "stdout_hash": "b185780269d703af7d4c9ebb1fae6d016c66b65a703122316665cc2b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_hex-64bd268.stdout
+++ b/tests/reference/asr-test_builtin_hex-64bd268.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        144
+                                        142
                                         {
                                             
                                         })
@@ -219,11 +219,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        145
+                        143
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    145
+                                    143
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -235,7 +235,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        145 __main__global_stmts
+                        143 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_oct-20b9066.json
+++ b/tests/reference/asr-test_builtin_oct-20b9066.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_oct-20b9066.stdout",
-    "stdout_hash": "bd134acbeb89b19a351a1e8c83a4b87d16f7fc9f7023f08474c41539",
+    "stdout_hash": "309ab950a836d42a6f215f93bea43d8c636a569f47f173b1ad3805bd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_oct-20b9066.stdout
+++ b/tests/reference/asr-test_builtin_oct-20b9066.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        144
+                                        142
                                         {
                                             
                                         })
@@ -219,11 +219,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        145
+                        143
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    145
+                                    143
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -235,7 +235,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        145 __main__global_stmts
+                        143 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_pow-f02fcda.json
+++ b/tests/reference/asr-test_builtin_pow-f02fcda.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_pow-f02fcda.stdout",
-    "stdout_hash": "258d681557b770ac9002690bafdcde1e839381a25fd2f17eb800c991",
+    "stdout_hash": "656fc9a4c448dc71d7fc1c871155a05f0c4204bcfc6e9d32eab844f5",
     "stderr": "asr-test_builtin_pow-f02fcda.stderr",
     "stderr_hash": "859ce76c74748f2d32c7eab92cfbba789a78d4cbf5818646b99806ea",
     "returncode": 0

--- a/tests/reference/asr-test_builtin_pow-f02fcda.stdout
+++ b/tests/reference/asr-test_builtin_pow-f02fcda.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        144
+                                        142
                                         {
                                             
                                         })
@@ -1880,11 +1880,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        145
+                        143
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    145
+                                    143
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1896,7 +1896,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        145 __main__global_stmts
+                        143 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_builtin_round-7417a21.json
+++ b/tests/reference/asr-test_builtin_round-7417a21.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_builtin_round-7417a21.stdout",
-    "stdout_hash": "bcbc248e1f35f49f1df019a62171071686661c829c751ce18d2517cf",
+    "stdout_hash": "f9b0b278c3907de38bf2216f5f7c05e7235f885188ab06daabd2876d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_builtin_round-7417a21.stdout
+++ b/tests/reference/asr-test_builtin_round-7417a21.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        144
+                                        142
                                         {
                                             
                                         })
@@ -886,11 +886,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        145
+                        143
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    145
+                                    143
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -902,7 +902,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        145 __main__global_stmts
+                        143 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_complex_01-a6def58.json
+++ b/tests/reference/asr-test_complex_01-a6def58.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_complex_01-a6def58.stdout",
-    "stdout_hash": "a84c9183063ae89cc770192023dcf33f4362b9fb171ac23528e9d1df",
+    "stdout_hash": "9073ee7e90e853192eafaf00947d7c926a98144388a4ea537d774f12",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_complex_01-a6def58.stdout
+++ b/tests/reference/asr-test_complex_01-a6def58.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        148
+                                        146
                                         {
                                             
                                         })
@@ -1975,11 +1975,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        149
+                        147
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    149
+                                    147
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1991,7 +1991,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        149 __main__global_stmts
+                        147 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_complex_02-782ba2d.json
+++ b/tests/reference/asr-test_complex_02-782ba2d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_complex_02-782ba2d.stdout",
-    "stdout_hash": "a29ffdab664ab5715b98cfe9caf059249cc09445d62a7103f240641d",
+    "stdout_hash": "f41d0ff96de8e204727c2fc135812d0262063d6cb6ab903c89172c8f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_complex_02-782ba2d.stdout
+++ b/tests/reference/asr-test_complex_02-782ba2d.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        147
+                                        145
                                         {
                                             
                                         })
@@ -691,11 +691,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        148
+                        146
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    148
+                                    146
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -707,7 +707,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        148 __main__global_stmts
+                        146 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_numpy_03-e600a49.json
+++ b/tests/reference/asr-test_numpy_03-e600a49.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_03-e600a49.stdout",
-    "stdout_hash": "07a2cd32c7c778915851b99b3f9faab7fab266e547479872e6997451",
+    "stdout_hash": "5b16e1922ff5e89e454f6aeed0fe728447b0b9dbe291a078df6e5123",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_03-e600a49.stdout
+++ b/tests/reference/asr-test_numpy_03-e600a49.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        245
+                                        243
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             test_1d_to_nd:
                                 (Function
                                     (SymbolTable
-                                        229
+                                        227
                                         {
                                             a:
                                                 (Variable
-                                                    229
+                                                    227
                                                     a
                                                     []
                                                     Local
@@ -73,7 +73,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    229
+                                                    227
                                                     b
                                                     []
                                                     Local
@@ -94,7 +94,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    229
+                                                    227
                                                     c
                                                     []
                                                     Local
@@ -119,7 +119,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    229
+                                                    227
                                                     d
                                                     []
                                                     InOut
@@ -140,7 +140,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    229
+                                                    227
                                                     eps
                                                     []
                                                     Local
@@ -156,7 +156,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    229
+                                                    227
                                                     i
                                                     []
                                                     Local
@@ -172,7 +172,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    229
+                                                    227
                                                     j
                                                     []
                                                     Local
@@ -188,7 +188,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    229
+                                                    227
                                                     k
                                                     []
                                                     Local
@@ -204,7 +204,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    229
+                                                    227
                                                     l
                                                     []
                                                     Local
@@ -220,7 +220,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    229
+                                                    227
                                                     newshape
                                                     []
                                                     Local
@@ -241,7 +241,7 @@
                                                 ),
                                             newshape1:
                                                 (Variable
-                                                    229
+                                                    227
                                                     newshape1
                                                     []
                                                     Local
@@ -282,9 +282,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 229 d)]
+                                    [(Var 227 d)]
                                     [(Assignment
-                                        (Var 229 eps)
+                                        (Var 227 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -292,7 +292,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 229 b)
+                                        (Var 227 b)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -308,7 +308,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 229 k)
+                                        ((Var 227 k)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -319,10 +319,10 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
-                                            (Var 229 i)
+                                            (Var 227 i)
                                             (IntrinsicElementalFunction
                                                 FloorDiv
-                                                [(Var 229 k)
+                                                [(Var 227 k)
                                                 (IntegerConstant 16 (Integer 4))]
                                                 0
                                                 (Integer 4)
@@ -331,12 +331,12 @@
                                             ()
                                         )
                                         (Assignment
-                                            (Var 229 j)
+                                            (Var 227 j)
                                             (IntegerBinOp
-                                                (Var 229 k)
+                                                (Var 227 k)
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 229 i)
+                                                    (Var 227 i)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -349,9 +349,9 @@
                                         )
                                         (Assignment
                                             (ArrayItem
-                                                (Var 229 b)
+                                                (Var 227 b)
                                                 [(()
-                                                (Var 229 k)
+                                                (Var 227 k)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -360,9 +360,9 @@
                                             (RealBinOp
                                                 (Cast
                                                     (IntegerBinOp
-                                                        (Var 229 i)
+                                                        (Var 227 i)
                                                         Add
-                                                        (Var 229 j)
+                                                        (Var 227 j)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -383,7 +383,7 @@
                                         []
                                     )
                                     (Assignment
-                                        (Var 229 a)
+                                        (Var 227 a)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -400,7 +400,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 229 newshape)
+                                        (Var 227 newshape)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -416,7 +416,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 229 newshape)
+                                            (Var 227 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -429,7 +429,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 229 newshape)
+                                            (Var 227 newshape)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -441,11 +441,11 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 229 a)
+                                        (Var 227 a)
                                         (ArrayReshape
-                                            (Var 229 b)
+                                            (Var 227 b)
                                             (ArrayPhysicalCast
-                                                (Var 229 newshape)
+                                                (Var 227 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -468,7 +468,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 229 i)
+                                        ((Var 227 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -480,7 +480,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 229 j)
+                                            ((Var 227 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -497,12 +497,12 @@
                                                         [(RealBinOp
                                                             (RealBinOp
                                                                 (ArrayItem
-                                                                    (Var 229 a)
+                                                                    (Var 227 a)
                                                                     [(()
-                                                                    (Var 229 i)
+                                                                    (Var 227 i)
                                                                     ())
                                                                     (()
-                                                                    (Var 229 j)
+                                                                    (Var 227 j)
                                                                     ())]
                                                                     (Real 8)
                                                                     RowMajor
@@ -511,9 +511,9 @@
                                                                 Sub
                                                                 (Cast
                                                                     (IntegerBinOp
-                                                                        (Var 229 i)
+                                                                        (Var 227 i)
                                                                         Add
-                                                                        (Var 229 j)
+                                                                        (Var 227 j)
                                                                         (Integer 4)
                                                                         ()
                                                                     )
@@ -537,7 +537,7 @@
                                                         ()
                                                     )
                                                     LtE
-                                                    (Var 229 eps)
+                                                    (Var 227 eps)
                                                     (Logical 4)
                                                     ()
                                                 )
@@ -548,7 +548,7 @@
                                         []
                                     )
                                     (Assignment
-                                        (Var 229 c)
+                                        (Var 227 c)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -567,7 +567,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 229 newshape1)
+                                        (Var 227 newshape1)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -583,7 +583,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 229 newshape1)
+                                            (Var 227 newshape1)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -596,7 +596,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 229 newshape1)
+                                            (Var 227 newshape1)
                                             [(()
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
@@ -609,7 +609,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 229 newshape1)
+                                            (Var 227 newshape1)
                                             [(()
                                             (IntegerConstant 2 (Integer 4))
                                             ())]
@@ -621,11 +621,11 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 229 c)
+                                        (Var 227 c)
                                         (ArrayReshape
-                                            (Var 229 d)
+                                            (Var 227 d)
                                             (ArrayPhysicalCast
-                                                (Var 229 newshape1)
+                                                (Var 227 newshape1)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -648,7 +648,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 229 i)
+                                        ((Var 227 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 16 (Integer 4))
@@ -660,7 +660,7 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(DoLoop
                                             ()
-                                            ((Var 229 j)
+                                            ((Var 227 j)
                                             (IntegerConstant 0 (Integer 4))
                                             (IntegerBinOp
                                                 (IntegerConstant 16 (Integer 4))
@@ -672,7 +672,7 @@
                                             (IntegerConstant 1 (Integer 4)))
                                             [(DoLoop
                                                 ()
-                                                ((Var 229 k)
+                                                ((Var 227 k)
                                                 (IntegerConstant 0 (Integer 4))
                                                 (IntegerBinOp
                                                     (IntegerConstant 16 (Integer 4))
@@ -689,15 +689,15 @@
                                                             [(RealBinOp
                                                                 (RealBinOp
                                                                     (ArrayItem
-                                                                        (Var 229 c)
+                                                                        (Var 227 c)
                                                                         [(()
-                                                                        (Var 229 i)
+                                                                        (Var 227 i)
                                                                         ())
                                                                         (()
-                                                                        (Var 229 j)
+                                                                        (Var 227 j)
                                                                         ())
                                                                         (()
-                                                                        (Var 229 k)
+                                                                        (Var 227 k)
                                                                         ())]
                                                                         (Real 8)
                                                                         RowMajor
@@ -707,14 +707,14 @@
                                                                     (Cast
                                                                         (IntegerBinOp
                                                                             (IntegerBinOp
-                                                                                (Var 229 i)
+                                                                                (Var 227 i)
                                                                                 Add
-                                                                                (Var 229 j)
+                                                                                (Var 227 j)
                                                                                 (Integer 4)
                                                                                 ()
                                                                             )
                                                                             Add
-                                                                            (Var 229 k)
+                                                                            (Var 227 k)
                                                                             (Integer 4)
                                                                             ()
                                                                         )
@@ -738,7 +738,7 @@
                                                             ()
                                                         )
                                                         LtE
-                                                        (Var 229 eps)
+                                                        (Var 227 eps)
                                                         (Logical 4)
                                                         ()
                                                     )
@@ -759,11 +759,11 @@
                             test_nd_to_1d:
                                 (Function
                                     (SymbolTable
-                                        228
+                                        226
                                         {
                                             a:
                                                 (Variable
-                                                    228
+                                                    226
                                                     a
                                                     []
                                                     InOut
@@ -786,7 +786,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    228
+                                                    226
                                                     b
                                                     []
                                                     Local
@@ -807,7 +807,7 @@
                                                 ),
                                             c:
                                                 (Variable
-                                                    228
+                                                    226
                                                     c
                                                     []
                                                     Local
@@ -832,7 +832,7 @@
                                                 ),
                                             d:
                                                 (Variable
-                                                    228
+                                                    226
                                                     d
                                                     []
                                                     Local
@@ -853,7 +853,7 @@
                                                 ),
                                             eps:
                                                 (Variable
-                                                    228
+                                                    226
                                                     eps
                                                     []
                                                     Local
@@ -869,7 +869,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    228
+                                                    226
                                                     i
                                                     []
                                                     Local
@@ -885,7 +885,7 @@
                                                 ),
                                             j:
                                                 (Variable
-                                                    228
+                                                    226
                                                     j
                                                     []
                                                     Local
@@ -901,7 +901,7 @@
                                                 ),
                                             k:
                                                 (Variable
-                                                    228
+                                                    226
                                                     k
                                                     []
                                                     Local
@@ -917,7 +917,7 @@
                                                 ),
                                             l:
                                                 (Variable
-                                                    228
+                                                    226
                                                     l
                                                     []
                                                     Local
@@ -933,7 +933,7 @@
                                                 ),
                                             newshape:
                                                 (Variable
-                                                    228
+                                                    226
                                                     newshape
                                                     []
                                                     Local
@@ -954,7 +954,7 @@
                                                 ),
                                             newshape1:
                                                 (Variable
-                                                    228
+                                                    226
                                                     newshape1
                                                     []
                                                     Local
@@ -997,9 +997,9 @@
                                         .false.
                                     )
                                     []
-                                    [(Var 228 a)]
+                                    [(Var 226 a)]
                                     [(Assignment
-                                        (Var 228 eps)
+                                        (Var 226 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -1007,7 +1007,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 228 b)
+                                        (Var 226 b)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1022,7 +1022,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 228 newshape)
+                                        (Var 226 newshape)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1038,7 +1038,7 @@
                                     )
                                     (Assignment
                                         (ArrayItem
-                                            (Var 228 newshape)
+                                            (Var 226 newshape)
                                             [(()
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
@@ -1050,11 +1050,11 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 228 b)
+                                        (Var 226 b)
                                         (ArrayReshape
-                                            (Var 228 a)
+                                            (Var 226 a)
                                             (ArrayPhysicalCast
-                                                (Var 228 newshape)
+                                                (Var 226 newshape)
                                                 FixedSizeArray
                                                 DescriptorArray
                                                 (Array
@@ -1077,7 +1077,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 228 k)
+                                        ((Var 226 k)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 256 (Integer 4))
@@ -1088,10 +1088,10 @@
                                         )
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
-                                            (Var 228 i)
+                                            (Var 226 i)
                                             (IntrinsicElementalFunction
                                                 FloorDiv
-                                                [(Var 228 k)
+                                                [(Var 226 k)
                                                 (IntegerConstant 16 (Integer 4))]
                                                 0
                                                 (Integer 4)
@@ -1100,12 +1100,12 @@
                                             ()
                                         )
                                         (Assignment
-                                            (Var 228 j)
+                                            (Var 226 j)
                                             (IntegerBinOp
-                                                (Var 228 k)
+                                                (Var 226 k)
                                                 Sub
                                                 (IntegerBinOp
-                                                    (Var 228 i)
+                                                    (Var 226 i)
                                                     Mul
                                                     (IntegerConstant 16 (Integer 4))
                                                     (Integer 4)
@@ -1123,9 +1123,9 @@
                                                     [(RealBinOp
                                                         (RealBinOp
                                                             (ArrayItem
-                                                                (Var 228 b)
+                                                                (Var 226 b)
                                                                 [(()
-                                                                (Var 228 k)
+                                                                (Var 226 k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
@@ -1134,9 +1134,9 @@
                                                             Sub
                                                             (Cast
                                                                 (IntegerBinOp
-                                                                    (Var 228 i)
+                                                                    (Var 226 i)
                                                                     Add
-                                                                    (Var 228 j)
+                                                                    (Var 226 j)
                                                                     (Integer 4)
                                                                     ()
                                                                 )
@@ -1160,7 +1160,7 @@
                                                     ()
                                                 )
                                                 LtE
-                                                (Var 228 eps)
+                                                (Var 226 eps)
                                                 (Logical 4)
                                                 ()
                                             )
@@ -1169,7 +1169,7 @@
                                         []
                                     )
                                     (Assignment
-                                        (Var 228 c)
+                                        (Var 226 c)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1188,7 +1188,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 228 c)
+                                        (Var 226 c)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -1196,6 +1196,469 @@
                                                 [((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 16 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 16 (Integer 4)))
+                                                ((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 16 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            ()
+                                            RowMajor
+                                        )
+                                        ()
+                                    )
+                                    (DoLoop
+                                        ()
+                                        ((Var 226 i)
+                                        (IntegerConstant 0 (Integer 4))
+                                        (IntegerBinOp
+                                            (IntegerConstant 16 (Integer 4))
+                                            Sub
+                                            (IntegerConstant 1 (Integer 4))
+                                            (Integer 4)
+                                            (IntegerConstant 15 (Integer 4))
+                                        )
+                                        (IntegerConstant 1 (Integer 4)))
+                                        [(DoLoop
+                                            ()
+                                            ((Var 226 j)
+                                            (IntegerConstant 0 (Integer 4))
+                                            (IntegerBinOp
+                                                (IntegerConstant 16 (Integer 4))
+                                                Sub
+                                                (IntegerConstant 1 (Integer 4))
+                                                (Integer 4)
+                                                (IntegerConstant 15 (Integer 4))
+                                            )
+                                            (IntegerConstant 1 (Integer 4)))
+                                            [(DoLoop
+                                                ()
+                                                ((Var 226 k)
+                                                (IntegerConstant 0 (Integer 4))
+                                                (IntegerBinOp
+                                                    (IntegerConstant 16 (Integer 4))
+                                                    Sub
+                                                    (IntegerConstant 1 (Integer 4))
+                                                    (Integer 4)
+                                                    (IntegerConstant 15 (Integer 4))
+                                                )
+                                                (IntegerConstant 1 (Integer 4)))
+                                                [(Assignment
+                                                    (ArrayItem
+                                                        (Var 226 c)
+                                                        [(()
+                                                        (Var 226 i)
+                                                        ())
+                                                        (()
+                                                        (Var 226 j)
+                                                        ())
+                                                        (()
+                                                        (Var 226 k)
+                                                        ())]
+                                                        (Real 8)
+                                                        RowMajor
+                                                        ()
+                                                    )
+                                                    (RealBinOp
+                                                        (Cast
+                                                            (IntegerBinOp
+                                                                (IntegerBinOp
+                                                                    (Var 226 i)
+                                                                    Add
+                                                                    (Var 226 j)
+                                                                    (Integer 4)
+                                                                    ()
+                                                                )
+                                                                Add
+                                                                (Var 226 k)
+                                                                (Integer 4)
+                                                                ()
+                                                            )
+                                                            IntegerToReal
+                                                            (Real 8)
+                                                            ()
+                                                        )
+                                                        Add
+                                                        (RealConstant
+                                                            0.500000
+                                                            (Real 8)
+                                                        )
+                                                        (Real 8)
+                                                        ()
+                                                    )
+                                                    ()
+                                                )]
+                                                []
+                                            )]
+                                            []
+                                        )]
+                                        []
+                                    )
+                                    (Assignment
+                                        (Var 226 d)
+                                        (ArrayConstructor
+                                            []
+                                            (Array
+                                                (Real 8)
+                                                [((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 4096 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            ()
+                                            RowMajor
+                                        )
+                                        ()
+                                    )
+                                    (Assignment
+                                        (Var 226 newshape1)
+                                        (ArrayConstructor
+                                            []
+                                            (Array
+                                                (Integer 4)
+                                                [((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 1 (Integer 4)))]
+                                                FixedSizeArray
+                                            )
+                                            ()
+                                            RowMajor
+                                        )
+                                        ()
+                                    )
+                                    (Assignment
+                                        (ArrayItem
+                                            (Var 226 newshape1)
+                                            [(()
+                                            (IntegerConstant 0 (Integer 4))
+                                            ())]
+                                            (Integer 4)
+                                            RowMajor
+                                            ()
+                                        )
+                                        (IntegerConstant 4096 (Integer 4))
+                                        ()
+                                    )
+                                    (Assignment
+                                        (Var 226 d)
+                                        (ArrayReshape
+                                            (Var 226 c)
+                                            (ArrayPhysicalCast
+                                                (Var 226 newshape1)
+                                                FixedSizeArray
+                                                DescriptorArray
+                                                (Array
+                                                    (Integer 4)
+                                                    [((IntegerConstant 0 (Integer 4))
+                                                    (IntegerConstant 1 (Integer 4)))]
+                                                    DescriptorArray
+                                                )
+                                                ()
+                                            )
+                                            (Array
+                                                (Real 8)
+                                                [(()
+                                                ())]
+                                                FixedSizeArray
+                                            )
+                                            ()
+                                        )
+                                        ()
+                                    )
+                                    (DoLoop
+                                        ()
+                                        ((Var 226 l)
+                                        (IntegerConstant 0 (Integer 4))
+                                        (IntegerBinOp
+                                            (IntegerConstant 4096 (Integer 4))
+                                            Sub
+                                            (IntegerConstant 1 (Integer 4))
+                                            (Integer 4)
+                                            (IntegerConstant 4095 (Integer 4))
+                                        )
+                                        (IntegerConstant 1 (Integer 4)))
+                                        [(Assignment
+                                            (Var 226 i)
+                                            (Cast
+                                                (RealBinOp
+                                                    (Cast
+                                                        (Var 226 l)
+                                                        IntegerToReal
+                                                        (Real 8)
+                                                        ()
+                                                    )
+                                                    Div
+                                                    (Cast
+                                                        (IntegerConstant 256 (Integer 4))
+                                                        IntegerToReal
+                                                        (Real 8)
+                                                        (RealConstant
+                                                            256.000000
+                                                            (Real 8)
+                                                        )
+                                                    )
+                                                    (Real 8)
+                                                    ()
+                                                )
+                                                RealToInteger
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            ()
+                                        )
+                                        (Assignment
+                                            (Var 226 j)
+                                            (IntrinsicElementalFunction
+                                                FloorDiv
+                                                [(IntegerBinOp
+                                                    (Var 226 l)
+                                                    Sub
+                                                    (IntegerBinOp
+                                                        (Var 226 i)
+                                                        Mul
+                                                        (IntegerConstant 256 (Integer 4))
+                                                        (Integer 4)
+                                                        ()
+                                                    )
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (IntegerConstant 16 (Integer 4))]
+                                                0
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            ()
+                                        )
+                                        (Assignment
+                                            (Var 226 k)
+                                            (IntegerBinOp
+                                                (IntegerBinOp
+                                                    (Var 226 l)
+                                                    Sub
+                                                    (IntegerBinOp
+                                                        (Var 226 i)
+                                                        Mul
+                                                        (IntegerConstant 256 (Integer 4))
+                                                        (Integer 4)
+                                                        ()
+                                                    )
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                Sub
+                                                (IntegerBinOp
+                                                    (Var 226 j)
+                                                    Mul
+                                                    (IntegerConstant 16 (Integer 4))
+                                                    (Integer 4)
+                                                    ()
+                                                )
+                                                (Integer 4)
+                                                ()
+                                            )
+                                            ()
+                                        )
+                                        (Assert
+                                            (RealCompare
+                                                (IntrinsicElementalFunction
+                                                    Abs
+                                                    [(RealBinOp
+                                                        (RealBinOp
+                                                            (ArrayItem
+                                                                (Var 226 d)
+                                                                [(()
+                                                                (Var 226 l)
+                                                                ())]
+                                                                (Real 8)
+                                                                RowMajor
+                                                                ()
+                                                            )
+                                                            Sub
+                                                            (Cast
+                                                                (IntegerBinOp
+                                                                    (IntegerBinOp
+                                                                        (Var 226 i)
+                                                                        Add
+                                                                        (Var 226 j)
+                                                                        (Integer 4)
+                                                                        ()
+                                                                    )
+                                                                    Add
+                                                                    (Var 226 k)
+                                                                    (Integer 4)
+                                                                    ()
+                                                                )
+                                                                IntegerToReal
+                                                                (Real 8)
+                                                                ()
+                                                            )
+                                                            (Real 8)
+                                                            ()
+                                                        )
+                                                        Sub
+                                                        (RealConstant
+                                                            0.500000
+                                                            (Real 8)
+                                                        )
+                                                        (Real 8)
+                                                        ()
+                                                    )]
+                                                    0
+                                                    (Real 8)
+                                                    ()
+                                                )
+                                                LtE
+                                                (Var 226 eps)
+                                                (Logical 4)
+                                                ()
+                                            )
+                                            ()
+                                        )]
+                                        []
+                                    )]
+                                    ()
+                                    Public
+                                    .false.
+                                    .false.
+                                    ()
+                                ),
+                            test_reshape_with_argument:
+                                (Function
+                                    (SymbolTable
+                                        228
+                                        {
+                                            a:
+                                                (Variable
+                                                    228
+                                                    a
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 8)
+                                                        [((IntegerConstant 0 (Integer 4))
+                                                        (IntegerConstant 16 (Integer 4)))
+                                                        ((IntegerConstant 0 (Integer 4))
+                                                        (IntegerConstant 16 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            d:
+                                                (Variable
+                                                    228
+                                                    d
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Array
+                                                        (Real 8)
+                                                        [((IntegerConstant 0 (Integer 4))
+                                                        (IntegerConstant 4096 (Integer 4)))]
+                                                        FixedSizeArray
+                                                    )
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            i:
+                                                (Variable
+                                                    228
+                                                    i
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            j:
+                                                (Variable
+                                                    228
+                                                    j
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            k:
+                                                (Variable
+                                                    228
+                                                    k
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                ),
+                                            l:
+                                                (Variable
+                                                    228
+                                                    l
+                                                    []
+                                                    Local
+                                                    ()
+                                                    ()
+                                                    Default
+                                                    (Integer 4)
+                                                    ()
+                                                    Source
+                                                    Public
+                                                    Required
+                                                    .false.
+                                                )
+                                        })
+                                    test_reshape_with_argument
+                                    (FunctionType
+                                        []
+                                        ()
+                                        Source
+                                        Implementation
+                                        ()
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        .false.
+                                        []
+                                        .false.
+                                    )
+                                    [test_nd_to_1d
+                                    test_1d_to_nd]
+                                    []
+                                    [(Assignment
+                                        (Var 228 a)
+                                        (ArrayConstructor
+                                            []
+                                            (Array
+                                                (Real 8)
+                                                [((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 16 (Integer 4)))
                                                 ((IntegerConstant 0 (Integer 4))
                                                 (IntegerConstant 16 (Integer 4)))]
@@ -1230,68 +1693,64 @@
                                                 (IntegerConstant 15 (Integer 4))
                                             )
                                             (IntegerConstant 1 (Integer 4)))
-                                            [(DoLoop
-                                                ()
-                                                ((Var 228 k)
-                                                (IntegerConstant 0 (Integer 4))
-                                                (IntegerBinOp
-                                                    (IntegerConstant 16 (Integer 4))
-                                                    Sub
-                                                    (IntegerConstant 1 (Integer 4))
-                                                    (Integer 4)
-                                                    (IntegerConstant 15 (Integer 4))
+                                            [(Assignment
+                                                (ArrayItem
+                                                    (Var 228 a)
+                                                    [(()
+                                                    (Var 228 i)
+                                                    ())
+                                                    (()
+                                                    (Var 228 j)
+                                                    ())]
+                                                    (Real 8)
+                                                    RowMajor
+                                                    ()
                                                 )
-                                                (IntegerConstant 1 (Integer 4)))
-                                                [(Assignment
-                                                    (ArrayItem
-                                                        (Var 228 c)
-                                                        [(()
-                                                        (Var 228 i)
-                                                        ())
-                                                        (()
-                                                        (Var 228 j)
-                                                        ())
-                                                        (()
-                                                        (Var 228 k)
-                                                        ())]
-                                                        (Real 8)
-                                                        RowMajor
-                                                        ()
-                                                    )
-                                                    (RealBinOp
-                                                        (Cast
-                                                            (IntegerBinOp
-                                                                (IntegerBinOp
-                                                                    (Var 228 i)
-                                                                    Add
-                                                                    (Var 228 j)
-                                                                    (Integer 4)
-                                                                    ()
-                                                                )
-                                                                Add
-                                                                (Var 228 k)
-                                                                (Integer 4)
-                                                                ()
-                                                            )
-                                                            IntegerToReal
-                                                            (Real 8)
+                                                (RealBinOp
+                                                    (Cast
+                                                        (IntegerBinOp
+                                                            (Var 228 i)
+                                                            Add
+                                                            (Var 228 j)
+                                                            (Integer 4)
                                                             ()
                                                         )
-                                                        Add
-                                                        (RealConstant
-                                                            0.500000
-                                                            (Real 8)
-                                                        )
+                                                        IntegerToReal
                                                         (Real 8)
                                                         ()
                                                     )
+                                                    Add
+                                                    (RealConstant
+                                                        0.500000
+                                                        (Real 8)
+                                                    )
+                                                    (Real 8)
                                                     ()
-                                                )]
-                                                []
+                                                )
+                                                ()
                                             )]
                                             []
                                         )]
                                         []
+                                    )
+                                    (SubroutineCall
+                                        2 test_nd_to_1d
+                                        ()
+                                        [((ArrayPhysicalCast
+                                            (Var 228 a)
+                                            FixedSizeArray
+                                            DescriptorArray
+                                            (Array
+                                                (Real 8)
+                                                [((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 16 (Integer 4)))
+                                                ((IntegerConstant 0 (Integer 4))
+                                                (IntegerConstant 16 (Integer 4)))]
+                                                DescriptorArray
+                                            )
+                                            ()
+                                        ))]
+                                        ()
                                     )
                                     (Assignment
                                         (Var 228 d)
@@ -1305,60 +1764,6 @@
                                             )
                                             ()
                                             RowMajor
-                                        )
-                                        ()
-                                    )
-                                    (Assignment
-                                        (Var 228 newshape1)
-                                        (ArrayConstructor
-                                            []
-                                            (Array
-                                                (Integer 4)
-                                                [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 1 (Integer 4)))]
-                                                FixedSizeArray
-                                            )
-                                            ()
-                                            RowMajor
-                                        )
-                                        ()
-                                    )
-                                    (Assignment
-                                        (ArrayItem
-                                            (Var 228 newshape1)
-                                            [(()
-                                            (IntegerConstant 0 (Integer 4))
-                                            ())]
-                                            (Integer 4)
-                                            RowMajor
-                                            ()
-                                        )
-                                        (IntegerConstant 4096 (Integer 4))
-                                        ()
-                                    )
-                                    (Assignment
-                                        (Var 228 d)
-                                        (ArrayReshape
-                                            (Var 228 c)
-                                            (ArrayPhysicalCast
-                                                (Var 228 newshape1)
-                                                FixedSizeArray
-                                                DescriptorArray
-                                                (Array
-                                                    (Integer 4)
-                                                    [((IntegerConstant 0 (Integer 4))
-                                                    (IntegerConstant 1 (Integer 4)))]
-                                                    DescriptorArray
-                                                )
-                                                ()
-                                            )
-                                            (Array
-                                                (Real 8)
-                                                [(()
-                                                ())]
-                                                FixedSizeArray
-                                            )
-                                            ()
                                         )
                                         ()
                                     )
@@ -1456,416 +1861,11 @@
                                             )
                                             ()
                                         )
-                                        (Assert
-                                            (RealCompare
-                                                (IntrinsicElementalFunction
-                                                    Abs
-                                                    [(RealBinOp
-                                                        (RealBinOp
-                                                            (ArrayItem
-                                                                (Var 228 d)
-                                                                [(()
-                                                                (Var 228 l)
-                                                                ())]
-                                                                (Real 8)
-                                                                RowMajor
-                                                                ()
-                                                            )
-                                                            Sub
-                                                            (Cast
-                                                                (IntegerBinOp
-                                                                    (IntegerBinOp
-                                                                        (Var 228 i)
-                                                                        Add
-                                                                        (Var 228 j)
-                                                                        (Integer 4)
-                                                                        ()
-                                                                    )
-                                                                    Add
-                                                                    (Var 228 k)
-                                                                    (Integer 4)
-                                                                    ()
-                                                                )
-                                                                IntegerToReal
-                                                                (Real 8)
-                                                                ()
-                                                            )
-                                                            (Real 8)
-                                                            ()
-                                                        )
-                                                        Sub
-                                                        (RealConstant
-                                                            0.500000
-                                                            (Real 8)
-                                                        )
-                                                        (Real 8)
-                                                        ()
-                                                    )]
-                                                    0
-                                                    (Real 8)
-                                                    ()
-                                                )
-                                                LtE
-                                                (Var 228 eps)
-                                                (Logical 4)
-                                                ()
-                                            )
-                                            ()
-                                        )]
-                                        []
-                                    )]
-                                    ()
-                                    Public
-                                    .false.
-                                    .false.
-                                    ()
-                                ),
-                            test_reshape_with_argument:
-                                (Function
-                                    (SymbolTable
-                                        230
-                                        {
-                                            a:
-                                                (Variable
-                                                    230
-                                                    a
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Array
-                                                        (Real 8)
-                                                        [((IntegerConstant 0 (Integer 4))
-                                                        (IntegerConstant 16 (Integer 4)))
-                                                        ((IntegerConstant 0 (Integer 4))
-                                                        (IntegerConstant 16 (Integer 4)))]
-                                                        FixedSizeArray
-                                                    )
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            d:
-                                                (Variable
-                                                    230
-                                                    d
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Array
-                                                        (Real 8)
-                                                        [((IntegerConstant 0 (Integer 4))
-                                                        (IntegerConstant 4096 (Integer 4)))]
-                                                        FixedSizeArray
-                                                    )
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            i:
-                                                (Variable
-                                                    230
-                                                    i
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            j:
-                                                (Variable
-                                                    230
-                                                    j
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            k:
-                                                (Variable
-                                                    230
-                                                    k
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                ),
-                                            l:
-                                                (Variable
-                                                    230
-                                                    l
-                                                    []
-                                                    Local
-                                                    ()
-                                                    ()
-                                                    Default
-                                                    (Integer 4)
-                                                    ()
-                                                    Source
-                                                    Public
-                                                    Required
-                                                    .false.
-                                                )
-                                        })
-                                    test_reshape_with_argument
-                                    (FunctionType
-                                        []
-                                        ()
-                                        Source
-                                        Implementation
-                                        ()
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        .false.
-                                        []
-                                        .false.
-                                    )
-                                    [test_nd_to_1d
-                                    test_1d_to_nd]
-                                    []
-                                    [(Assignment
-                                        (Var 230 a)
-                                        (ArrayConstructor
-                                            []
-                                            (Array
-                                                (Real 8)
-                                                [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 16 (Integer 4)))
-                                                ((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 16 (Integer 4)))]
-                                                FixedSizeArray
-                                            )
-                                            ()
-                                            RowMajor
-                                        )
-                                        ()
-                                    )
-                                    (DoLoop
-                                        ()
-                                        ((Var 230 i)
-                                        (IntegerConstant 0 (Integer 4))
-                                        (IntegerBinOp
-                                            (IntegerConstant 16 (Integer 4))
-                                            Sub
-                                            (IntegerConstant 1 (Integer 4))
-                                            (Integer 4)
-                                            (IntegerConstant 15 (Integer 4))
-                                        )
-                                        (IntegerConstant 1 (Integer 4)))
-                                        [(DoLoop
-                                            ()
-                                            ((Var 230 j)
-                                            (IntegerConstant 0 (Integer 4))
-                                            (IntegerBinOp
-                                                (IntegerConstant 16 (Integer 4))
-                                                Sub
-                                                (IntegerConstant 1 (Integer 4))
-                                                (Integer 4)
-                                                (IntegerConstant 15 (Integer 4))
-                                            )
-                                            (IntegerConstant 1 (Integer 4)))
-                                            [(Assignment
-                                                (ArrayItem
-                                                    (Var 230 a)
-                                                    [(()
-                                                    (Var 230 i)
-                                                    ())
-                                                    (()
-                                                    (Var 230 j)
-                                                    ())]
-                                                    (Real 8)
-                                                    RowMajor
-                                                    ()
-                                                )
-                                                (RealBinOp
-                                                    (Cast
-                                                        (IntegerBinOp
-                                                            (Var 230 i)
-                                                            Add
-                                                            (Var 230 j)
-                                                            (Integer 4)
-                                                            ()
-                                                        )
-                                                        IntegerToReal
-                                                        (Real 8)
-                                                        ()
-                                                    )
-                                                    Add
-                                                    (RealConstant
-                                                        0.500000
-                                                        (Real 8)
-                                                    )
-                                                    (Real 8)
-                                                    ()
-                                                )
-                                                ()
-                                            )]
-                                            []
-                                        )]
-                                        []
-                                    )
-                                    (SubroutineCall
-                                        2 test_nd_to_1d
-                                        ()
-                                        [((ArrayPhysicalCast
-                                            (Var 230 a)
-                                            FixedSizeArray
-                                            DescriptorArray
-                                            (Array
-                                                (Real 8)
-                                                [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 16 (Integer 4)))
-                                                ((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 16 (Integer 4)))]
-                                                DescriptorArray
-                                            )
-                                            ()
-                                        ))]
-                                        ()
-                                    )
-                                    (Assignment
-                                        (Var 230 d)
-                                        (ArrayConstructor
-                                            []
-                                            (Array
-                                                (Real 8)
-                                                [((IntegerConstant 0 (Integer 4))
-                                                (IntegerConstant 4096 (Integer 4)))]
-                                                FixedSizeArray
-                                            )
-                                            ()
-                                            RowMajor
-                                        )
-                                        ()
-                                    )
-                                    (DoLoop
-                                        ()
-                                        ((Var 230 l)
-                                        (IntegerConstant 0 (Integer 4))
-                                        (IntegerBinOp
-                                            (IntegerConstant 4096 (Integer 4))
-                                            Sub
-                                            (IntegerConstant 1 (Integer 4))
-                                            (Integer 4)
-                                            (IntegerConstant 4095 (Integer 4))
-                                        )
-                                        (IntegerConstant 1 (Integer 4)))
-                                        [(Assignment
-                                            (Var 230 i)
-                                            (Cast
-                                                (RealBinOp
-                                                    (Cast
-                                                        (Var 230 l)
-                                                        IntegerToReal
-                                                        (Real 8)
-                                                        ()
-                                                    )
-                                                    Div
-                                                    (Cast
-                                                        (IntegerConstant 256 (Integer 4))
-                                                        IntegerToReal
-                                                        (Real 8)
-                                                        (RealConstant
-                                                            256.000000
-                                                            (Real 8)
-                                                        )
-                                                    )
-                                                    (Real 8)
-                                                    ()
-                                                )
-                                                RealToInteger
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            ()
-                                        )
-                                        (Assignment
-                                            (Var 230 j)
-                                            (IntrinsicElementalFunction
-                                                FloorDiv
-                                                [(IntegerBinOp
-                                                    (Var 230 l)
-                                                    Sub
-                                                    (IntegerBinOp
-                                                        (Var 230 i)
-                                                        Mul
-                                                        (IntegerConstant 256 (Integer 4))
-                                                        (Integer 4)
-                                                        ()
-                                                    )
-                                                    (Integer 4)
-                                                    ()
-                                                )
-                                                (IntegerConstant 16 (Integer 4))]
-                                                0
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            ()
-                                        )
-                                        (Assignment
-                                            (Var 230 k)
-                                            (IntegerBinOp
-                                                (IntegerBinOp
-                                                    (Var 230 l)
-                                                    Sub
-                                                    (IntegerBinOp
-                                                        (Var 230 i)
-                                                        Mul
-                                                        (IntegerConstant 256 (Integer 4))
-                                                        (Integer 4)
-                                                        ()
-                                                    )
-                                                    (Integer 4)
-                                                    ()
-                                                )
-                                                Sub
-                                                (IntegerBinOp
-                                                    (Var 230 j)
-                                                    Mul
-                                                    (IntegerConstant 16 (Integer 4))
-                                                    (Integer 4)
-                                                    ()
-                                                )
-                                                (Integer 4)
-                                                ()
-                                            )
-                                            ()
-                                        )
                                         (Assignment
                                             (ArrayItem
-                                                (Var 230 d)
+                                                (Var 228 d)
                                                 [(()
-                                                (Var 230 l)
+                                                (Var 228 l)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -1875,14 +1875,14 @@
                                                 (Cast
                                                     (IntegerBinOp
                                                         (IntegerBinOp
-                                                            (Var 230 i)
+                                                            (Var 228 i)
                                                             Add
-                                                            (Var 230 j)
+                                                            (Var 228 j)
                                                             (Integer 4)
                                                             ()
                                                         )
                                                         Add
-                                                        (Var 230 k)
+                                                        (Var 228 k)
                                                         (Integer 4)
                                                         ()
                                                     )
@@ -1906,7 +1906,7 @@
                                         2 test_1d_to_nd
                                         ()
                                         [((ArrayPhysicalCast
-                                            (Var 230 d)
+                                            (Var 228 d)
                                             FixedSizeArray
                                             DescriptorArray
                                             (Array
@@ -1936,11 +1936,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        246
+                        244
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    246
+                                    244
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -1952,7 +1952,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        246 __main__global_stmts
+                        244 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_numpy_04-ecbb614.json
+++ b/tests/reference/asr-test_numpy_04-ecbb614.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_numpy_04-ecbb614.stdout",
-    "stdout_hash": "f19bfb437f886c57e96adc17fbe7c9e30112eeb2d31ff71051024917",
+    "stdout_hash": "e54a0a88fdbc84f91eafdbbc6b24ce565a8ffb332f55ad4837718c64",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-test_numpy_04-ecbb614.stdout
+++ b/tests/reference/asr-test_numpy_04-ecbb614.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        231
+                                        229
                                         {
                                             
                                         })
@@ -46,7 +46,7 @@
                             check:
                                 (Function
                                     (SymbolTable
-                                        230
+                                        228
                                         {
                                             
                                         })
@@ -89,11 +89,11 @@
                             test_array_01:
                                 (Function
                                     (SymbolTable
-                                        228
+                                        226
                                         {
                                             eps:
                                                 (Variable
-                                                    228
+                                                    226
                                                     eps
                                                     []
                                                     Local
@@ -109,7 +109,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    228
+                                                    226
                                                     x
                                                     []
                                                     Local
@@ -147,7 +147,7 @@
                                     []
                                     []
                                     [(Assignment
-                                        (Var 228 x)
+                                        (Var 226 x)
                                         (ArrayConstant
                                             [(RealConstant
                                                 1.000000
@@ -172,7 +172,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 228 eps)
+                                        (Var 226 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -185,7 +185,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 228 x)
+                                                        (Var 226 x)
                                                         [(()
                                                         (IntegerConstant 0 (Integer 4))
                                                         ())]
@@ -206,7 +206,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 228 eps)
+                                            (Var 226 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -218,7 +218,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 228 x)
+                                                        (Var 226 x)
                                                         [(()
                                                         (IntegerConstant 1 (Integer 4))
                                                         ())]
@@ -239,7 +239,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 228 eps)
+                                            (Var 226 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -251,7 +251,7 @@
                                                 Abs
                                                 [(RealBinOp
                                                     (ArrayItem
-                                                        (Var 228 x)
+                                                        (Var 226 x)
                                                         [(()
                                                         (IntegerConstant 2 (Integer 4))
                                                         ())]
@@ -272,7 +272,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 228 eps)
+                                            (Var 226 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -287,11 +287,11 @@
                             test_array_02:
                                 (Function
                                     (SymbolTable
-                                        229
+                                        227
                                         {
                                             eps:
                                                 (Variable
-                                                    229
+                                                    227
                                                     eps
                                                     []
                                                     Local
@@ -307,7 +307,7 @@
                                                 ),
                                             x:
                                                 (Variable
-                                                    229
+                                                    227
                                                     x
                                                     []
                                                     Local
@@ -345,7 +345,7 @@
                                     []
                                     []
                                     [(Assignment
-                                        (Var 229 x)
+                                        (Var 227 x)
                                         (ArrayConstant
                                             [(IntegerConstant 1 (Integer 4))
                                             (IntegerConstant 2 (Integer 4))
@@ -361,7 +361,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 229 eps)
+                                        (Var 227 eps)
                                         (RealConstant
                                             0.000000
                                             (Real 8)
@@ -375,7 +375,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 229 x)
+                                                            (Var 227 x)
                                                             [(()
                                                             (IntegerConstant 0 (Integer 4))
                                                             ())]
@@ -397,7 +397,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 229 eps)
+                                            (Var 227 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -410,7 +410,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 229 x)
+                                                            (Var 227 x)
                                                             [(()
                                                             (IntegerConstant 1 (Integer 4))
                                                             ())]
@@ -432,7 +432,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 229 eps)
+                                            (Var 227 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -445,7 +445,7 @@
                                                     Abs
                                                     [(IntegerBinOp
                                                         (ArrayItem
-                                                            (Var 229 x)
+                                                            (Var 227 x)
                                                             [(()
                                                             (IntegerConstant 2 (Integer 4))
                                                             ())]
@@ -467,7 +467,7 @@
                                                 ()
                                             )
                                             Lt
-                                            (Var 229 eps)
+                                            (Var 227 eps)
                                             (Logical 4)
                                             ()
                                         )
@@ -490,11 +490,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        232
+                        230
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    232
+                                    230
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -506,7 +506,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        232 __main__global_stmts
+                        230 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-test_pow-3f5d550.json
+++ b/tests/reference/asr-test_pow-3f5d550.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-test_pow-3f5d550.stdout",
-    "stdout_hash": "f3e4a4900d210a8b43d4f1d8484c54470e7e3d418ccdaacdb76f42fd",
+    "stdout_hash": "dcb48d62a5fef4d9e6bd002df7ace47222b96f908e8abcff6ee0469b",
     "stderr": "asr-test_pow-3f5d550.stderr",
     "stderr_hash": "3d950301563cce75654f28bf41f6f53428ed1f5ae997774345f374a3",
     "returncode": 0

--- a/tests/reference/asr-test_pow-3f5d550.stdout
+++ b/tests/reference/asr-test_pow-3f5d550.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        144
+                                        142
                                         {
                                             
                                         })
@@ -130,11 +130,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        145
+                        143
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    145
+                                    143
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -146,7 +146,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        145 __main__global_stmts
+                        143 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/asr-vec_01-66ac423.json
+++ b/tests/reference/asr-vec_01-66ac423.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-vec_01-66ac423.stdout",
-    "stdout_hash": "11888d2d6b51ccb637ca4828824934e3bb4292511a120c19e057d9dc",
+    "stdout_hash": "d274b5c52f919a4711e6af28d76199fd5c59446a489a339d098438d7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-vec_01-66ac423.stdout
+++ b/tests/reference/asr-vec_01-66ac423.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        232
+                                        230
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             loop_vec:
                                 (Function
                                     (SymbolTable
-                                        228
+                                        226
                                         {
                                             a:
                                                 (Variable
-                                                    228
+                                                    226
                                                     a
                                                     []
                                                     Local
@@ -71,7 +71,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    228
+                                                    226
                                                     b
                                                     []
                                                     Local
@@ -92,7 +92,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    228
+                                                    226
                                                     i
                                                     []
                                                     Local
@@ -125,7 +125,7 @@
                                     []
                                     []
                                     [(Assignment
-                                        (Var 228 a)
+                                        (Var 226 a)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -140,7 +140,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 228 b)
+                                        (Var 226 b)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -156,7 +156,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 228 i)
+                                        ((Var 226 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -168,9 +168,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
                                             (ArrayItem
-                                                (Var 228 b)
+                                                (Var 226 b)
                                                 [(()
-                                                (Var 228 i)
+                                                (Var 226 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -186,7 +186,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 228 i)
+                                        ((Var 226 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -198,18 +198,18 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
                                             (ArrayItem
-                                                (Var 228 a)
+                                                (Var 226 a)
                                                 [(()
-                                                (Var 228 i)
+                                                (Var 226 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
                                                 ()
                                             )
                                             (ArrayItem
-                                                (Var 228 b)
+                                                (Var 226 b)
                                                 [(()
-                                                (Var 228 i)
+                                                (Var 226 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -221,7 +221,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 228 i)
+                                        ((Var 226 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -234,9 +234,9 @@
                                         [(Assert
                                             (RealCompare
                                                 (ArrayItem
-                                                    (Var 228 a)
+                                                    (Var 226 a)
                                                     [(()
-                                                    (Var 228 i)
+                                                    (Var 226 i)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -271,11 +271,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        233
+                        231
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    233
+                                    231
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -287,7 +287,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        233 __main__global_stmts
+                        231 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()

--- a/tests/reference/c-expr7-bb2692a.json
+++ b/tests/reference/c-expr7-bb2692a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "c-expr7-bb2692a.stdout",
-    "stdout_hash": "92e36dc1146bef152cab7c8086ce6de203a3d966dc5415331bd27257",
+    "stdout_hash": "f1014d9b9d4462e529064c23b3df5b8c3d2fe7b387296c853192b955",
     "stderr": "c-expr7-bb2692a.stderr",
     "stderr_hash": "6e9790ac88db1a9ead8f64a91ba8a6605de67167037908a74b77be0c",
     "returncode": 0

--- a/tests/reference/c-expr7-bb2692a.stdout
+++ b/tests/reference/c-expr7-bb2692a.stdout
@@ -1,4 +1,3 @@
-#include <complex.h>
 #include <inttypes.h>
 #include <math.h>
 
@@ -22,10 +21,6 @@ double __lpython_overloaded_0__pow(int32_t x, int32_t y)
     _lpython_return_variable = (double)(pow(x, y));
     return _lpython_return_variable;
 }
-
-float _lfortran_caimag(float_complex_t x);
-
-double _lfortran_zaimag(double_complex_t x);
 
 void test_pow()
 {

--- a/tests/reference/cpp-expr15-1661c0d.json
+++ b/tests/reference/cpp-expr15-1661c0d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr15-1661c0d.stdout",
-    "stdout_hash": "c6660bd5efa0a0602ea96a86d5c44220cb4390dea4eebf4cb16211bc",
+    "stdout_hash": "89ea3f4e66182b1d6619b5babff51fde20752f5940bdfa027f9e9aa4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/cpp-expr15-1661c0d.stdout
+++ b/tests/reference/cpp-expr15-1661c0d.stdout
@@ -23,8 +23,6 @@ double test1();
 std::complex<double> test2();
 int32_t test3();
 std::complex<double> __lpython_overloaded_9__complex(int32_t x, int32_t y);
-float _lfortran_caimag(std::complex<float> x);
-double _lfortran_zaimag(std::complex<double> x);
 namespace {
 }
 
@@ -35,10 +33,6 @@ std::complex<double> __lpython_overloaded_9__complex(int32_t x, int32_t y)
     _lpython_return_variable = std::complex<double>(x) + std::complex<double>(y)*std::complex<double>(0.000000, 1.000000);
     return _lpython_return_variable;
 }
-
-float _lfortran_caimag(std::complex<float> x);
-
-double _lfortran_zaimag(std::complex<double> x);
 
 double test1()
 {

--- a/tests/reference/cpp-expr7-529bd53.json
+++ b/tests/reference/cpp-expr7-529bd53.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-expr7-529bd53.stdout",
-    "stdout_hash": "8f72ce4b2d8f170884e171b1bdfa4a4ea07344825b6787d814a446cf",
+    "stdout_hash": "24b9dbec9975483d188f9ff05d5bda7117eb1b6d618424118db3e359",
     "stderr": "cpp-expr7-529bd53.stderr",
     "stderr_hash": "6e9790ac88db1a9ead8f64a91ba8a6605de67167037908a74b77be0c",
     "returncode": 0

--- a/tests/reference/cpp-expr7-529bd53.stdout
+++ b/tests/reference/cpp-expr7-529bd53.stdout
@@ -23,8 +23,6 @@ void main0();
 void test_pow();
 int32_t test_pow_1(int32_t a, int32_t b);
 double __lpython_overloaded_0__pow(int32_t x, int32_t y);
-float _lfortran_caimag(std::complex<float> x);
-double _lfortran_zaimag(std::complex<double> x);
 namespace {
 }
 
@@ -35,10 +33,6 @@ double __lpython_overloaded_0__pow(int32_t x, int32_t y)
     _lpython_return_variable = (double)(std::pow(x, y));
     return _lpython_return_variable;
 }
-
-float _lfortran_caimag(std::complex<float> x);
-
-double _lfortran_zaimag(std::complex<double> x);
 
 void test_pow()
 {

--- a/tests/reference/cpp-test_builtin_pow-56b3f92.json
+++ b/tests/reference/cpp-test_builtin_pow-56b3f92.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "cpp-test_builtin_pow-56b3f92.stdout",
-    "stdout_hash": "dec0af96e013cd38032672f4812f876e586bf697757278addd17b591",
+    "stdout_hash": "1ba4554c50fe8ead16dca0fd1370e2255261d28724e6f9aa3a17543f",
     "stderr": "cpp-test_builtin_pow-56b3f92.stderr",
     "stderr_hash": "859ce76c74748f2d32c7eab92cfbba789a78d4cbf5818646b99806ea",
     "returncode": 0

--- a/tests/reference/cpp-test_builtin_pow-56b3f92.stdout
+++ b/tests/reference/cpp-test_builtin_pow-56b3f92.stdout
@@ -36,8 +36,6 @@ int64_t __lpython_overloaded_8___mod(int64_t a, int64_t b);
 int32_t __lpython_overloaded_8__pow(bool x, bool y);
 std::complex<double> __lpython_overloaded_9__complex(int32_t x, int32_t y);
 std::complex<float> __lpython_overloaded_9__pow(std::complex<float> c, int32_t y);
-float _lfortran_caimag(std::complex<float> x);
-double _lfortran_zaimag(std::complex<double> x);
 namespace {
 }
 
@@ -162,10 +160,6 @@ std::complex<float> __lpython_overloaded_9__pow(std::complex<float> c, int32_t y
     _lpython_return_variable = std::pow(c, std::complex<double>(y));
     return _lpython_return_variable;
 }
-
-float _lfortran_caimag(std::complex<float> x);
-
-double _lfortran_zaimag(std::complex<double> x);
 
 void test_pow()
 {

--- a/tests/reference/pass_loop_vectorise-vec_01-be9985e.json
+++ b/tests/reference/pass_loop_vectorise-vec_01-be9985e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_loop_vectorise-vec_01-be9985e.stdout",
-    "stdout_hash": "a5ba6cadd177ba6fad5a403bb43e9dcf177dfcd7df661db6c43eb737",
+    "stdout_hash": "477d833ef6932a780cad4c5214b9dfbd7979b18abf70b31bc57a9cd1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_loop_vectorise-vec_01-be9985e.stdout
+++ b/tests/reference/pass_loop_vectorise-vec_01-be9985e.stdout
@@ -10,7 +10,7 @@
                             __main__global_stmts:
                                 (Function
                                     (SymbolTable
-                                        232
+                                        230
                                         {
                                             
                                         })
@@ -46,11 +46,11 @@
                             loop_vec:
                                 (Function
                                     (SymbolTable
-                                        228
+                                        226
                                         {
                                             a:
                                                 (Variable
-                                                    228
+                                                    226
                                                     a
                                                     []
                                                     Local
@@ -71,7 +71,7 @@
                                                 ),
                                             b:
                                                 (Variable
-                                                    228
+                                                    226
                                                     b
                                                     []
                                                     Local
@@ -92,7 +92,7 @@
                                                 ),
                                             i:
                                                 (Variable
-                                                    228
+                                                    226
                                                     i
                                                     []
                                                     Local
@@ -109,11 +109,11 @@
                                             vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization:
                                                 (Function
                                                     (SymbolTable
-                                                        234
+                                                        232
                                                         {
                                                             __1_k:
                                                                 (Variable
-                                                                    234
+                                                                    232
                                                                     __1_k
                                                                     []
                                                                     Local
@@ -129,7 +129,7 @@
                                                                 ),
                                                             arg0:
                                                                 (Variable
-                                                                    234
+                                                                    232
                                                                     arg0
                                                                     []
                                                                     In
@@ -150,7 +150,7 @@
                                                                 ),
                                                             arg1:
                                                                 (Variable
-                                                                    234
+                                                                    232
                                                                     arg1
                                                                     []
                                                                     In
@@ -171,7 +171,7 @@
                                                                 ),
                                                             arg2:
                                                                 (Variable
-                                                                    234
+                                                                    232
                                                                     arg2
                                                                     []
                                                                     In
@@ -187,7 +187,7 @@
                                                                 ),
                                                             arg3:
                                                                 (Variable
-                                                                    234
+                                                                    232
                                                                     arg3
                                                                     []
                                                                     In
@@ -203,7 +203,7 @@
                                                                 ),
                                                             arg4:
                                                                 (Variable
-                                                                    234
+                                                                    232
                                                                     arg4
                                                                     []
                                                                     In
@@ -219,7 +219,7 @@
                                                                 ),
                                                             arg5:
                                                                 (Variable
-                                                                    234
+                                                                    232
                                                                     arg5
                                                                     []
                                                                     In
@@ -265,18 +265,18 @@
                                                         .false.
                                                     )
                                                     []
-                                                    [(Var 234 arg0)
-                                                    (Var 234 arg1)
-                                                    (Var 234 arg2)
-                                                    (Var 234 arg3)
-                                                    (Var 234 arg4)
-                                                    (Var 234 arg5)]
+                                                    [(Var 232 arg0)
+                                                    (Var 232 arg1)
+                                                    (Var 232 arg2)
+                                                    (Var 232 arg3)
+                                                    (Var 232 arg4)
+                                                    (Var 232 arg5)]
                                                     [(Assignment
-                                                        (Var 234 __1_k)
+                                                        (Var 232 __1_k)
                                                         (IntegerBinOp
-                                                            (Var 234 arg2)
+                                                            (Var 232 arg2)
                                                             Sub
-                                                            (Var 234 arg4)
+                                                            (Var 232 arg4)
                                                             (Integer 4)
                                                             ()
                                                         )
@@ -286,23 +286,23 @@
                                                         ()
                                                         (IntegerCompare
                                                             (IntegerBinOp
-                                                                (Var 234 __1_k)
+                                                                (Var 232 __1_k)
                                                                 Add
-                                                                (Var 234 arg4)
+                                                                (Var 232 arg4)
                                                                 (Integer 4)
                                                                 ()
                                                             )
                                                             Lt
-                                                            (Var 234 arg3)
+                                                            (Var 232 arg3)
                                                             (Logical 4)
                                                             ()
                                                         )
                                                         [(Assignment
-                                                            (Var 234 __1_k)
+                                                            (Var 232 __1_k)
                                                             (IntegerBinOp
-                                                                (Var 234 __1_k)
+                                                                (Var 232 __1_k)
                                                                 Add
-                                                                (Var 234 arg4)
+                                                                (Var 232 arg4)
                                                                 (Integer 4)
                                                                 ()
                                                             )
@@ -310,18 +310,18 @@
                                                         )
                                                         (Assignment
                                                             (ArrayItem
-                                                                (Var 234 arg0)
+                                                                (Var 232 arg0)
                                                                 [(()
-                                                                (Var 234 __1_k)
+                                                                (Var 232 __1_k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
                                                                 ()
                                                             )
                                                             (ArrayItem
-                                                                (Var 234 arg1)
+                                                                (Var 232 arg1)
                                                                 [(()
-                                                                (Var 234 __1_k)
+                                                                (Var 232 __1_k)
                                                                 ())]
                                                                 (Real 8)
                                                                 RowMajor
@@ -356,7 +356,7 @@
                                     []
                                     []
                                     [(Assignment
-                                        (Var 228 a)
+                                        (Var 226 a)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -371,7 +371,7 @@
                                         ()
                                     )
                                     (Assignment
-                                        (Var 228 b)
+                                        (Var 226 b)
                                         (ArrayConstructor
                                             []
                                             (Array
@@ -387,7 +387,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 228 i)
+                                        ((Var 226 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -399,9 +399,9 @@
                                         (IntegerConstant 1 (Integer 4)))
                                         [(Assignment
                                             (ArrayItem
-                                                (Var 228 b)
+                                                (Var 226 b)
                                                 [(()
-                                                (Var 228 i)
+                                                (Var 226 i)
                                                 ())]
                                                 (Real 8)
                                                 RowMajor
@@ -417,17 +417,17 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 228 i)
+                                        ((Var 226 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerConstant 1151 (Integer 4))
                                         (IntegerConstant 1 (Integer 4)))
                                         [(SubroutineCall
-                                            228 vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization
+                                            226 vector_copy_f64[9216]f64[9216]i32@IntrinsicOptimization
                                             ()
-                                            [((Var 228 a))
-                                            ((Var 228 b))
+                                            [((Var 226 a))
+                                            ((Var 226 b))
                                             ((IntegerBinOp
-                                                (Var 228 i)
+                                                (Var 226 i)
                                                 Mul
                                                 (IntegerConstant 8 (Integer 4))
                                                 (Integer 4)
@@ -435,7 +435,7 @@
                                             ))
                                             ((IntegerBinOp
                                                 (IntegerBinOp
-                                                    (Var 228 i)
+                                                    (Var 226 i)
                                                     Add
                                                     (IntegerConstant 1 (Integer 4))
                                                     (Integer 4)
@@ -454,7 +454,7 @@
                                     )
                                     (DoLoop
                                         ()
-                                        ((Var 228 i)
+                                        ((Var 226 i)
                                         (IntegerConstant 0 (Integer 4))
                                         (IntegerBinOp
                                             (IntegerConstant 9216 (Integer 4))
@@ -467,9 +467,9 @@
                                         [(Assert
                                             (RealCompare
                                                 (ArrayItem
-                                                    (Var 228 a)
+                                                    (Var 226 a)
                                                     [(()
-                                                    (Var 228 i)
+                                                    (Var 226 i)
                                                     ())]
                                                     (Real 8)
                                                     RowMajor
@@ -504,11 +504,11 @@
             main_program:
                 (Program
                     (SymbolTable
-                        233
+                        231
                         {
                             __main__global_stmts:
                                 (ExternalSymbol
-                                    233
+                                    231
                                     __main__global_stmts
                                     2 __main__global_stmts
                                     __main__
@@ -520,7 +520,7 @@
                     main_program
                     [__main__]
                     [(SubroutineCall
-                        233 __main__global_stmts
+                        231 __main__global_stmts
                         2 __main__global_stmts
                         []
                         ()


### PR DESCRIPTION
Fixes: #2703 