### PR TITLE
`StructType` node update

### DIFF
--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -199,7 +199,7 @@ ttype
     | Set(ttype type)
     | List(ttype type)
     | Tuple(ttype* type)
-    | StructType(symbol derived_type)
+    | StructType(ttype* data_member_types, ttype* member_function_types, bool is_cstruct, symbol derived_type)
     | Enum(symbol enum_type)
     | Union(symbol union_type)
     | Class(symbol class_type)

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -480,7 +480,7 @@ ASR::asr_t* getStructInstanceMember_t(Allocator& al, const Location& loc,
                 nullptr, 0, member_variable->m_name, ASR::accessType::Public));
             current_scope->add_symbol(mem_name, mem_es);
         }
-        ASR::ttype_t* member_type = ASRUtils::TYPE(ASR::make_StructType_t(al,
+        ASR::ttype_t* member_type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al,
             member_variable->base.base.loc, mem_es));
         return ASR::make_StructInstanceMember_t(al, loc, ASRUtils::EXPR(v_var),
             mem_es, ASRUtils::fix_scoped_type(al, member_type, current_scope), nullptr);
@@ -543,10 +543,10 @@ ASR::asr_t* getStructInstanceMember_t(Allocator& al, const Location& loc,
                     } else {
                         der_ext = current_scope->get_symbol(mangled_name);
                     }
-                    ASR::asr_t* der_new = ASR::make_StructType_t(al, loc, der_ext);
+                    ASR::asr_t* der_new = ASRUtils::make_StructType_t_util(al, loc, der_ext);
                     member_type_ = ASRUtils::TYPE(der_new);
                 } else if(ASR::is_a<ASR::ExternalSymbol_t>(*der_type_sym)) {
-                    member_type_ = ASRUtils::TYPE(ASR::make_StructType_t(al, loc, der_type_sym));
+                    member_type_ = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, loc, der_type_sym));
                 }
                 member_type = ASRUtils::make_Array_t_util(al, loc,
                     member_type_, m_dims, n_dims);
@@ -677,7 +677,7 @@ bool use_overloaded(ASR::expr_t* left, ASR::expr_t* right,
                                                 ASRUtils::symbol_name(ASRUtils::get_asr_owner(struct_t->m_derived_type)), nullptr, 0,
                                                 ASRUtils::symbol_name(struct_t->m_derived_type), ASR::accessType::Public)));
                                     }
-                                    return_type = ASRUtils::TYPE(ASR::make_StructType_t(al, loc,
+                                    return_type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, loc,
                                         curr_scope->resolve_symbol(ASRUtils::symbol_name(struct_t->m_derived_type))));
                                     if( is_array ) {
                                         return_type = ASRUtils::make_Array_t_util(al, loc, return_type, m_dims, n_dims);
@@ -768,7 +768,7 @@ void process_overloaded_unary_minus_function(ASR::symbol_t* proc, ASR::expr_t* o
                                 ASRUtils::symbol_name(ASRUtils::get_asr_owner(struct_t->m_derived_type)), nullptr, 0,
                                 ASRUtils::symbol_name(struct_t->m_derived_type), ASR::accessType::Public)));
                     }
-                    return_type = ASRUtils::TYPE(ASR::make_StructType_t(al, loc,
+                    return_type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, loc,
                         curr_scope->resolve_symbol(ASRUtils::symbol_name(struct_t->m_derived_type))));
                     if( is_array ) {
                         return_type = ASRUtils::make_Array_t_util(

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3659,12 +3659,9 @@ static inline ASR::symbol_t* import_struct_instance_member(Allocator& al, ASR::s
             }
             mem_type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, mem_type->base.loc,
                 scope->get_symbol(struct_type_name_)));
-            // mem_type = ASRUtils::TYPE(ASR::make_StructType_t(al, mem_type->base.loc, scope->get_symbol(struct_type_name_)));
         } else {
             mem_type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, mem_type->base.loc,
                 scope->resolve_symbol(struct_type_name)));
-            // mem_type = ASRUtils::TYPE(ASR::make_StructType_t(al, mem_type->base.loc,
-            //     scope->resolve_symbol(struct_type_name)));
         }
     }
     if( n_dims > 0 ) {
@@ -4923,7 +4920,6 @@ static inline void import_struct_t(Allocator& al,
                 der_sym = current_scope->resolve_symbol(sym_name);
             }
             var_type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, loc, der_sym));
