### PR TITLE
Add a method to create an empty set

### DIFF
--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -6454,10 +6454,9 @@ namespace LCompilers {
         llvm::Value* el_mask = LLVM::CreateLoad(*builder, get_pointer_to_mask(set));
         llvm::Value* capacity = LLVM::CreateLoad(*builder, get_pointer_to_capacity(set));
         llvm::Function *fn = builder->GetInsertBlock()->getParent();
-        std::string s = check_if_exists ? "qq" : "pp"; 
-        llvm::BasicBlock *thenBB = llvm::BasicBlock::Create(context, "then"+s, fn);
-        llvm::BasicBlock *elseBB = llvm::BasicBlock::Create(context, "else"+s);
-        llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont"+s);
+        llvm::BasicBlock *thenBB = llvm::BasicBlock::Create(context, "then", fn);
+        llvm::BasicBlock *elseBB = llvm::BasicBlock::Create(context, "else");
+        llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(context, "ifcont");
         llvm::Value* el_mask_value = LLVM::CreateLoad(*builder,
                                         llvm_utils->create_ptr_gep(el_mask, el_hash));
         llvm::Value* is_prob_not_needed = builder->CreateICmpEQ(el_mask_value,

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -2568,9 +2568,14 @@ public:
         ASR::Variable_t* v_variable = ASR::down_cast<ASR::Variable_t>(v_sym);
         std::string var_name = v_variable->m_name;
         ASR::ttype_t* type = v_variable->m_type;
-        if (!init_expr && ASR::is_a<ASR::Dict_t>(*type)) {
-            init_expr = ASRUtils::EXPR(ASR::make_DictConstant_t(al, loc, 
-                  nullptr, 0, nullptr, 0, type));
+        if (!init_expr) {
+            if (ASR::is_a<ASR::Dict_t>(*type)) {
+                init_expr = ASRUtils::EXPR(ASR::make_DictConstant_t(al, loc, 
+                      nullptr, 0, nullptr, 0, type));
+            } else if (ASR::is_a<ASR::Set_t>(*type)) {
+                init_expr = ASRUtils::EXPR(ASR::make_SetConstant_t(al, loc,
+                      nullptr, 0, type));
+            }
         }
 
         if( init_expr ) {


### PR DESCRIPTION
Right now, there is no easy way to create an empty set, and `set()` has not been implemented yet. This initializes set types as an empty set. It can be a temporary or permanent change.