### PR TITLE
Fix intermediate integer overflow in math.lcm and math.hypot

### DIFF
--- a/src/runtime/math.py
+++ b/src/runtime/math.py
@@ -490,17 +490,15 @@ def lcm(a: i32, b: i32) -> i32:
     """
     Returns least common multiple of `a` and `b`
     """
-    a_: i32
-    b_: i32
-    a_ = a
-    b_ = b
+    a_: i32 = a
+    b_: i32 = b
     if a_ < 0:
         a_ = -a_
     if b_ < 0:
         b_ = -b_
-    if a_*b_ == 0:
+    if a_ == 0 or b_ == 0:
         return 0
-    return i32((a_*b_)//gcd(a_, b_))
+    return i32((a_ // gcd(a_, b_)) * b_)
 
 
 def copysign(x: f64, y: f64) -> f64:
@@ -517,7 +515,9 @@ def hypot(x: i32, y: i32) -> f64:
     """
     Returns the hypotenuse of the right triangle with sides `x` and `y`.
     """
-    return sqrt(f64(1.0)*f64(x**2 + y**2))
+    xf: f64 = f64(x)
+    yf: f64 = f64(y)
+    return sqrt(xf**2 + yf**2)
 
 @overload
 def trunc(x: f64) -> i64:


### PR DESCRIPTION
## Fix intermediate overflows in lcm and hypot

The `lcm` and `hypot` functions were returning incorrect results for larger `i32` inputs due to intermediate overflows. This PR ensures that calculations remain within valid ranges even when intermediate values exceed the 32-bit signed integer limit ($2^{31}-1$).

### Implementation Details:
- **`math.lcm`**: Switched the order of operations to `(a // gcd(a, b)) * b` (unlike previously, where a*b was happening first). Dividing by the GCD first prevents the intermediate product from overflowing the `i32` range.
- **`math.hypot`**: Inputs are now cast to `f64` before the power operation (`xf**2 + yf**2`). This ensures the squaring happens in floating-point math, avoiding the `i32` ceiling.

### Verification:
Validated the fixes with a stress test using inputs that previously triggered overflows:

* **lcm(60000, 40000)**: Correctly returns `120000` (previously returned `-94749`).
* **hypot(60000, 80000)**: Correctly returns `100000.0` (previously returned `37550.84`).

Fixes numerical stability issues in the math module for large inputs.