### PR TITLE
Fix separator inside print

### DIFF
--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -8432,14 +8432,11 @@ public:
         args.push_back(nullptr); // reserve space for fmt_str
         std::vector<std::string> fmt;
         llvm::Value *sep = nullptr;
-        llvm::Value *sep_no_space = nullptr;
         llvm::Value *end = nullptr;
-        bool global_sep_space = false;
         if (x.m_separator) {
             this->visit_expr_wrapper(x.m_separator, true);
             sep = tmp;
         } else {
-            global_sep_space = true;
             sep = builder->CreateGlobalStringPtr(" ");
         }
         if (x.m_end) {
@@ -8451,14 +8448,7 @@ public:
         for (size_t i=0; i<x.n_values; i++) {
             if (i != 0) {
                 fmt.push_back("%s");
-                if (global_sep_space &&
-                    !(ASRUtils::is_character(*ASRUtils::expr_type(x.m_values[i]))
-                        && ASRUtils::is_character(*ASRUtils::expr_type(x.m_values[i - 1])))) {
-                    args.push_back(sep);
-                } else {
-                    sep_no_space = sep_no_space != nullptr ? sep_no_space : builder->CreateGlobalStringPtr("");
-                    args.push_back(sep_no_space);
-                }
+                args.push_back(sep);
             }
             compute_fmt_specifier_and_arg(fmt, args, x.m_values[i], x.base.base.loc);
         }

--- a/tests/reference/runtime-test_list_item_mixed_print-a3fd49f.json
+++ b/tests/reference/runtime-test_list_item_mixed_print-a3fd49f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "runtime-test_list_item_mixed_print-a3fd49f.stdout",
-    "stdout_hash": "9d9a68fea29f11320efb0764ce38ed3d4090f64457b0f1eb10251a2b",
+    "stdout_hash": "cffcdb43864ef4e234dec5a10923f9077b7c6d1f4d9c37df1882f375",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/runtime-test_list_item_mixed_print-a3fd49f.stdout
+++ b/tests/reference/runtime-test_list_item_mixed_print-a3fd49f.stdout
@@ -1,12 +1,12 @@
-Hello
-This isLPython
+ Hello
+This is LPython
 1 2 3 ... 3 4 5
 The first element is: 1
 The middle element is: 3
 3.14000000000000012e+00 * 2 = 6.28000000000000025e+00
 Total: 9.41999999999999993e+00
 (1, 2, 3) is a tuple, but 1 is a number.
-123
+1 is smaller than 2 is smaller than 3
 1 # 2 # 3 # 4 # 5 # 
 
 List  0 : [1, 2]


### PR DESCRIPTION
Fix #2677 and #2668.

I think `global_sep_space` isn't needed because we set the sep to `" "` as the default when it's not specified.

I couldn't figure out why that if condition of two consecutive non characters was in place and also why `sep_no_space` was used.

When the if condition of two consecutive non characters was false, the empty separator was being pushed.