### PR TITLE
Parameterised init and methods

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -3054,6 +3054,30 @@ public:
         }
     }
 
+    void instantiate_methods(const ASR::Struct_t &x) {
+        SymbolTable *current_scope_copy = current_scope;
+        current_scope = x.m_symtab;
+        for ( auto &item : x.m_symtab->get_scope() ) {
+            if ( is_a<ASR::Function_t>(*item.second) ) {
+                ASR::Function_t *v = down_cast<ASR::Function_t>(item.second);
+                instantiate_function(*v);
+            }
+        }
+        current_scope = current_scope_copy;
+    }
+
+    void visit_methods (const ASR::Struct_t &x) {
+        SymbolTable *current_scope_copy = current_scope;
+        current_scope = x.m_symtab;
+        for ( auto &item : x.m_symtab->get_scope() ) {
+            if ( is_a<ASR::Function_t>(*item.second) ) {
+                ASR::Function_t *v = down_cast<ASR::Function_t>(item.second);
+                visit_Function(*v);
+            }
+        }
+        current_scope = current_scope_copy;
+    }
+
     void start_module_init_function_prototype(const ASR::Module_t &x) {
         uint32_t h = get_hash((ASR::asr_t*)&x);
         llvm::FunctionType *function_type = llvm::FunctionType::get(
@@ -3095,6 +3119,9 @@ public:
             } else if (is_a<ASR::EnumType_t>(*item.second)) {
                 ASR::EnumType_t *et = down_cast<ASR::EnumType_t>(item.second);
                 visit_EnumType(*et);
+            } else if (is_a<ASR::Struct_t>(*item.second)) {
+                ASR::Struct_t *st = down_cast<ASR::Struct_t>(item.second);
+                instantiate_methods(*st);
             }
         }
         finish_module_init_function_prototype(x);
@@ -4145,6 +4172,9 @@ public:
             if (is_a<ASR::Function_t>(*item.second)) {
                 ASR::Function_t *s = ASR::down_cast<ASR::Function_t>(item.second);
                 visit_Function(*s);
+            } else if ( is_a<ASR::Struct_t>(*item.second) ) {
+                ASR::Struct_t *st = down_cast<ASR::Struct_t>(item.second);
+                visit_methods(*st); 
             }
         }
     }

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -2961,11 +2961,7 @@ public:
                     if (f_name == "__init__") {
                         this->handle_init_method(*f, member_names, member_init);
                         this->handle_class_method(*f);
-                        // This seems hackish, as struct depends on itself
-                        // We need to handle this later.
-                        // Removing this throws a ASR verify error
                         member_fn_names.push_back(al, f->m_name);
-                        struct_dependencies.push_back(al, x.m_name);
                     } else {
                         this->handle_class_method(*f);
                         member_fn_names.push_back(al, f->m_name);

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -4280,9 +4280,7 @@ public:
             args_vec.push_back(al,*arg);
         }
         new_args->m_args = args_vec.p;
-        x = *AST::down_cast<AST::FunctionDef_t>(AST::make_FunctionDef_t(al,x.base.base.loc,
-        x.m_name,*new_args,x.m_body,x.n_body,x.m_decorator_list,x.n_decorator_list,
-        x.m_returns,x.m_type_comment));
+        x.m_args = *new_args;
         visit_FunctionDef(x);
     }
 


### PR DESCRIPTION
Enabled generation of parameterised init and methods in the ASR. Adding self after symtab visit in each function symtabs so as to have the correct type of the class.

TODO:
- [x]  Enable function code gen in the ASR->LLVM
- [ ] Call __init__ instead of the StructConstructor
- [ ] Modify the method calls to replace self with the calling object 
@certik @Thirumalai-Shaktivel 