-            // var_type = ASRUtils::TYPE(ASR::make_StructType_t(al, loc, der_sym));
             if( is_array ) {
                 var_type = ASRUtils::make_Array_t_util(al, loc, var_type, m_dims, n_dims,
                     ASR::abiType::Source, false, ptype, true);

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2468,7 +2468,8 @@ static inline ASR::asr_t* make_StructType_t_util(Allocator& al, Location loc, AS
     for(size_t i = 0; i < st->n_members; i++){
         ASR::symbol_t* temp = current_scope->get_symbol(st->m_members[i]);
         if(ASR::is_a<ASR::Variable_t>(*temp)){
-            ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(temp);
+            ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(
+                                                ASRUtils::symbol_get_past_external(temp));
             members.push_back(al,var->m_type); 
         }
     }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2451,17 +2451,7 @@ static inline bool is_aggregate_type(ASR::ttype_t* asr_type) {
 static inline ASR::dimension_t* duplicate_dimensions(Allocator& al, ASR::dimension_t* m_dims, size_t n_dims);
 
 static inline ASR::asr_t* make_StructType_t_util(Allocator& al, Location loc, ASR::symbol_t* der){
-    if(!ASR::is_a<ASR::Struct_t>(*der)){
-        return ASR::make_StructType_t(al, 
-                                loc, 
-                                nullptr,
-                                0,
-                                nullptr, 
-                                0,      
-                                false,    
-                                der);
-    }
-    ASR::Struct_t* st = ASR::down_cast<ASR::Struct_t>(der);
+    ASR::Struct_t* st = ASR::down_cast<ASR::Struct_t>(ASRUtils::symbol_get_past_external(der));
     Vec<ASR::ttype_t*> members;
     members.reserve(al, st->n_members);
     SymbolTable* current_scope = st->m_symtab;

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2451,23 +2451,31 @@ static inline bool is_aggregate_type(ASR::ttype_t* asr_type) {
 static inline ASR::dimension_t* duplicate_dimensions(Allocator& al, ASR::dimension_t* m_dims, size_t n_dims);
 
 static inline ASR::asr_t* make_StructType_t_util(Allocator& al, Location loc, ASR::symbol_t* der){
-    // ASR::Struct_t* st = ASR::down_cast<ASR::Struct_t>(der);
-    // Vec<ASR::ttype_t*> members;
-    // members.reserve(al, st->n_members);
-    // SymbolTable* current_scope = st->m_symtab;
-    // for(size_t i = 0; i < st->n_members; i++){
-    //     ASR::symbol_t* temp = current_scope->resolve_symbol(st->m_members[i]);
-    //     if(ASR::is_a<ASR::ttype_t>(temp->base)){
-    //         ASR::ttype_t* mem = TYPE(&(temp->base));
-    //         members.push_back(al,mem); 
-    //     }
-    // }
-    return ASR::make_StructType_t(al, 
+    if(!ASR::is_a<ASR::Struct_t>(*der)){
+        return ASR::make_StructType_t(al, 
                                 loc, 
-                                // members.p, 
-                                // members.n,
                                 nullptr,
                                 0,
+                                nullptr, 
+                                0,      
+                                false,    
+                                der);
+    }
+    ASR::Struct_t* st = ASR::down_cast<ASR::Struct_t>(der);
+    Vec<ASR::ttype_t*> members;
+    members.reserve(al, st->n_members);
+    SymbolTable* current_scope = st->m_symtab;
+    for(size_t i = 0; i < st->n_members; i++){
+        ASR::symbol_t* temp = current_scope->get_symbol(st->m_members[i]);
+        if(ASR::is_a<ASR::Variable_t>(*temp)){
+            ASR::Variable_t* var = ASR::down_cast<ASR::Variable_t>(temp);
+            members.push_back(al,var->m_type); 
+        }
+    }
+    return ASR::make_StructType_t(al, 
+                                loc, 
+                                members.p, 
+                                members.n,
                                 nullptr, //Correct this when mem fn added to Struct_t
                                 0,       //Correct this when mem fn added to Struct_t
                                 true,    //Correct this when mem fn added to Struct_t

--- a/src/libasr/pass/instantiate_template.cpp
+++ b/src/libasr/pass/instantiate_template.cpp
@@ -694,7 +694,7 @@ public:
                     std::string new_struct_name = context_map[struct_name];
                     ASR::symbol_t *sym = func_scope->resolve_symbol(new_struct_name);
                     return ASRUtils::TYPE(
-                        ASR::make_StructType_t(al, s->base.base.loc, sym));
+                        ASRUtils::make_StructType_t_util(al, s->base.base.loc, sym));
                 } else {
                     return ttype;
                 }
@@ -1365,7 +1365,7 @@ public:
                 std::string struct_name = ASRUtils::symbol_name(s->m_derived_type);
                 if (symbol_subs.find(struct_name) != symbol_subs.end()) {
                     ASR::symbol_t *sym = symbol_subs[struct_name];
-                    return ASRUtils::TYPE(ASR::make_StructType_t(al, ttype->base.loc, sym));
+                    return ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, ttype->base.loc, sym));
                 }
                 return ttype;
             }
@@ -1785,7 +1785,7 @@ public:
                 std::string struct_name = ASRUtils::symbol_name(s->m_derived_type);
                 if (symbol_subs.find(struct_name) != symbol_subs.end()) {
                     ASR::symbol_t *sym = symbol_subs[struct_name];
-                    ttype = ASRUtils::TYPE(ASR::make_StructType_t(al, s->base.base.loc, sym));
+                    ttype = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, s->base.base.loc, sym));
                 }
                 return ttype;
             }

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -306,7 +306,7 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
                             m_derived_type = ASR::down_cast<ASR::symbol_t>(fn);
                             current_scope->add_symbol(fn_name, m_derived_type);
                         }
