### PR TITLE
Initialize empty value to dictionaries without type given

### DIFF
--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -2569,10 +2569,6 @@ public:
         std::string var_name = v_variable->m_name;
         ASR::ttype_t* type = v_variable->m_type;
         if (!init_expr && ASR::is_a<ASR::Dict_t>(*type)) {
-            ASR::ttype_t *key_type = ASR::down_cast<ASR::Dict_t>(type)->m_key_type;
-            ASR::ttype_t *value_type = ASR::down_cast<ASR::Dict_t>(type)->m_value_type;
-            ASR::ttype_t *dict_type = ASRUtils::TYPE(ASR::make_Dict_t(al, loc,
-                                                 key_type, value_type));
             init_expr = ASRUtils::EXPR(ASR::make_DictConstant_t(al, loc, 
                   nullptr, 0, nullptr, 0, type));
         }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -2568,6 +2568,15 @@ public:
         ASR::Variable_t* v_variable = ASR::down_cast<ASR::Variable_t>(v_sym);
         std::string var_name = v_variable->m_name;
         ASR::ttype_t* type = v_variable->m_type;
+        if (!init_expr && ASR::is_a<ASR::Dict_t>(*type)) {
+            ASR::ttype_t *key_type = ASR::down_cast<ASR::Dict_t>(type)->m_key_type;
+            ASR::ttype_t *value_type = ASR::down_cast<ASR::Dict_t>(type)->m_value_type;
+            ASR::ttype_t *dict_type = ASRUtils::TYPE(ASR::make_Dict_t(al, loc,
+                                                 key_type, value_type));
+            init_expr = ASRUtils::EXPR(ASR::make_DictConstant_t(al, loc, 
+                  nullptr, 0, nullptr, 0, type));
+        }
+
         if( init_expr ) {
             value = ASRUtils::expr_value(init_expr);
             SetChar variable_dependencies_vec;

--- a/tests/reference/asr-dictionary1-a105a36.json
+++ b/tests/reference/asr-dictionary1-a105a36.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-dictionary1-a105a36.stdout",
-    "stdout_hash": "3ea42309cc8f2201f43bb2fdeb28a85feea890fe49db4063af5c46f8",
+    "stdout_hash": "ac58817e3dc84de980d646cffeb63540c55bde9ca4229b8a7c58b77a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-dictionary1-a105a36.stdout
+++ b/tests/reference/asr-dictionary1-a105a36.stdout
@@ -143,12 +143,36 @@
                                     [(Assignment
                                         (Var 3 x)
                                         (DictConstant
+                                            []
+                                            []
+                                            (Dict
+                                                (Integer 4)
+                                                (Integer 4)
+                                            )
+                                        )
+                                        ()
+                                    )
+                                    (Assignment
+                                        (Var 3 x)
+                                        (DictConstant
                                             [(IntegerConstant 1 (Integer 4))
                                             (IntegerConstant 3 (Integer 4))]
                                             [(IntegerConstant 2 (Integer 4))
                                             (IntegerConstant 4 (Integer 4))]
                                             (Dict
                                                 (Integer 4)
+                                                (Integer 4)
+                                            )
+                                        )
+                                        ()
+                                    )
+                                    (Assignment
+                                        (Var 3 y)
+                                        (DictConstant
+                                            []
+                                            []
+                                            (Dict
+                                                (Character 1 -2 ())
                                                 (Integer 4)
                                             )
                                         )
@@ -288,6 +312,18 @@
                                     [(Assignment
                                         (Var 5 y)
                                         (DictConstant
+                                            []
+                                            []
+                                            (Dict
+                                                (Character 1 -2 ())
+                                                (Integer 4)
+                                            )
+                                        )
+                                        ()
+                                    )
+                                    (Assignment
+                                        (Var 5 y)
+                                        (DictConstant
                                             [(StringConstant
                                                 "a"
                                                 (Character 1 1 ())
@@ -390,6 +426,18 @@
                                     []
                                     []
                                     [(Assignment
+                                        (Var 4 y)
+                                        (DictConstant
+                                            []
+                                            []
+                                            (Dict
+                                                (Character 1 -2 ())
+                                                (Integer 4)
+                                            )
+                                        )
+                                        ()
+                                    )
+                                    (Assignment
                                         (Var 4 y)
                                         (DictConstant
                                             [(StringConstant
@@ -496,6 +544,18 @@
                                     [(Assignment
                                         (Var 6 y)
                                         (DictConstant
+                                            []
+                                            []
+                                            (Dict
+                                                (Character 1 -2 ())
+                                                (Integer 4)
+                                            )
+                                        )
+                                        ()
+                                    )
+                                    (Assignment
+                                        (Var 6 y)
+                                        (DictConstant
                                             [(StringConstant
                                                 "a"
                                                 (Character 1 1 ())
@@ -574,7 +634,19 @@
                                     )
                                     [f]
                                     []
-                                    [(SubroutineCall
+                                    [(Assignment
+                                        (Var 8 x)
+                                        (DictConstant
+                                            []
+                                            []
+                                            (Dict
+                                                (Integer 4)
+                                                (Integer 4)
+                                            )
+                                        )
+                                        ()
+                                    )
+                                    (SubroutineCall
                                         2 f
                                         ()
                                         [((Var 8 x))]

--- a/tests/reference/asr-print_list_tuple_03-9de3736.json
+++ b/tests/reference/asr-print_list_tuple_03-9de3736.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-print_list_tuple_03-9de3736.stdout",
-    "stdout_hash": "8962f3d49727ceb8f899acc2382f5fb6d24b16506a154ccf907400f5",
+    "stdout_hash": "9bc9712a40c386ddbd519614bb9ed900ebde24b5db7d0876f7e88e95",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-print_list_tuple_03-9de3736.stdout
+++ b/tests/reference/asr-print_list_tuple_03-9de3736.stdout
@@ -112,6 +112,21 @@
                                     [(Assignment
                                         (Var 3 x)
                                         (DictConstant
+                                            []
+                                            []
+                                            (Dict
+                                                (Integer 4)
+                                                (Tuple
+                                                    [(Integer 4)
+                                                    (Integer 4)]
+                                                )
+                                            )
+                                        )
+                                        ()
+                                    )
+                                    (Assignment
+                                        (Var 3 x)
+                                        (DictConstant
                                             [(IntegerConstant 1 (Integer 4))
                                             (IntegerConstant 2 (Integer 4))]
                                             [(TupleConstant
@@ -135,6 +150,20 @@
                                                 (Tuple
                                                     [(Integer 4)
                                                     (Integer 4)]
+                                                )
+                                            )
+                                        )
+                                        ()
+                                    )
+                                    (Assignment
+                                        (Var 3 y)
+                                        (DictConstant
+                                            []
+                                            []
+                                            (Dict
+                                                (Integer 4)
+                                                (List
+                                                    (Integer 4)
                                                 )
                                             )
                                         )

--- a/tests/reference/pass_print_list_tuple-print_list_tuple_03-195fa9c.json
+++ b/tests/reference/pass_print_list_tuple-print_list_tuple_03-195fa9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_print_list_tuple-print_list_tuple_03-195fa9c.stdout",
-    "stdout_hash": "f63197ac9c1a649cfb2d3a3ef6f6672964ad753593afc68ce6d567e9",
+    "stdout_hash": "edb9d31c77ac27a72de4454275693936ef43c07263a2da687e16da5c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_print_list_tuple-print_list_tuple_03-195fa9c.stdout
+++ b/tests/reference/pass_print_list_tuple-print_list_tuple_03-195fa9c.stdout
@@ -146,6 +146,21 @@
                                     [(Assignment
                                         (Var 3 x)
                                         (DictConstant
+                                            []
+                                            []
+                                            (Dict
+                                                (Integer 4)
+                                                (Tuple
+                                                    [(Integer 4)
+                                                    (Integer 4)]
+                                                )
+                                            )
+                                        )
+                                        ()
+                                    )
+                                    (Assignment
+                                        (Var 3 x)
+                                        (DictConstant
                                             [(IntegerConstant 1 (Integer 4))
                                             (IntegerConstant 2 (Integer 4))]
                                             [(TupleConstant
@@ -169,6 +184,20 @@
                                                 (Tuple
                                                     [(Integer 4)
                                                     (Integer 4)]
+                                                )
+                                            )
+                                        )
+                                        ()
+                                    )
+                                    (Assignment
+                                        (Var 3 y)
+                                        (DictConstant
+                                            []
+                                            []
+                                            (Dict
+                                                (Integer 4)
+                                                (List
+                                                    (Integer 4)
                                                 )
                                             )
                                         )


### PR DESCRIPTION
Add default empty dictionary if initialized without a value.