### PR TITLE
Fixes complex datatype's symbol duplication bug while using interactive

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -2806,33 +2806,41 @@ public:
             llvm::StructType* list_type = static_cast<llvm::StructType*>(
                 llvm_utils->get_type_from_ttype_t_util(x.m_type, module.get()));
             llvm::Constant *ptr = module->getOrInsertGlobal(x.m_name, list_type);
-            module->getNamedGlobal(x.m_name)->setInitializer(
-                llvm::ConstantStruct::get(list_type,
-                llvm::Constant::getNullValue(list_type)));
+            if (!external) {
+                module->getNamedGlobal(x.m_name)->setInitializer(
+                    llvm::ConstantStruct::get(list_type,
+                    llvm::Constant::getNullValue(list_type)));
+            }
             llvm_symtab[h] = ptr;
         } else if (x.m_type->type == ASR::ttypeType::Tuple) {
             llvm::StructType* tuple_type = static_cast<llvm::StructType*>(
                 llvm_utils->get_type_from_ttype_t_util(x.m_type, module.get()));
             llvm::Constant *ptr = module->getOrInsertGlobal(x.m_name, tuple_type);
-            module->getNamedGlobal(x.m_name)->setInitializer(
-                llvm::ConstantStruct::get(tuple_type,
-                llvm::Constant::getNullValue(tuple_type)));
+            if (!external) {
+                module->getNamedGlobal(x.m_name)->setInitializer(
+                    llvm::ConstantStruct::get(tuple_type,
+                    llvm::Constant::getNullValue(tuple_type)));
+            }
             llvm_symtab[h] = ptr;
         } else if(x.m_type->type == ASR::ttypeType::Dict) {
             llvm::StructType* dict_type = static_cast<llvm::StructType*>(
                 llvm_utils->get_type_from_ttype_t_util(x.m_type, module.get()));
             llvm::Constant *ptr = module->getOrInsertGlobal(x.m_name, dict_type);
-            module->getNamedGlobal(x.m_name)->setInitializer(
-                llvm::ConstantStruct::get(dict_type,
-                llvm::Constant::getNullValue(dict_type)));
+            if (!external) {
+                module->getNamedGlobal(x.m_name)->setInitializer(
+                    llvm::ConstantStruct::get(dict_type,
+                    llvm::Constant::getNullValue(dict_type)));
+            }
             llvm_symtab[h] = ptr;
         } else if(x.m_type->type == ASR::ttypeType::Set) {
             llvm::StructType* set_type = static_cast<llvm::StructType*>(
                 llvm_utils->get_type_from_ttype_t_util(x.m_type, module.get()));
             llvm::Constant *ptr = module->getOrInsertGlobal(x.m_name, set_type);
-            module->getNamedGlobal(x.m_name)->setInitializer(
-                llvm::ConstantStruct::get(set_type,
-                llvm::Constant::getNullValue(set_type)));
+            if (!external) {
+                module->getNamedGlobal(x.m_name)->setInitializer(
+                    llvm::ConstantStruct::get(set_type,
+                    llvm::Constant::getNullValue(set_type)));
+            }
             llvm_symtab[h] = ptr;
         } else if (x.m_type->type == ASR::ttypeType::TypeParameter) {
             // Ignore type variables


### PR DESCRIPTION
Orginal Bug:

```bash
❯ lp
>>> l: list[i32] = [1, 2, 3]
>>> print(l)
Internal Compiler Error: Unhandled exception
Traceback (most recent call last):
  Binary file "/home/vipul/Workspace/bin/lpython/src/bin/lpython", in _start()
  Binary file "/lib64/libc.so.6", in __libc_start_main_alias_2()
  Binary file "/lib64/libc.so.6", in __libc_start_call_main()
  Binary file "/home/vipul/Workspace/bin/lpython/src/bin/lpython", in main()
  File "lpython.cpp", line 0, in (anonymous namespace)::interactive_python_repl(LCompilers::PassManager&, LCompilers::CompilerOptions&, bool) [clone .isra.0]
  Binary file "/home/vipul/Workspace/bin/lpython/src/bin/lpython", in LCompilers::PythonCompiler::evaluate(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, LCompilers::LocationManager&, LCompilers::PassManager&, LCompilers::diag::Diagnostics&)
LCompilersException: addModule() returned an error: Duplicate definition of symbol 'l'
```

---

I just followed the way `visit_Variable` handles normal integer types and adapted it to work with `list`, `dict`, etc.