### PR TITLE
Add support for class members

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -843,6 +843,7 @@ RUN(NAME class_03          LABELS cpython llvm llvm_jit)
 RUN(NAME class_04          LABELS cpython llvm llvm_jit)
 RUN(NAME class_05          LABELS cpython llvm llvm_jit)
 RUN(NAME class_06          LABELS cpython llvm llvm_jit)
+RUN(NAME class_07          LABELS cpython llvm llvm_jit)
 
 
 # callback_04 is to test emulation. So just run with cpython

--- a/integration_tests/class_07.py
+++ b/integration_tests/class_07.py
@@ -1,0 +1,17 @@
+from lpython import i32
+
+class MyClass:
+    class_var: i32 = 42
+
+    def __init__(self: "MyClass", instance_value: i32):
+        self.instance_var: i32 = instance_value
+
+def main():
+    assert MyClass.class_var == 42
+    MyClass.class_var = 100
+    assert MyClass.class_var == 100
+    obj1: MyClass = MyClass(10)
+    assert obj1.class_var == 100
+
+if __name__ == '__main__':
+    main()

--- a/src/libasr/ASR.asdl
+++ b/src/libasr/ASR.asdl
@@ -218,7 +218,7 @@ ttype
 cast_kind = RealToInteger | IntegerToReal | LogicalToReal | RealToReal | IntegerToInteger | RealToComplex | IntegerToComplex | IntegerToLogical | RealToLogical | CharacterToLogical | CharacterToInteger | CharacterToList | ComplexToLogical | ComplexToComplex | ComplexToReal | ComplexToInteger | LogicalToInteger | RealToCharacter | IntegerToCharacter | LogicalToCharacter | UnsignedIntegerToInteger | UnsignedIntegerToUnsignedInteger | UnsignedIntegerToReal | UnsignedIntegerToLogical | IntegerToUnsignedInteger | RealToUnsignedInteger | CPtrToUnsignedInteger | UnsignedIntegerToCPtr | IntegerToSymbolicExpression | ListToArray | DerivedToBase
 storage_type = Default | Save | Parameter
 access = Public | Private
-intent = Local | In | Out | InOut | ReturnVar | Unspecified
+intent = Local | In | Out | InOut | ReturnVar | ClassMember | Unspecified
 deftype = Implementation | Interface
 presence = Required | Optional
 abi = Source | LFortranModule | GFortranModule | BindC | BindPython | BindJS | Interactive | Intrinsic

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -1852,6 +1852,7 @@ const ASR::intentType intent_local=ASR::intentType::Local; // local variable (no
 const ASR::intentType intent_in   =ASR::intentType::In; // dummy argument, intent(in)
 const ASR::intentType intent_out  =ASR::intentType::Out; // dummy argument, intent(out)
 const ASR::intentType intent_inout=ASR::intentType::InOut; // dummy argument, intent(inout)
+const ASR::intentType intent_classmember=ASR::intentType::ClassMember; // class variable
 const ASR::intentType intent_return_var=ASR::intentType::ReturnVar; // return variable of a function
 const ASR::intentType intent_unspecified=ASR::intentType::Unspecified; // dummy argument, ambiguous intent
 

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -797,7 +797,7 @@ public:
             s = ASRUtils::symbol_get_past_external(x.m_v);
         }
         require(is_a<Variable_t>(*s) || is_a<Function_t>(*s)
-                || is_a<ASR::EnumType_t>(*s) || is_a<ASR::ExternalSymbol_t>(*s),
+                || is_a<ASR::EnumType_t>(*s) || is_a<ASR::ExternalSymbol_t>(*s) || is_a<ASR::Struct_t>(*s),
             "Var_t::m_v " + x_mv_name + " does not point to a Variable_t, " \
             "Function_t, or EnumType_t (possibly behind ExternalSymbol_t)");
         require(symtab_in_scope(current_symtab, x.m_v),


### PR DESCRIPTION
Fix #2723 

Add support for class members by identifying them by the new intent `ClassMember` and creating a global variable for each class member.

All the tests are not passing yet, but I need a review to know if I'm going in the right direction.