### PR TITLE
CI tests for LLVM 10, 14, 15 and 16

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -537,7 +537,7 @@ jobs:
 
             cmake --build . -j16 --target install
 
-      - name: Test Linux LLVM 10-16
+      - name: Test Linux LLVM ${{ matrix.llvm-version }}
         shell: bash -e -l {0}
         run: |
             ctest --output-on-failure

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -496,6 +496,56 @@ jobs:
             cd integration_tests
             ./run_tests.py -b cpython c_py
 
+  test_llvm:
+    name: Test LLVM ${{ matrix.llvm-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        llvm-version: ["10", "14", "15", "16"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: mamba-org/setup-micromamba@v1.8.0
+        with:
+          environment-file: ci/environment_linux_llvm.yml
+          create-args: >-
+            llvmdev=${{ matrix.llvm-version }}
+            python=3.10
+            bison=3.4
+
+      - uses: hendrikmuhs/ccache-action@main
+        with:
+          variant: sccache
+          key: ${{ github.job }}-${{ matrix.llvm-version }}
+
+      - name: Build Linux
+        shell: bash -e -l {0}
+        run: |
+            ./build0.sh
+            export CXXFLAGS="-Werror"
+            cmake . -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DWITH_LLVM=yes \
+              -DLFORTRAN_BUILD_ALL=yes \
+              -DWITH_STACKTRACE=no \
+              -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
+              -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
+              -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+
+            cmake --build . -j16 --target install
+
+      - name: Test Linux LLVM 10-16
+        shell: bash -e -l {0}
+        run: |
+            ctest --output-on-failure
+            cd integration_tests
+            ./run_tests.py -b llvm llvm_jit
+            ./run_tests.py -b llvm llvm_jit -f
+
   build_jupyter_kernel:
     name: Build Jupyter Kernel
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -524,11 +524,12 @@ jobs:
         run: |
             ./build0.sh
             export CXXFLAGS="-Werror"
-            cmake . -GNinja \
+            cmake . -G"Unix Makefiles" \
               -DCMAKE_BUILD_TYPE=Debug \
               -DWITH_LLVM=yes \
               -DLFORTRAN_BUILD_ALL=yes \
               -DWITH_STACKTRACE=no \
+              -DWITH_RUNTIME_STACKTRACE=yes \
               -DCMAKE_PREFIX_PATH="$CONDA_PREFIX" \
               -DCMAKE_INSTALL_PREFIX=`pwd`/inst \
               -DCMAKE_C_COMPILER_LAUNCHER=sccache \

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -502,7 +502,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm-version: ["10", "14", "15", "16"]
+        llvm-version: ["10", "15", "16"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -540,7 +540,7 @@ jobs:
       - name: Test Linux LLVM ${{ matrix.llvm-version }}
         shell: bash -e -l {0}
         run: |
-            # ctest --output-on-failure
+            ctest --output-on-failure
             cd integration_tests
             ./run_tests.py -b llvm llvm_jit
             ./run_tests.py -b llvm llvm_jit -f

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -513,10 +513,6 @@ jobs:
           environment-file: ci/environment_linux_llvm.yml
           create-args: >-
             llvmdev=${{ matrix.llvm-version }}
-            python=3.10
-            bison=3.4
-            symengine=0.12.0
-            sympy=1.11.1
 
       - uses: hendrikmuhs/ccache-action@main
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -540,7 +540,7 @@ jobs:
       - name: Test Linux LLVM ${{ matrix.llvm-version }}
         shell: bash -e -l {0}
         run: |
-            ctest --output-on-failure
+            # ctest --output-on-failure
             cd integration_tests
             ./run_tests.py -b llvm llvm_jit
             ./run_tests.py -b llvm llvm_jit -f

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -515,6 +515,8 @@ jobs:
             llvmdev=${{ matrix.llvm-version }}
             python=3.10
             bison=3.4
+            symengine=0.12.0
+            sympy=1.11.1
 
       - uses: hendrikmuhs/ccache-action@main
         with:

--- a/ci/environment_linux_llvm.yml
+++ b/ci/environment_linux_llvm.yml
@@ -3,19 +3,18 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - toml
-  - pytest
-  - jupyter
-  - xeus=1.0.1
-  - xtl
-  - nlohmann_json
-  - cppzmq
-  - jupyter_kernel_test
-  - xonsh
+  - git
+  - pip
+  - make
   - re2c
-  - numpy
+  - toml
   - zlib
-  - ninja
-  - rapidjson
-#  - bison=3.4  [not win]
-#  - m2-bison=3.4  [win]
+  - cmake
+  - numpy
+  - flake8
+  - setuptools
+  - bison=3.4
+  - python=3.10.2
+  - zstd-static=1.5
+  - symengine=0.12.0
+  - sympy=1.11.1

--- a/ci/environment_linux_llvm.yml
+++ b/ci/environment_linux_llvm.yml
@@ -1,0 +1,21 @@
+name: lp
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - toml
+  - pytest
+  - jupyter
+  - xeus=1.0.1
+  - xtl
+  - nlohmann_json
+  - cppzmq
+  - jupyter_kernel_test
+  - xonsh
+  - re2c
+  - numpy
+  - zlib
+  - ninja
+  - rapidjson
+#  - bison=3.4  [not win]
+#  - m2-bison=3.4  [win]

--- a/src/lpython/tests/test_llvm.cpp
+++ b/src/lpython/tests/test_llvm.cpp
@@ -41,59 +41,59 @@ define i64 @f2()
     //CHECK(e.execfn<int64_t>("f2") == 5);
 }
 
-TEST_CASE("llvm 1 fail") {
-    LCompilers::LLVMEvaluator e;
-    CHECK_THROWS_AS(e.add_module(R"""(
-define i64 @f1()
-{
-    ; FAIL: "=x" is incorrect syntax
-    %1 =x alloca i64
-}
-        )"""), LCompilers::LCompilersException);
-    CHECK_THROWS_WITH(e.add_module(R"""(
-define i64 @f1()
-{
-    ; FAIL: "=x" is incorrect syntax
-    %1 =x alloca i64
-}
-        )"""), "parse_module(): Invalid LLVM IR");
-}
+// TEST_CASE("llvm 1 fail") {
+//     LCompilers::LLVMEvaluator e;
+//     CHECK_THROWS_AS(e.add_module(R"""(
+// define i64 @f1()
+// {
+//     ; FAIL: "=x" is incorrect syntax
+//     %1 =x alloca i64
+// }
+//         )"""), LCompilers::LCompilersException);
+//     CHECK_THROWS_WITH(e.add_module(R"""(
+// define i64 @f1()
+// {
+//     ; FAIL: "=x" is incorrect syntax
+//     %1 =x alloca i64
+// }
+//         )"""), "parse_module(): Invalid LLVM IR");
+// }
 
 
-TEST_CASE("llvm 2") {
-    LCompilers::LLVMEvaluator e;
-    e.add_module(R"""(
-@count = global i64 0
+// TEST_CASE("llvm 2") {
+//     LCompilers::LLVMEvaluator e;
+//     e.add_module(R"""(
+// @count = global i64 0
 
-define i64 @f1()
-{
-    store i64 4, i64* @count
-    %1 = load i64, i64* @count
-    ret i64 %1
-}
-    )""");
-    CHECK(e.execfn<int64_t>("f1") == 4);
+// define i64 @f1()
+// {
+//     store i64 4, i64* @count
+//     %1 = load i64, i64* @count
+//     ret i64 %1
+// }
+//     )""");
+//     CHECK(e.execfn<int64_t>("f1") == 4);
 
-    e.add_module(R"""(
-@count = external global i64
+//     e.add_module(R"""(
+// @count = external global i64
 
-define i64 @f2()
-{
-    %1 = load i64, i64* @count
-    ret i64 %1
-}
-    )""");
-    CHECK(e.execfn<int64_t>("f2") == 4);
+// define i64 @f2()
+// {
+//     %1 = load i64, i64* @count
+//     ret i64 %1
+// }
+//     )""");
+//     CHECK(e.execfn<int64_t>("f2") == 4);
 
-    CHECK_THROWS_AS(e.add_module(R"""(
-define i64 @f3()
-{
-    ; FAIL: @count is not defined
-    %1 = load i64, i64* @count
-    ret i64 %1
-}
-        )"""), LCompilers::LCompilersException);
-}
+//     CHECK_THROWS_AS(e.add_module(R"""(
+// define i64 @f3()
+// {
+//     ; FAIL: @count is not defined
+//     %1 = load i64, i64* @count
+//     ret i64 %1
+// }
+//         )"""), LCompilers::LCompilersException);
+// }
 
 TEST_CASE("llvm 3") {
     LCompilers::LLVMEvaluator e;

--- a/src/lpython/tests/test_llvm.cpp
+++ b/src/lpython/tests/test_llvm.cpp
@@ -41,59 +41,59 @@ define i64 @f2()
     //CHECK(e.execfn<int64_t>("f2") == 5);
 }
 
-// TEST_CASE("llvm 1 fail") {
-//     LCompilers::LLVMEvaluator e;
-//     CHECK_THROWS_AS(e.add_module(R"""(
-// define i64 @f1()
-// {
-//     ; FAIL: "=x" is incorrect syntax
-//     %1 =x alloca i64
-// }
-//         )"""), LCompilers::LCompilersException);
-//     CHECK_THROWS_WITH(e.add_module(R"""(
-// define i64 @f1()
-// {
-//     ; FAIL: "=x" is incorrect syntax
-//     %1 =x alloca i64
-// }
-//         )"""), "parse_module(): Invalid LLVM IR");
-// }
+TEST_CASE("llvm 1 fail") {
+    LCompilers::LLVMEvaluator e;
+    CHECK_THROWS_AS(e.add_module(R"""(
+define i64 @f1()
+{
+    ; FAIL: "=x" is incorrect syntax
+    %1 =x alloca i64
+}
+        )"""), LCompilers::LCompilersException);
+    CHECK_THROWS_WITH(e.add_module(R"""(
+define i64 @f1()
+{
+    ; FAIL: "=x" is incorrect syntax
+    %1 =x alloca i64
+}
+        )"""), "parse_module(): Invalid LLVM IR");
+}
 
 
-// TEST_CASE("llvm 2") {
-//     LCompilers::LLVMEvaluator e;
-//     e.add_module(R"""(
-// @count = global i64 0
+TEST_CASE("llvm 2") {
+    LCompilers::LLVMEvaluator e;
+    e.add_module(R"""(
+@count = global i64 0
 
-// define i64 @f1()
-// {
-//     store i64 4, i64* @count
-//     %1 = load i64, i64* @count
-//     ret i64 %1
-// }
-//     )""");
-//     CHECK(e.execfn<int64_t>("f1") == 4);
+define i64 @f1()
+{
+    store i64 4, i64* @count
+    %1 = load i64, i64* @count
+    ret i64 %1
+}
+    )""");
+    CHECK(e.execfn<int64_t>("f1") == 4);
 
-//     e.add_module(R"""(
-// @count = external global i64
+    e.add_module(R"""(
+@count = external global i64
 
-// define i64 @f2()
-// {
-//     %1 = load i64, i64* @count
-//     ret i64 %1
-// }
-//     )""");
-//     CHECK(e.execfn<int64_t>("f2") == 4);
+define i64 @f2()
+{
+    %1 = load i64, i64* @count
+    ret i64 %1
+}
+    )""");
+    CHECK(e.execfn<int64_t>("f2") == 4);
 
-//     CHECK_THROWS_AS(e.add_module(R"""(
-// define i64 @f3()
-// {
-//     ; FAIL: @count is not defined
-//     %1 = load i64, i64* @count
-//     ret i64 %1
-// }
-//         )"""), LCompilers::LCompilersException);
-// }
+    CHECK_THROWS_AS(e.add_module(R"""(
+define i64 @f3()
+{
+    ; FAIL: @count is not defined
+    %1 = load i64, i64* @count
+    ret i64 %1
+}
+        )"""), LCompilers::LCompilersException);
+}
 
 TEST_CASE("llvm 3") {
     LCompilers::LLVMEvaluator e;


### PR DESCRIPTION
By default, we test LLVM 11

Adapted from https://github.com/lfortran/lfortran/blob/58cf9fc94736031c7b7e28bbdf38378a28945228/.github/workflows/CI.yml#L673-L718