### PR TITLE
Prevent segmentation faults in particular cases of read checking

### DIFF
--- a/integration_tests/test_membership_01.py
+++ b/integration_tests/test_membership_01.py
@@ -26,7 +26,7 @@ def test_str_set():
     a: set[str] = {'a', 'b', 'c', 'e', 'f'}
     i: str
     assert ('a' in a)
-    # assert ('d' not in a)
+    assert ('d' not in a)
     i = 'c'
     assert (i in a)
 


### PR DESCRIPTION
These segfaults primarily occurred when we were trying to access elements where the mask value was 0, implying it was not set. I have prevented such accesses. 