-                        var_type_ = ASRUtils::TYPE(ASR::make_StructType_t(al, struct_t->base.base.loc,
+                        var_type_ = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, struct_t->base.base.loc,
                                     m_derived_type));
                         if( ASR::is_a<ASR::Array_t>(*var_type) ) {
                             ASR::Array_t* array_t = ASR::down_cast<ASR::Array_t>(var_type);

--- a/src/libasr/pass/pass_utils.cpp
+++ b/src/libasr/pass/pass_utils.cpp
@@ -98,7 +98,7 @@ namespace LCompilers {
                         struct_t->m_derived_type)->get_counter() ) { \
                     ASR::symbol_t* m_derived_type = current_scope->resolve_symbol( \
                         ASRUtils::symbol_name(struct_t->m_derived_type)); \
-                    ASR::ttype_t* struct_type = ASRUtils::TYPE(ASR::make_StructType_t(al, \
+                    ASR::ttype_t* struct_type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, \
                         struct_t->base.base.loc, m_derived_type)); \
                     array_ref_type = struct_type; \
                 } \

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -570,7 +570,7 @@ public:
                 } else {
                     sym = es_s;
                 }
-                return ASRUtils::TYPE(ASR::make_StructType_t(al, loc, sym));
+                return ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, loc, sym));
             }
             default: {
                 return return_type;
@@ -822,7 +822,7 @@ public:
                 ASR::symbol_t *der_sym = ASRUtils::symbol_get_past_external(s);
                 if( der_sym ) {
                     if ( ASR::is_a<ASR::Struct_t>(*der_sym) ) {
-                        type = ASRUtils::TYPE(ASR::make_StructType_t(al, loc, s));
+                        type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, loc, s));
                         type = ASRUtils::make_Array_t_util(al, loc, type, dims.p, dims.size(), abi, is_argument);
                     } else if( ASR::is_a<ASR::EnumType_t>(*der_sym) ) {
                         type = ASRUtils::TYPE(ASR::make_Enum_t(al, loc, s));
@@ -1312,7 +1312,7 @@ public:
             for (size_t i = args.size(); i < st->n_members; i++) {
                 args.push_back(al, st->m_initializers[i]);
             }
-            ASR::ttype_t* der_type = ASRUtils::TYPE(ASR::make_StructType_t(al, loc, stemp));
+            ASR::ttype_t* der_type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, loc, stemp));
             return ASR::make_StructConstructor_t(al, loc, stemp, args.p, args.size(), der_type, nullptr);
         } else if( ASR::is_a<ASR::EnumType_t>(*s) ) {
             Vec<ASR::expr_t*> args_new;
@@ -5831,7 +5831,7 @@ public:
                                                                     s2c(al, struct_member_name), ASR::accessType::Public));
                             current_scope->add_symbol(import_name, import_struct_member);
                         }
-                        member_var_type = ASRUtils::TYPE(ASR::make_StructType_t(al, loc, import_struct_member));
+                        member_var_type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, loc, import_struct_member));
                     }
                 }
             }
