### PR TITLE
Add `set()` for creating an empty set

### DIFF
--- a/integration_tests/test_set_constructor.py
+++ b/integration_tests/test_set_constructor.py
@@ -1,0 +1,15 @@
+def test_empty_set():
+    a: set[i32] = set()
+    assert len(a) == 0
+    a.add(2)
+    a.remove(2)
+    a.add(3)
+    assert a.pop() == 3
+
+    b: set[str] = set()
+
+    assert len(b) == 0
+    b.add('a')
+    b.remove('a')
+    b.add('b')
+    assert b.pop() == 3

--- a/integration_tests/test_set_constructor.py
+++ b/integration_tests/test_set_constructor.py
@@ -13,3 +13,5 @@ def test_empty_set():
     b.remove('a')
     b.add('b')
     assert b.pop() == 3
+
+test_empty_set()

--- a/src/lpython/semantics/python_ast_to_asr.cpp
+++ b/src/lpython/semantics/python_ast_to_asr.cpp
@@ -8622,6 +8622,20 @@ we will have to use something else.
                                         ASRUtils::type_to_str(type) + " type.", x.base.base.loc);
                 }
                 return;
+            } else if( call_name == "set" ) {
+                parse_args(x, args);
+                if (args.size() == 0) {
+                    if( assign_asr_target != nullptr ) {
+                        tmp = ASR::make_SetConstant_t(al, x.base.base.loc, nullptr, 0,
+                                                      ASRUtils::expr_type(assign_asr_target));
+                    }
+                    else {
+                        tmp = nullptr;
+                    }
+                    return ;
+                }
+
+                throw SemanticError("set is only used for an empty set for now.", x.base.base.loc);
             } else if( call_name == "deepcopy" ) {
                 parse_args(x, args);
                 if( args.size() != 1 ) {


### PR DESCRIPTION
Currently this only supports an empty set, but should support all iterables in the future.