### PR TITLE
Print diagnostics in each interactive loop

### DIFF
--- a/src/bin/lpython.cpp
+++ b/src/bin/lpython.cpp
@@ -886,6 +886,8 @@ int interactive_python_repl(
             res = fe.evaluate(code_string, verbose, lm, pass_manager, diagnostics);
             if (res.ok) {
                 r = res.result;
+                std::cerr << diagnostics.render(lm, compiler_options);
+                diagnostics.clear();
             } else {
                 LCOMPILERS_ASSERT(diagnostics.has_error())
                 std::cerr << diagnostics.render(lm, compiler_options);


### PR DESCRIPTION
Fixed #2807
Fixed #2757

In interactive mode, some errors or suggestions were added to the diagnostics but did not throw any errors. These should also be printed.