@@ -5965,7 +5965,7 @@ public:
                                                                     s2c(al, struct_member_name), ASR::accessType::Public));
                             current_scope->add_symbol(import_name, import_struct_member);
                         }
-                        member_var_type = ASRUtils::TYPE(ASR::make_StructType_t(al, loc, import_struct_member));
+                        member_var_type = ASRUtils::TYPE(ASRUtils::make_StructType_t_util(al, loc, import_struct_member));
                     }
                 }
             }

--- a/tests/reference/asr-intent_01-66824bc.json
+++ b/tests/reference/asr-intent_01-66824bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-intent_01-66824bc.stdout",
-    "stdout_hash": "38b4d1ece76c889c88eefaa5555a6dc36a8af86de4aadd829c112e80",
+    "stdout_hash": "96424532864b51ff2a8d92da1fb40a8498342dcea99b54660a4c83c5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-intent_01-66824bc.stdout
+++ b/tests/reference/asr-intent_01-66824bc.stdout
@@ -56,6 +56,9 @@
                                                     Default
                                                     (Array
                                                         (StructType
+                                                            [(Integer 4)]
+                                                            []
+                                                            .true.
                                                             2 Foo
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
@@ -132,6 +135,9 @@
                                         )
                                         (Array
                                             (StructType
+                                                [(Integer 4)]
+                                                []
+                                                .true.
                                                 2 Foo
                                             )
                                             [((IntegerConstant 0 (Integer 4))

--- a/tests/reference/asr-structs_01-66dc2c9.json
+++ b/tests/reference/asr-structs_01-66dc2c9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_01-66dc2c9.stdout",
-    "stdout_hash": "ea461fd5fd7cbed415b1c4f879f266ee64487c3545e6469091eefaa6",
+    "stdout_hash": "153f705e29f2c88ec969ce035e2c91aca1caa2bdd3571966dd5c4f87",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_01-66dc2c9.stdout
+++ b/tests/reference/asr-structs_01-66dc2c9.stdout
@@ -109,6 +109,10 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Integer 4)
+                                                        (Integer 4)]
+                                                        []
+                                                        .true.
                                                         2 S
                                                     )
                                                     ()
@@ -142,6 +146,10 @@
                                             [((IntegerConstant 2 (Integer 4)))
                                             (())]
                                             (StructType
+                                                [(Integer 4)
+                                                (Integer 4)]
+                                                []
+                                                .true.
                                                 2 S
                                             )
                                             ()

--- a/tests/reference/asr-structs_01-be14d49.json
+++ b/tests/reference/asr-structs_01-be14d49.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_01-be14d49.stdout",
-    "stdout_hash": "9bfbbca1021052ba2e89a60c105899a6957f0adc9b1e271f33f81522",
+    "stdout_hash": "d70bd606bcda91e16034b677f6b03ae998de9012002a4c6a7c6a1bd2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_01-be14d49.stdout
+++ b/tests/reference/asr-structs_01-be14d49.stdout
@@ -109,6 +109,10 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Real 4)
+                                                        (Integer 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -121,6 +125,10 @@
                                     change_struct
                                     (FunctionType
                                         [(StructType
+                                            [(Real 4)
+                                            (Integer 4)]
+                                            []
+                                            .true.
                                             2 A
                                         )]
                                         ()
@@ -208,6 +216,10 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Real 4)
+                                                        (Integer 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -220,6 +232,10 @@
                                     f
                                     (FunctionType
                                         [(StructType
+                                            [(Real 4)
+                                            (Integer 4)]
+                                            []
+                                            .true.
                                             2 A
                                         )]
                                         ()
@@ -277,6 +293,10 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Real 4)
+                                                        (Integer 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -322,6 +342,10 @@
                                             ))
                                             ((IntegerConstant 3 (Integer 4)))]
                                             (StructType
+                                                [(Real 4)
+                                                (Integer 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             ()

--- a/tests/reference/asr-structs_02-2ab459a.json
+++ b/tests/reference/asr-structs_02-2ab459a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_02-2ab459a.stdout",
-    "stdout_hash": "e910877f218afa129f1152ab8ce74e1c0872f2473bdb761d290b057f",
+    "stdout_hash": "579bf1e4f7b37ce8e0483caa4a8d82bfb99cc5d30698ca3fd976a058",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_02-2ab459a.stdout
+++ b/tests/reference/asr-structs_02-2ab459a.stdout
@@ -125,6 +125,10 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Integer 4)
+                                                        (Real 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -144,6 +148,10 @@
                                                     Default
                                                     (Pointer
                                                         (StructType
+                                                            [(Integer 4)
+                                                            (Real 4)]
+                                                            []
+                                                            .true.
                                                             2 A
                                                         )
                                                     )
@@ -221,6 +229,10 @@
                                                 )
                                             ))]
                                             (StructType
+                                                [(Integer 4)
+                                                (Real 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             ()
@@ -233,6 +245,10 @@
                                             (Var 4 a1)
                                             (Pointer
                                                 (StructType
+                                                    [(Integer 4)
+                                                    (Real 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                             )
@@ -246,6 +262,10 @@
                                             (Var 4 a1)
                                             (Pointer
                                                 (StructType
+                                                    [(Integer 4)
+                                                    (Real 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                             )

--- a/tests/reference/asr-structs_03-0cef911.json
+++ b/tests/reference/asr-structs_03-0cef911.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_03-0cef911.stdout",
-    "stdout_hash": "f47b680d013f3ae57b3c7376d3d74527a0523942d81b577a7b6f0d90",
+    "stdout_hash": "861480a7b8a448fb0d9e773baf8e0ef2242c7fd5ea683e4e95fde396",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_03-0cef911.stdout
+++ b/tests/reference/asr-structs_03-0cef911.stdout
@@ -110,6 +110,10 @@
                                                     Default
                                                     (Pointer
                                                         (StructType
+                                                            [(Integer 4)
+                                                            (Real 4)]
+                                                            []
+                                                            .true.
                                                             2 A
                                                         )
                                                     )
@@ -124,6 +128,10 @@
                                     (FunctionType
                                         [(Pointer
                                             (StructType
+                                                [(Integer 4)
+                                                (Real 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                         )]
@@ -182,6 +190,10 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Integer 4)
+                                                        (Real 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -201,6 +213,10 @@
                                                     Default
                                                     (Pointer
                                                         (StructType
+                                                            [(Integer 4)
+                                                            (Real 4)]
+                                                            []
+                                                            .true.
                                                             2 A
                                                         )
                                                     )
@@ -246,6 +262,10 @@
                                                 )
                                             ))]
                                             (StructType
+                                                [(Integer 4)
+                                                (Real 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             ()
@@ -258,6 +278,10 @@
                                             (Var 5 x)
                                             (Pointer
                                                 (StructType
+                                                    [(Integer 4)
+                                                    (Real 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                             )

--- a/tests/reference/asr-structs_04-387747b.json
+++ b/tests/reference/asr-structs_04-387747b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_04-387747b.stdout",
-    "stdout_hash": "e53b9fa00b0c80ca7642803f56790172d7f512f12ce00c290c9796d2",
+    "stdout_hash": "56f0b2b928e0341162acaf38cbf035abf58005563f71011f588597db",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_04-387747b.stdout
+++ b/tests/reference/asr-structs_04-387747b.stdout
@@ -73,6 +73,10 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Real 4)
+                                                        (Integer 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -123,6 +127,10 @@
                                         ))
                                         ((IntegerConstant 0 (Integer 4)))]
                                         (StructType
+                                            [(Real 4)
+                                            (Integer 4)]
+                                            []
+                                            .true.
                                             2 A
                                         )
                                         ()
@@ -181,6 +189,16 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Integer 4)
+                                                        (StructType
+                                                            [(Real 4)
+                                                            (Integer 4)]
+                                                            []
+                                                            .true.
+                                                            2 A
+                                                        )]
+                                                        []
+                                                        .true.
                                                         2 B
                                                     )
                                                     ()
@@ -193,6 +211,16 @@
                                     f
                                     (FunctionType
                                         [(StructType
+                                            [(Integer 4)
+                                            (StructType
+                                                [(Real 4)
+                                                (Integer 4)]
+                                                []
+                                                .true.
+                                                2 A
+                                            )]
+                                            []
+                                            .true.
                                             2 B
                                         )]
                                         ()
@@ -221,6 +249,10 @@
                                                 (Var 5 b)
                                                 4 a
                                                 (StructType
+                                                    [(Real 4)
+                                                    (Integer 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 ()
@@ -234,6 +266,10 @@
                                                 (Var 5 b)
                                                 4 a
                                                 (StructType
+                                                    [(Real 4)
+                                                    (Integer 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 ()
@@ -267,6 +303,10 @@
                                                     (Var 5 b)
                                                     4 a
                                                     (StructType
+                                                        [(Real 4)
+                                                        (Integer 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -290,6 +330,10 @@
                                                         (Var 5 b)
                                                         4 a
                                                         (StructType
+                                                            [(Real 4)
+                                                            (Integer 4)]
+                                                            []
+                                                            .true.
                                                             2 A
                                                         )
                                                         ()
@@ -333,6 +377,10 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Real 4)
+                                                        (Integer 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -351,6 +399,10 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Real 4)
+                                                        (Integer 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -369,6 +421,16 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Integer 4)
+                                                        (StructType
+                                                            [(Real 4)
+                                                            (Integer 4)]
+                                                            []
+                                                            .true.
+                                                            2 A
+                                                        )]
+                                                        []
+                                                        .true.
                                                         2 B
                                                     )
                                                     ()
@@ -413,6 +475,10 @@
                                             ))
                                             ((IntegerConstant 1 (Integer 4)))]
                                             (StructType
+                                                [(Real 4)
+                                                (Integer 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             ()
@@ -437,6 +503,10 @@
                                             ))
                                             ((IntegerConstant 2 (Integer 4)))]
                                             (StructType
+                                                [(Real 4)
+                                                (Integer 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             ()
@@ -450,6 +520,16 @@
                                             [((IntegerConstant 1 (Integer 4)))
                                             ((Var 6 a1))]
                                             (StructType
+                                                [(Integer 4)
+                                                (StructType
+                                                    [(Real 4)
+                                                    (Integer 4)]
+                                                    []
+                                                    .true.
+                                                    2 A
+                                                )]
+                                                []
+                                                .true.
                                                 2 B
                                             )
                                             ()
@@ -461,6 +541,10 @@
                                             (Var 6 b)
                                             4 a
                                             (StructType
+                                                [(Real 4)
+                                                (Integer 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             ()
@@ -484,6 +568,10 @@
                                                 (Var 6 b)
                                                 4 a
                                                 (StructType
+                                                    [(Real 4)
+                                                    (Integer 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 ()
@@ -501,6 +589,10 @@
                                                 (Var 6 b)
                                                 4 a
                                                 (StructType
+                                                    [(Real 4)
+                                                    (Integer 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 ()

--- a/tests/reference/asr-structs_05-fa98307.json
+++ b/tests/reference/asr-structs_05-fa98307.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_05-fa98307.stdout",
-    "stdout_hash": "c63ee21559df1aebb160c48602c620f09fcbe66d78bbe27dbc26409f",
+    "stdout_hash": "94cc7a800d3a6722461f1b7da81cf7cf74d432c0ddf918dcbeec0981",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_05-fa98307.stdout
+++ b/tests/reference/asr-structs_05-fa98307.stdout
@@ -200,6 +200,15 @@
                                                     Default
                                                     (Array
                                                         (StructType
+                                                            [(Real 8)
+                                                            (Integer 4)
+                                                            (Integer 8)
+                                                            (Real 4)
+                                                            (Integer 2)
+                                                            (Integer 1)
+                                                            (Logical 4)]
+                                                            []
+                                                            .true.
                                                             2 A
                                                         )
                                                         [((IntegerConstant 0 (Integer 4))
@@ -238,6 +247,15 @@
                                             []
                                             (Array
                                                 (StructType
+                                                    [(Real 8)
+                                                    (Integer 4)
+                                                    (Integer 8)
+                                                    (Real 4)
+                                                    (Integer 2)
+                                                    (Integer 1)
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
@@ -256,6 +274,15 @@
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
                                             (StructType
+                                                [(Real 8)
+                                                (Integer 4)
+                                                (Integer 8)
+                                                (Real 4)
+                                                (Integer 2)
+                                                (Integer 1)
+                                                (Logical 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             RowMajor
@@ -303,6 +330,15 @@
                                                 (Logical 4)
                                             ))]
                                             (StructType
+                                                [(Real 8)
+                                                (Integer 4)
+                                                (Integer 8)
+                                                (Real 4)
+                                                (Integer 2)
+                                                (Integer 1)
+                                                (Logical 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             ()
@@ -316,6 +352,15 @@
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
                                             (StructType
+                                                [(Real 8)
+                                                (Integer 4)
+                                                (Integer 8)
+                                                (Real 4)
+                                                (Integer 2)
+                                                (Integer 1)
+                                                (Logical 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             RowMajor
@@ -363,6 +408,15 @@
                                                 (Logical 4)
                                             ))]
                                             (StructType
+                                                [(Real 8)
+                                                (Integer 4)
+                                                (Integer 8)
+                                                (Real 4)
+                                                (Integer 2)
+                                                (Integer 1)
+                                                (Logical 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             ()
@@ -378,6 +432,15 @@
                                             DescriptorArray
                                             (Array
                                                 (StructType
+                                                    [(Real 8)
+                                                    (Integer 4)
+                                                    (Integer 8)
+                                                    (Real 4)
+                                                    (Integer 2)
+                                                    (Integer 1)
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
@@ -407,6 +470,15 @@
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
                                             (StructType
+                                                [(Real 8)
+                                                (Integer 4)
+                                                (Integer 8)
+                                                (Real 4)
+                                                (Integer 2)
+                                                (Integer 1)
+                                                (Logical 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             RowMajor
@@ -423,6 +495,15 @@
                                             DescriptorArray
                                             (Array
                                                 (StructType
+                                                    [(Real 8)
+                                                    (Integer 4)
+                                                    (Integer 8)
+                                                    (Real 4)
+                                                    (Integer 2)
+                                                    (Integer 1)
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
@@ -442,6 +523,15 @@
                                             DescriptorArray
                                             (Array
                                                 (StructType
+                                                    [(Real 8)
+                                                    (Integer 4)
+                                                    (Integer 8)
+                                                    (Real 4)
+                                                    (Integer 2)
+                                                    (Integer 1)
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 [((IntegerConstant 0 (Integer 4))
@@ -483,6 +573,15 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Real 8)
+                                                        (Integer 4)
+                                                        (Integer 8)
+                                                        (Real 4)
+                                                        (Integer 2)
+                                                        (Integer 1)
+                                                        (Logical 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -495,6 +594,15 @@
                                     update_1
                                     (FunctionType
                                         [(StructType
+                                            [(Real 8)
+                                            (Integer 4)
+                                            (Integer 8)
+                                            (Real 4)
+                                            (Integer 2)
+                                            (Integer 1)
+                                            (Logical 4)]
+                                            []
+                                            .true.
                                             2 A
                                         )]
                                         ()
@@ -622,6 +730,15 @@
                                                     Default
                                                     (Array
                                                         (StructType
+                                                            [(Real 8)
+                                                            (Integer 4)
+                                                            (Integer 8)
+                                                            (Real 4)
+                                                            (Integer 2)
+                                                            (Integer 1)
+                                                            (Logical 4)]
+                                                            []
+                                                            .true.
                                                             2 A
                                                         )
                                                         [(()
@@ -639,6 +756,15 @@
                                     (FunctionType
                                         [(Array
                                             (StructType
+                                                [(Real 8)
+                                                (Integer 4)
+                                                (Integer 8)
+                                                (Real 4)
+                                                (Integer 2)
+                                                (Integer 1)
+                                                (Logical 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             [(()
@@ -667,6 +793,15 @@
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
                                                 (StructType
+                                                    [(Real 8)
+                                                    (Integer 4)
+                                                    (Integer 8)
+                                                    (Real 4)
+                                                    (Integer 2)
+                                                    (Integer 1)
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 RowMajor
@@ -687,6 +822,15 @@
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
                                                 (StructType
+                                                    [(Real 8)
+                                                    (Integer 4)
+                                                    (Integer 8)
+                                                    (Real 4)
+                                                    (Integer 2)
+                                                    (Integer 1)
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 RowMajor
@@ -710,6 +854,15 @@
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
                                                 (StructType
+                                                    [(Real 8)
+                                                    (Integer 4)
+                                                    (Integer 8)
+                                                    (Real 4)
+                                                    (Integer 2)
+                                                    (Integer 1)
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 RowMajor
@@ -735,6 +888,15 @@
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
                                                 (StructType
+                                                    [(Real 8)
+                                                    (Integer 4)
+                                                    (Integer 8)
+                                                    (Real 4)
+                                                    (Integer 2)
+                                                    (Integer 1)
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 RowMajor
@@ -766,6 +928,15 @@
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
                                                 (StructType
+                                                    [(Real 8)
+                                                    (Integer 4)
+                                                    (Integer 8)
+                                                    (Real 4)
+                                                    (Integer 2)
+                                                    (Integer 1)
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 RowMajor
@@ -791,6 +962,15 @@
                                                 (IntegerConstant 1 (Integer 4))
                                                 ())]
                                                 (StructType
+                                                    [(Real 8)
+                                                    (Integer 4)
+                                                    (Integer 8)
+                                                    (Real 4)
+                                                    (Integer 2)
+                                                    (Integer 1)
+                                                    (Logical 4)]
+                                                    []
+                                                    .true.
                                                     2 A
                                                 )
                                                 RowMajor
@@ -846,6 +1026,15 @@
                                                     Default
                                                     (Array
                                                         (StructType
+                                                            [(Real 8)
+                                                            (Integer 4)
+                                                            (Integer 8)
+                                                            (Real 4)
+                                                            (Integer 2)
+                                                            (Integer 1)
+                                                            (Logical 4)]
+                                                            []
+                                                            .true.
                                                             2 A
                                                         )
                                                         [(()
@@ -868,6 +1057,15 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Real 8)
+                                                        (Integer 4)
+                                                        (Integer 8)
+                                                        (Real 4)
+                                                        (Integer 2)
+                                                        (Integer 1)
+                                                        (Logical 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -886,6 +1084,15 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Real 8)
+                                                        (Integer 4)
+                                                        (Integer 8)
+                                                        (Real 4)
+                                                        (Integer 2)
+                                                        (Integer 1)
+                                                        (Logical 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -963,6 +1170,15 @@
                                     (FunctionType
                                         [(Array
                                             (StructType
+                                                [(Real 8)
+                                                (Integer 4)
+                                                (Integer 8)
+                                                (Real 4)
+                                                (Integer 2)
+                                                (Integer 1)
+                                                (Logical 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             [(()
@@ -1007,6 +1223,15 @@
                                             (IntegerConstant 0 (Integer 4))
                                             ())]
                                             (StructType
+                                                [(Real 8)
+                                                (Integer 4)
+                                                (Integer 8)
+                                                (Real 4)
+                                                (Integer 2)
+                                                (Integer 1)
+                                                (Logical 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             RowMajor
@@ -1222,6 +1447,15 @@
                                             (IntegerConstant 1 (Integer 4))
                                             ())]
                                             (StructType
+                                                [(Real 8)
+                                                (Integer 4)
+                                                (Integer 8)
+                                                (Real 4)
+                                                (Integer 2)
+                                                (Integer 1)
+                                                (Logical 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             RowMajor

--- a/tests/reference/asr-structs_16-44de89a.json
+++ b/tests/reference/asr-structs_16-44de89a.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-structs_16-44de89a.stdout",
-    "stdout_hash": "256933d5fe98d3dad16d4fdeee012bcd5f01255ffd4f39d46151640a",
+    "stdout_hash": "56e72c6d35e8827acf67645e7e998e962ff4e6939ec6e54c91cd0774",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-structs_16-44de89a.stdout
+++ b/tests/reference/asr-structs_16-44de89a.stdout
@@ -169,6 +169,12 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Union
+                                                            3 B
+                                                        )
+                                                        (Integer 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()
@@ -242,6 +248,12 @@
                                             [((Var 5 bd))
                                             ((IntegerConstant 2 (Integer 4)))]
                                             (StructType
+                                                [(Union
+                                                    3 B
+                                                )
+                                                (Integer 4)]
+                                                []
+                                                .true.
                                                 2 A
                                             )
                                             ()

--- a/tests/reference/pass_class_constructor-structs_16-5e3508f.json
+++ b/tests/reference/pass_class_constructor-structs_16-5e3508f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "pass_class_constructor-structs_16-5e3508f.stdout",
-    "stdout_hash": "7b07da67a935f00f37dc4f491778a540221af6fd57a0c1ebe2419b14",
+    "stdout_hash": "6b3bd1934a2cd04b82f44484a9307b3d9b1619f469a364678b53d839",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/pass_class_constructor-structs_16-5e3508f.stdout
+++ b/tests/reference/pass_class_constructor-structs_16-5e3508f.stdout
@@ -189,6 +189,12 @@
                                                     ()
                                                     Default
                                                     (StructType
+                                                        [(Union
+                                                            3 B
+                                                        )
+                                                        (Integer 4)]
+                                                        []
+                                                        .true.
                                                         2 A
                                                     )
                                                     ()


### PR DESCRIPTION
Updated the ASR node `StructType` from 
```
StructType(symbol derived_type)
```
to 
```
StructType(ttype* data_member_types, ttype* member_function_types, bool is_cstruct, symbol derived_type)
```