### PR TITLE
better argument names for StringContains

### DIFF
--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -136,7 +136,7 @@ expr
     | StringItem(expr arg, expr idx, ttype type, expr? value)
     | StringSection(expr arg, expr? start, expr? end, expr? step, ttype type, expr? value)
     | StringCompare(expr left, cmpop op, expr right, ttype type, expr? value)
-    | StringContains(expr left, expr right, ttype type, expr? value)
+    | StringContains(expr substr, expr str, ttype type, expr? value)
     | StringOrd(expr arg, ttype type, expr? value)
     | StringChr(expr arg, ttype type, expr? value)
     | StringFormat(expr fmt, expr* args, string_format_kind kind, ttype type, expr? value)

--- a/src/libasr/codegen/asr_to_c_cpp.h
+++ b/src/libasr/codegen/asr_to_c_cpp.h
@@ -1246,9 +1246,9 @@ PyMODINIT_FUNC PyInit_lpython_module_)" + fn_name + R"((void) {
 
     void visit_StringContains(const ASR::StringContains_t &x) {
         CHECK_FAST_C_CPP(compiler_options, x)
-        self().visit_expr(*x.m_left);
+        self().visit_expr(*x.m_substr);
         std::string substr = src;
-        self().visit_expr(*x.m_right);
+        self().visit_expr(*x.m_str);
         std::string str = src;
         src = "_lfortran_str_contains(" + str + ", " + substr + ")";
     }

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -6455,10 +6455,10 @@ public:
             return;
         }
 
-        this->visit_expr_wrapper(x.m_left, true);
+        this->visit_expr_wrapper(x.m_substr, true);
         llvm::Value *substr = tmp;
 
-        this->visit_expr_wrapper(x.m_right, true);
+        this->visit_expr_wrapper(x.m_str, true);
         llvm::Value *right = tmp;
 
         tmp = lfortran_str_contains(right, substr);


### PR DESCRIPTION
This PR closes #2786 

Updated the StringContains ASDL definition:
expr left -> expr substr
expr right -> expr str