### PR TITLE
Supporting Logical Binop cases through symbolic pass

### DIFF
--- a/integration_tests/symbolics_02.py
+++ b/integration_tests/symbolics_02.py
@@ -108,4 +108,16 @@ def test_symbolic_operations():
     assert(b.is_positive == False)
     assert(c.is_positive == False)
 
+    # logical binop check
+    l1: bool = True and p.func == Pow
+    l2: bool = False or p.func == Pow
+    l3: bool = False and u.func == Mul
+    l4: bool = True or u.func == Add
+    if p.func == Pow and u.func == Mul:
+        print(True)
+    assert(l1)
+    assert(l2)
+    assert(not l3)
+    assert(l4)
+
 test_symbolic_operations()

--- a/src/libasr/pass/replace_symbolic.cpp
+++ b/src/libasr/pass/replace_symbolic.cpp
@@ -722,6 +722,32 @@ public:
                 ASR::stmt_t* stmt = ASRUtils::STMT(ASR::make_Assignment_t(al, x.base.base.loc, x.m_target, function_call, nullptr));
                 pass_result.push_back(al, stmt);
             }
+        }  else if (ASR::is_a<ASR::LogicalBinOp_t>(*x.m_value)) {
+            ASR::LogicalBinOp_t* logical_binop = ASR::down_cast<ASR::LogicalBinOp_t>(x.m_value);
+            ASR::expr_t* function_call_left = logical_binop->m_left;
+            ASR::expr_t* function_call_right = logical_binop->m_right;
+
+            if (ASR::is_a<ASR::IntrinsicElementalFunction_t>(*logical_binop->m_left)) {
+                ASR::IntrinsicElementalFunction_t* left = ASR::down_cast<ASR::IntrinsicElementalFunction_t>(logical_binop->m_left);
+                if (left->m_type->type == ASR::ttypeType::Logical) {
+                    if (is_logical_intrinsic_symbolic(logical_binop->m_left)) {
+                        function_call_left = process_attributes(x.base.base.loc, logical_binop->m_left);
+                    }
+                }
+            }
+            if (ASR::is_a<ASR::IntrinsicElementalFunction_t>(*logical_binop->m_right)) {
+                ASR::IntrinsicElementalFunction_t* right = ASR::down_cast<ASR::IntrinsicElementalFunction_t>(logical_binop->m_right);
+                if (right->m_type->type == ASR::ttypeType::Logical) {
+                    if (is_logical_intrinsic_symbolic(logical_binop->m_right)) {
+                        function_call_right = process_attributes(x.base.base.loc, logical_binop->m_right);
+                    }
+                }
+            }
+
+            ASR::expr_t* new_logical_binop = ASRUtils::EXPR(ASR::make_LogicalBinOp_t(al, x.base.base.loc,
+                function_call_left, logical_binop->m_op, function_call_right, logical_binop->m_type, logical_binop->m_value));
+            ASR::stmt_t* stmt = ASRUtils::STMT(ASR::make_Assignment_t(al, x.base.base.loc, x.m_target, new_logical_binop, nullptr));
+            pass_result.push_back(al, stmt);
         }
     }
 
@@ -761,6 +787,31 @@ public:
             ASR::stmt_t* stmt = ASRUtils::STMT(ASR::make_If_t(al, xx.base.base.loc, function_call,
                 xx.m_body, xx.n_body, xx.m_orelse, xx.n_orelse));
             pass_result.push_back(al, stmt);
+        }  else if (ASR::is_a<ASR::LogicalBinOp_t>(*xx.m_test)) {
+            ASR::LogicalBinOp_t* logical_binop = ASR::down_cast<ASR::LogicalBinOp_t>(xx.m_test);
+            ASR::expr_t* function_call_left = logical_binop->m_left;
+            ASR::expr_t* function_call_right = logical_binop->m_right;
+
+            if (ASR::is_a<ASR::IntrinsicElementalFunction_t>(*logical_binop->m_left)) {
+                ASR::IntrinsicElementalFunction_t* left = ASR::down_cast<ASR::IntrinsicElementalFunction_t>(logical_binop->m_left);
+                if (left->m_type->type == ASR::ttypeType::Logical) {
+                    if (is_logical_intrinsic_symbolic(logical_binop->m_left)) {
+                        function_call_left = process_attributes(xx.base.base.loc, logical_binop->m_left);
+                    }
+                }
+            }
+            if (ASR::is_a<ASR::IntrinsicElementalFunction_t>(*logical_binop->m_right)) {
+                ASR::IntrinsicElementalFunction_t* right = ASR::down_cast<ASR::IntrinsicElementalFunction_t>(logical_binop->m_right);
+                if (right->m_type->type == ASR::ttypeType::Logical) {
+                    if (is_logical_intrinsic_symbolic(logical_binop->m_right)) {
+                        function_call_right = process_attributes(xx.base.base.loc, logical_binop->m_right);
+                    }
+                }
+            }
+
+            ASR::expr_t* new_logical_binop = ASRUtils::EXPR(ASR::make_LogicalBinOp_t(al, xx.base.base.loc,
+                function_call_left, logical_binop->m_op, function_call_right, logical_binop->m_type, logical_binop->m_value));
+            xx.m_test = new_logical_binop;
         }
     }
 


### PR DESCRIPTION
This is for handling some cases that we come across during the gruntz algorithm. For eg 
```
    if e == x or (e.is_Pow and signinf(e.base, x) == 1):
        return S(1)     
```       

