### PR TITLE
CI: Upgrade SymEngine to 0.12.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -403,7 +403,7 @@ jobs:
           create-args: >-
             python=3.10
             bison=3.4
-            symengine=0.11.1
+            symengine=0.12.0
             sympy=1.11.1
 
       - uses: hendrikmuhs/ccache-action@main


### PR DESCRIPTION
This would allow us to use `basic_sign` and `basic_add_as_two_terms` and `basic_mul_as_two_terms` from symengine's C wrapper.