### PR TITLE
Docs: Fix typos, grammar, and formatting inconsistencies across documentation

### DIFF
--- a/doc/src/CONTRIBUTING.md
+++ b/doc/src/CONTRIBUTING.md
@@ -7,7 +7,7 @@ your contribution so that it can be merged.
 
 ## Basic Setup
 
-To contribute, make sure your set up:
+To contribute, make sure you set up:
 
 * Your username + email
 * Your `~/.gitconfig`
@@ -84,7 +84,7 @@ We also tell LFortran how to print the new token in *parser.cpp*.
 
 :fontawesome-solid-code: *src/lfortran/parser/parser.cpp*
 ```
-std:string token2text(const int token)
+std::string token2text(const int token)
 {
     switch (token) {
         T(TK_CARET, "^")
@@ -241,7 +241,7 @@ Interactive Fortran. Experimental prototype, not ready for end users.
 ```
 ## Reach Out 
 
-If you have any questions or need help, please ask as at our
+If you have any questions or need help, please ask us at our
 [mailinglist](https://groups.io/g/lfortran) or a
 [chat](https://lfortran.zulipchat.com/).
 

--- a/doc/src/ansi.css
+++ b/doc/src/ansi.css
@@ -117,7 +117,7 @@
 .ansi-underline {
   text-decoration: underline;
 }
-/* The following styles are deprecated an will be removed in a future version */
+/* The following styles are deprecated and will be removed in a future version */
 .ansibold {
   font-weight: bold;
 }

--- a/doc/src/built-in functions.md
+++ b/doc/src/built-in functions.md
@@ -49,7 +49,7 @@ Returns the tuple (x // y, x % y).
 
 ### exp(x)
 
-- ****Parameter****
+- **Parameter**
     - x : floating point number (f32, f64)
 - **Returns** : floating point number (f32, f64) between [0.0, inf]
 
@@ -108,7 +108,7 @@ Returns the remainder of x / y, or x when x is smaller than y. Both x and y shou
 
 - **Parameters**
     - x : integer (i32, i64), floating point number (f32, f64), complex number (c32) or bool
-    - y: integer (i32, i64), floating point number (f32, f64) or bool
+    - y : integer (i32, i64), floating point number (f32, f64) or bool
 - **Returns** : integer (i32), floating point number (f32, f64) or a complex number
 
 Returns x<sup>y</sup>. When x is of type bool, y must also be of the same type. If x is 32-bit complex number (c32), y can only be a 32-bit integer (i32).

--- a/doc/src/design.md
+++ b/doc/src/design.md
@@ -8,7 +8,7 @@ are encouraged to use them independently for other applications and build tools
 on top:
 
 * Abstract Syntax Tree (AST), module `lfortran.ast`: Represents any Fortran
-  source code, strictly based on syntax, no semantic is included. The AST
+  source code, strictly based on syntax, no semantics are included. The AST
   module can convert itself to Fortran source code.
 
 * Abstract Semantic Representation (ASR), module `lfortran.asr`: Represents a valid

--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -40,7 +40,7 @@ Follow the steps below to install and run LPython on Linux, Windows or macOS.
     - Windows with WSL
         - Install Miniforge Prompt and add it to path:
             ```bash
-            wget  https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniconda.sh
+            wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O miniconda.sh
             bash miniconda.sh -b -p $HOME/conda_root
             export PATH="$HOME/conda_root/bin:$PATH"
             conda init bash # (shell name)
@@ -76,7 +76,7 @@ Follow the steps below to install and run LPython on Linux, Windows or macOS.
     - Generate the prerequisite files and build in Debug Mode:
 
         ```bash
-        # if you are developing on top of a forked repository; please run following command first
+        # if you are developing on top of a forked repository; please run the following command first
         # ./generate_default_tag.sh
 
 
@@ -108,7 +108,7 @@ Follow the steps below to install and run LPython on Linux, Windows or macOS.
     - Run the following commands to build the project:
         ```bash
         ./build0.sh
-        cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_LLVM=yes -DCMAKE_INSTALL_PREFIX=`pwd`/inst .\
+        cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_LLVM=yes -DCMAKE_INSTALL_PREFIX=`pwd`/inst .
         make -j8
         ```
 
@@ -134,7 +134,7 @@ Follow the steps below to install and run LPython on Linux, Windows or macOS.
         cd integration_tests
         ./run_tests.py
         ```
-    - In case you have recently updated macOS, you may get a warning like below in some test cases:
+    - In case you have recently updated macOS, you may get a warning like the one below in some test cases:
         ```bash
         ld: warning: object file (test_list_index2.out.tmp.o) was built for newer macOS version (14.0) than being linked (13.3)
         ```

--- a/doc/src/rebasing.md
+++ b/doc/src/rebasing.md
@@ -100,7 +100,7 @@ pick 663edf45b refactor
 # However, if you remove everything, the rebase will be aborted.
 #
 ```
-We want to squash commits named `refactor`(squash: meld commit with previous one), and we want to rename(`reword`) commit named `Added add4.py`, so will change `pick` option on our commits and type `squash or s`, `reword or r`
+We want to squash commits named `refactor`(squash: meld the commit with the previous one), and we want to rename(`reword`) commit named `Added add4.py`, so will change `pick` option on our commits and type `squash or s`, `reword or r`
 ```bash
 pick 132b89e0c Added add.py
 pick 75556f15c Added add2.py
@@ -143,7 +143,7 @@ Refactor
 # Untracked files:
 ...
 ```
-- second window: rename(reword) `Added add4.py`, you can edit the message as you want, I will rename it: `Added add4.py and edit it ` . 
+- second window: rename(reword) `Added add4.py`, you can edit the message as you want, I will rename it to: `Added add4.py and edit it ` . 
 ```
 Added add4.py
 
@@ -226,7 +226,7 @@ Date:   Sat Jul 30 23:36:27 2022 +0200
 and if you  want to push to the remote branch you must push with `--force` option.
 
 
-This [video](https://drive.google.com/file/d/1506h86_RLgwtjLi_uKWbdVNDsSVusIbr/view?usp=sharing) by *Naman Gera* he was rebasing a branch.
+In this [video](https://drive.google.com/file/d/1506h86_RLgwtjLi_uKWbdVNDsSVusIbr/view?usp=sharing), by *Naman Gera* he shows how to rebase a branch.
 
 ---
 # Merging


### PR DESCRIPTION
## Description
This PR fixes some documentation issues found across the repository, including typos, grammatical errors, and markdown formatting inconsistencies.

## Changes
* **ansi.css**: Fixed a typo in the comment block ("deprecated an will" -> "deprecated and will").
* **CONTRIBUTING.md**:
    * Fixed grammar issues, like: ("ask as" -> "ask us").
    * Fixed C++ syntax typo in the example (`std:string` -> `std::string`).
* **installation.md**:
    * Removed accidental double-spacing in the `wget` command.
    * Fixed the Windows/WSL `cmake` command to use the correct Linux path syntax (`.` instead of `.\`).
* **rebasing.md**: Improved the grammar in the video explanation part.
* **built-in functions.md**: Standardized the header formatting (`**Parameter**` vs `****Parameter****`) and fixed indentation alignment.
* **design.md**: Corrected grammar: ("no semantic is included" -> "no semantics are included").

## Motivation
These changes improve the readability and professionalism of the documentation for new users and contributors.

