### PR TITLE
Fix intermediate integer overflow in math.perm and math.comb

### DIFF
--- a/src/runtime/math.py
+++ b/src/runtime/math.py
@@ -225,11 +225,27 @@ def comb(n: i32, k: i32) -> i32:
     Computes the result of `nCk`, i.e, the number of ways to choose `k`
     items from `n` items without repetition and without order.
     """
-
-    if n < k or n < 0:
+    if k < 0 or k > n:
         return 0
-    return i32(factorial(n)//(factorial(k)*factorial(n-k)))
+    if k == 0 or k == n:
+        return 1
 
+    # Creating a local variable because assignment to input function parameter 'k' is not allowed
+    k_final: i32 = k
+
+    # Optimization: nCk is the same as nC(n-k), (done so that the number of iterations in loop can be reduced).
+    if k_final > n // 2:
+        k_final = n - k_final
+
+    result: i32 = 1
+    i: i32
+
+    for i in range(k_final):
+        # Calculate: result * (n - i) / (i + 1)
+        result = result * (n - i)
+        result = result // (i + 1)
+
+    return result
 
 def perm(n: i32, k: i32) -> i32:
     """
@@ -239,7 +255,13 @@ def perm(n: i32, k: i32) -> i32:
 
     if n < k or n < 0:
         return 0
-    return i32(factorial(n)//factorial(n-k))
+    if k == 0:
+        return 1
+    result: i32 = 1
+    i: i32
+    for i in range(n, n-k, -1):
+        result = result * i
+    return result
 
 
 def isqrt(n: i32) -> i32:


### PR DESCRIPTION
**Description**
The previous implementations calculated the full `factorial(n)` before division. This caused an **intermediate integer overflow** for valid 32-bit/64-bit inputs. For example, `perm(30, 1)` correctly evaluates to `30`, but calculating `30!` first exceeds the 64-bit integer limit and returns garbage.

**Changes**
* Replaced factorial-based formulas with iterative loops to keep intermediate values small.
* Added symmetry optimization for `comb` (`k = n - k` if `k > n/2`).
* Used local variables (e.g., `k_final`) to prevent parameter immutability compiler errors.

**Verification**
Verified locally that `perm(30, 1)` and `comb(30, 1)` now correctly return `30` instead of overflowing to negative values.